### PR TITLE
Fix dart format in main.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,11 +10,7 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
-      ),
+      home: Scaffold(body: Center(child: Text('Hello World!'))),
     );
   }
 }


### PR DESCRIPTION
## Summary

- Runs `dart format` on the default scaffold `lib/main.dart` to fix the formatting CI step
- The CI pipeline added in the previous commit caught this immediately — working as intended

## Test plan

- [ ] CI passes (format + analyze + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)