### PR TITLE
feat: APRS-IS TCP connection, station service, map station markers

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,10 +20,10 @@ Goal: A working app that connects to APRS-IS, receives packets, and plots statio
 - [x] Flutter project created and pushed to GitHub
 - [x] GitHub repo configured (labels, milestones, templates, CI)
 - [x] CI pipeline running (flutter format, analyze, test)
-- 🔵 `flutter_map` integrated with OSM tile layer
-- [ ] APRS-IS TCP connection established (`rotate.aprs2.net:14580`)
-- [ ] Basic station position parsing (plain/compressed lat/lon)
-- [ ] Station markers rendered on map
+- [x] `flutter_map` integrated with OSM tile layer
+- [x] APRS-IS TCP connection established (`rotate.aprs2.net:14580`)
+- [x] Basic station position parsing (plain/compressed lat/lon)
+- [x] Station markers rendered on map
 - [ ] Station info panel (callsign, symbol, last heard)
 
 ---

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'aprs_transport.dart';
+
+class AprsIsTransport implements AprsTransport {
+  final String host;
+  final int port;
+  final String loginLine;
+  final String? filterLine;
+
+  AprsIsTransport({
+    this.host = 'rotate.aprs2.net',
+    this.port = 14580,
+    required this.loginLine,
+    this.filterLine,
+  });
+
+  Socket? _socket;
+  final _controller = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get lines => _controller.stream;
+
+  @override
+  Future<void> connect() async {
+    _socket = await Socket.connect(host, port);
+    _socket!.write(loginLine);
+    if (filterLine != null) _socket!.write(filterLine);
+    (_socket! as Stream<List<int>>)
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          _controller.add,
+          onError: _controller.addError,
+          onDone: _controller.close,
+        );
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _socket?.close();
+    _socket = null;
+  }
+}

--- a/lib/core/transport/aprs_transport.dart
+++ b/lib/core/transport/aprs_transport.dart
@@ -1,0 +1,8 @@
+import 'dart:async';
+
+abstract class AprsTransport {
+  /// Raw APRS-IS lines, newline stripped. Comment lines included.
+  Stream<String> get lines;
+  Future<void> connect();
+  Future<void> disconnect();
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../core/packet/station.dart';
+import '../core/transport/aprs_is_transport.dart';
+import '../services/station_service.dart';
+
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
 
@@ -10,14 +14,46 @@ class MapScreen extends StatefulWidget {
 }
 
 class _MapScreenState extends State<MapScreen> {
-  final MapController _mapController = MapController();
+  late final StationService _service;
+  List<Marker> _markers = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final transport = AprsIsTransport(
+      loginLine: 'user NOCALL pass -1 vers meridian-aprs 0.1\r\n',
+      filterLine: '#filter r/39.0/-77.0/100\r\n',
+    );
+    _service = StationService(transport);
+    _service.stationUpdates.listen(_onStationsUpdated);
+    _service.start();
+  }
+
+  @override
+  void dispose() {
+    _service.stop();
+    super.dispose();
+  }
+
+  void _onStationsUpdated(Map<String, Station> stations) {
+    setState(() {
+      _markers = stations.values.map(_buildMarker).toList();
+    });
+  }
+
+  Marker _buildMarker(Station s) => Marker(
+    point: LatLng(s.lat, s.lon),
+    child: Tooltip(
+      message: s.callsign,
+      child: const Icon(Icons.location_on, color: Colors.red, size: 24),
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Meridian APRS')),
       body: FlutterMap(
-        mapController: _mapController,
         options: const MapOptions(
           initialCenter: LatLng(39.0, -77.0),
           initialZoom: 9,
@@ -27,7 +63,7 @@ class _MapScreenState extends State<MapScreen> {
             urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             userAgentPackageName: 'com.meridianaprs.app',
           ),
-          const MarkerLayer(markers: []),
+          MarkerLayer(markers: _markers),
         ],
       ),
     );

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import '../core/packet/position_parser.dart';
+import '../core/packet/result.dart';
+import '../core/packet/station.dart';
+import '../core/transport/aprs_transport.dart';
+
+class StationService {
+  final AprsTransport _transport;
+  final _stations = <String, Station>{};
+  final _controller = StreamController<Map<String, Station>>.broadcast();
+
+  StationService(this._transport);
+
+  Stream<Map<String, Station>> get stationUpdates => _controller.stream;
+  Map<String, Station> get currentStations => Map.unmodifiable(_stations);
+
+  Future<void> start() async {
+    await _transport.connect();
+    _transport.lines.listen(_handleLine);
+  }
+
+  Future<void> stop() async {
+    await _transport.disconnect();
+    await _controller.close();
+  }
+
+  void _handleLine(String raw) {
+    debugPrint(raw);
+    final result = parseAprsLine(raw);
+    if (result is Ok<Station>) {
+      _stations[result.value.callsign] = result.value;
+      _controller.add(Map.unmodifiable(_stations));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `AprsTransport` abstract interface (dart:async only — web-safe)
- `AprsIsTransport` TCP implementation via dart:io Socket
- `StationService` wires transport → parser → map updates via broadcast streams
- `MapScreen` updated: station markers rendered as red pins with callsign tooltip
- APRS-IS login with NOCALL/-1 (receive-only), 100km filter around DC area
- Raw packets printed to debug console via debugPrint (stripped in release)

## Test plan
- [ ] `flutter analyze` — zero issues
- [ ] `dart format` — no changes needed
- [ ] `flutter test` — all tests pass
- [ ] On desktop: debug console shows `# logresp` within 2s of launch
- [ ] Raw APRS packets appear in console within 10-15s
- [ ] Red station markers appear on DC-area map within 60s
- [ ] Hovering a marker shows callsign tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)