### PR TITLE
fix: v0.1 runtime fixes — parser DTI, dynamic filter, map UX

### DIFF
--- a/lib/core/packet/position_parser.dart
+++ b/lib/core/packet/position_parser.dart
@@ -17,9 +17,21 @@ ParseResult<Station> parseAprsLine(String raw) {
 
   if (info.isEmpty) return Err('Empty info field');
   final dti = info[0];
-  if (dti != '!' && dti != '=') return Err('Not a position report (DTI: $dti)');
 
-  final pos = _parsePosition(info.substring(1));
+  // Determine position substring based on DTI:
+  //   !  =  → position starts immediately after DTI
+  //   /  @  → 7-char timestamp precedes position (DDHHMMz / HHMMSSh)
+  final String posStr;
+  if (dti == '!' || dti == '=') {
+    posStr = info.substring(1);
+  } else if (dti == '/' || dti == '@') {
+    if (info.length < 9) return Err('Timestamped packet too short');
+    posStr = info.substring(8); // skip DTI + 7-char timestamp
+  } else {
+    return Err('Not a position report (DTI: $dti)');
+  }
+
+  final pos = _parsePosition(posStr);
   if (pos == null) return Err('Could not parse position');
 
   return Ok(

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -28,7 +28,8 @@ class AprsIsTransport implements AprsTransport {
     _socket = await Socket.connect(host, port);
     _socket!.write(loginLine);
     if (filterLine != null) _socket!.write(filterLine);
-    (_socket! as Stream<List<int>>)
+    _socket!
+        .cast<List<int>>()
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen(
@@ -37,6 +38,9 @@ class AprsIsTransport implements AprsTransport {
           onDone: _controller.close,
         );
   }
+
+  @override
+  void sendLine(String line) => _socket?.write(line);
 
   @override
   Future<void> disconnect() async {

--- a/lib/core/transport/aprs_transport.dart
+++ b/lib/core/transport/aprs_transport.dart
@@ -5,4 +5,6 @@ abstract class AprsTransport {
   Stream<String> get lines;
   Future<void> connect();
   Future<void> disconnect();
+  /// Send a raw line to the server (e.g. a new #filter command).
+  void sendLine(String line);
 }

--- a/lib/core/transport/aprs_transport.dart
+++ b/lib/core/transport/aprs_transport.dart
@@ -5,6 +5,7 @@ abstract class AprsTransport {
   Stream<String> get lines;
   Future<void> connect();
   Future<void> disconnect();
+
   /// Send a raw line to the server (e.g. a new #filter command).
   void sendLine(String line);
 }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -15,7 +17,10 @@ class MapScreen extends StatefulWidget {
 
 class _MapScreenState extends State<MapScreen> {
   late final StationService _service;
+  final _mapController = MapController();
   List<Marker> _markers = [];
+  Timer? _filterDebounce;
+  Timer? _markerDebounce;
 
   @override
   void initState() {
@@ -27,25 +32,51 @@ class _MapScreenState extends State<MapScreen> {
     _service = StationService(transport);
     _service.stationUpdates.listen(_onStationsUpdated);
     _service.start();
+    _mapController.mapEventStream
+        .where((e) => e is MapEventMoveEnd)
+        .cast<MapEventMoveEnd>()
+        .listen(_onMapMoveEnd);
   }
 
   @override
   void dispose() {
+    _filterDebounce?.cancel();
+    _markerDebounce?.cancel();
     _service.stop();
     super.dispose();
   }
 
+  void _onMapMoveEnd(MapEventMoveEnd event) {
+    _filterDebounce?.cancel();
+    _filterDebounce = Timer(const Duration(milliseconds: 800), () {
+      final center = event.camera.center;
+      debugPrint('Filter update: ${center.latitude}, ${center.longitude}');
+      _service.updateFilter(center.latitude, center.longitude);
+    });
+  }
+
   void _onStationsUpdated(Map<String, Station> stations) {
-    setState(() {
-      _markers = stations.values.map(_buildMarker).toList();
+    _markerDebounce?.cancel();
+    _markerDebounce = Timer(const Duration(milliseconds: 300), () {
+      if (!mounted) return;
+      setState(() {
+        _markers = _service.currentStations.values.map(_buildMarker).toList();
+      });
     });
   }
 
   Marker _buildMarker(Station s) => Marker(
     point: LatLng(s.lat, s.lon),
-    child: Tooltip(
-      message: s.callsign,
-      child: const Icon(Icons.location_on, color: Colors.red, size: 24),
+    width: 30,
+    height: 30,
+    child: GestureDetector(
+      onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(s.callsign), duration: const Duration(seconds: 2)),
+      ),
+      child: Tooltip(
+        message: s.callsign,
+        child: const Icon(Icons.location_on, color: Colors.red, size: 30),
+      ),
     ),
   );
 
@@ -54,6 +85,7 @@ class _MapScreenState extends State<MapScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Meridian APRS')),
       body: FlutterMap(
+        mapController: _mapController,
         options: const MapOptions(
           initialCenter: LatLng(39.0, -77.0),
           initialZoom: 9,

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -71,7 +71,10 @@ class _MapScreenState extends State<MapScreen> {
     height: 30,
     child: GestureDetector(
       onTap: () => ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(s.callsign), duration: const Duration(seconds: 2)),
+        SnackBar(
+          content: Text(s.callsign),
+          duration: const Duration(seconds: 2),
+        ),
       ),
       child: Tooltip(
         message: s.callsign,

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -21,6 +21,11 @@ class StationService {
     _transport.lines.listen(_handleLine);
   }
 
+  void updateFilter(double lat, double lon, {int radiusKm = 150}) {
+    final line = '#filter r/${lat.toStringAsFixed(2)}/${lon.toStringAsFixed(2)}/$radiusKm\r\n';
+    _transport.sendLine(line);
+  }
+
   Future<void> stop() async {
     await _transport.disconnect();
     await _controller.close();
@@ -30,8 +35,11 @@ class StationService {
     debugPrint(raw);
     final result = parseAprsLine(raw);
     if (result is Ok<Station>) {
+      debugPrint('PARSED: ${result.value.callsign} @ ${result.value.lat}, ${result.value.lon}');
       _stations[result.value.callsign] = result.value;
       _controller.add(Map.unmodifiable(_stations));
+    } else if (result is Err<Station>) {
+      debugPrint('SKIP: ${result.message} -- $raw');
     }
   }
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -22,7 +22,8 @@ class StationService {
   }
 
   void updateFilter(double lat, double lon, {int radiusKm = 150}) {
-    final line = '#filter r/${lat.toStringAsFixed(2)}/${lon.toStringAsFixed(2)}/$radiusKm\r\n';
+    final line =
+        '#filter r/${lat.toStringAsFixed(2)}/${lon.toStringAsFixed(2)}/$radiusKm\r\n';
     _transport.sendLine(line);
   }
 
@@ -35,7 +36,9 @@ class StationService {
     debugPrint(raw);
     final result = parseAprsLine(raw);
     if (result is Ok<Station>) {
-      debugPrint('PARSED: ${result.value.callsign} @ ${result.value.lat}, ${result.value.lon}');
+      debugPrint(
+        'PARSED: ${result.value.callsign} @ ${result.value.lat}, ${result.value.lon}',
+      );
       _stations[result.value.callsign] = result.value;
       _controller.add(Map.unmodifiable(_stations));
     } else if (result is Err<Station>) {

--- a/test/packet/ax25_parser_test.dart
+++ b/test/packet/ax25_parser_test.dart
@@ -49,6 +49,21 @@ void main() {
         expect(station.lon, isPositive); // East
       });
 
+      test('decodes lat/lon from / position-with-timestamp report', () {
+        // DTI '/' + 7-char timestamp + position
+        const raw = 'N0CALL>APRS:/221509z4903.50N/07201.75W-Test';
+        final station = (parseAprsLine(raw) as Ok<Station>).value;
+        expect(station.lat, closeTo(49.0583, 0.001));
+        expect(station.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('decodes lat/lon from @ position-with-timestamp report', () {
+        const raw = 'N0CALL>APRS:@221509z4903.50N/07201.75W-Test';
+        final station = (parseAprsLine(raw) as Ok<Station>).value;
+        expect(station.lat, closeTo(49.0583, 0.001));
+        expect(station.lon, closeTo(-72.0292, 0.001));
+      });
+
       test('preserves raw packet string', () {
         const raw = 'N0CALL>APRS:!4903.50N/07201.75W-Test';
         final station = (parseAprsLine(raw) as Ok<Station>).value;


### PR DESCRIPTION
## Summary
- Fix empty map: parser now handles \`/\` and \`@\` (position-with-timestamp) DTI types, which are the most common packets on APRS-IS
- Fix \`Utf8Decoder\` type error on Linux: use \`.cast<List<int>>()\` instead of \`as\` cast
- Dynamic APRS-IS filter: map pan sends updated \`#filter\` command mid-session (debounced 800ms)
- Stations persist across pans — no longer cleared on filter change
- Smooth panning: marker \`setState\` debounced 300ms so rebuilds don't interrupt gestures
- Tap a pin → SnackBar shows callsign; hover → Tooltip shows callsign

## Test plan
- [ ] \`flutter test\` — 15 tests pass (2 new: \`/\` and \`@\` DTI decoding)
- [ ] \`flutter analyze\` — zero issues
- [ ] Stations appear on map within ~60s of launch
- [ ] Map pans smoothly without jank
- [ ] Panning away and back preserves previously seen stations
- [ ] Panning to new area populates new stations within ~60s
- [ ] Tap a pin → callsign SnackBar; hover → callsign Tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)