### PR TITLE
feat: v0.2 packets — parser, packet log, APRS symbols

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding |
 
-**Current status: v0.1 Foundation complete. v0.2 Packets is next.**
+**Current status: v0.2 Packets complete. v0.3 TNC is next.**
 
 See `docs/ROADMAP.md` for per-milestone task breakdowns.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,6 +80,54 @@ Transport (bytes) → KISS framing → AX.25 frame → APRS parser → Station m
 UI action → Service Layer → APRS encoder → AX.25 frame → KISS framing → Transport (bytes)
 ```
 
+### Packet log data flow (v0.2+)
+
+```
+AprsIsTransport (raw lines)
+  → StationService.packetStream (broadcast stream)
+      → StationService.recentPackets (500-packet rolling buffer)
+      → PacketLogScreen (real-time list, type filter chips)
+          → tap → showPacketDetailSheet → PacketDetailSheet
+```
+
+`PacketLogScreen` seeds its local list from `recentPackets` on entry so the log is not empty when navigating to the screen after packets have already arrived. All subsequent packets arrive via `packetStream`.
+
+---
+
+## AprsPacket Sealed Class Hierarchy (v0.2+)
+
+All decoded APRS packets are represented as a sealed class hierarchy rooted at `AprsPacket` (`lib/core/packet/aprs_packet.dart`).
+
+```
+AprsPacket (sealed)
+  ├── PositionPacket   DTI: ! = / @
+  ├── WeatherPacket    DTI: _
+  ├── MessagePacket    DTI: :
+  ├── ObjectPacket     DTI: ;
+  ├── ItemPacket       DTI: )
+  ├── StatusPacket     DTI: >
+  ├── MicEPacket       DTI: ` '
+  └── UnknownPacket    catch-all for unrecognised or malformed input
+```
+
+`AprsParser.parse()` reads the data type identifier (DTI — the first character of the APRS info field) and dispatches to a type-specific private method. The parser never throws: any input that cannot be decoded yields an `UnknownPacket` with a `reason` string and the raw info field preserved for debugging.
+
+The sealed hierarchy enables exhaustive `switch` dispatch at the UI layer without dynamic casting. Because the hierarchy is sealed, the Dart compiler enforces that every subtype is handled — omitting a case is a compile error.
+
+`UnknownPacket` is load-bearing: it ensures the packet log always has something to display, and it makes it easy to identify packet types that need parser improvements.
+
+---
+
+## AprsSymbolWidget — Symbol Rendering Abstraction (v0.2+)
+
+`AprsSymbolWidget` (`lib/ui/widgets/aprs_symbol_widget.dart`) is a stateless widget that renders an APRS symbol given a `symbolTable` and `symbolCode` character.
+
+The v0.2 implementation maps symbol codes to Material Design icons (the same approach as the v0.1 `SymbolResolver`). The widget API is the call contract — all callers on the map and in the packet log use `AprsSymbolWidget` rather than resolving icon data directly.
+
+At v1.0, the implementation inside `AprsSymbolWidget` will be swapped to render from a proper APRS bitmap atlas or SVG set. Because all call sites use the widget, the swap is a single-file change with no ripple across screens or other widgets.
+
+`AprsSymbolWidget.iconDataForSymbol()` is also exposed as a static helper for callers (such as map marker builders) that need `IconData` directly rather than a widget subtree.
+
 ---
 
 ## Key Dependencies

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -73,3 +73,23 @@ This file logs significant architectural decisions made during the development o
 **Rationale:** Integrating a proper APRS symbol sprite sheet (PNG atlas or SVG set) requires bundling binary assets, writing sprite-region math, and handling all ~192 primary + 96 alternate symbols. For v0.1, Material Icons provide an immediately functional approximation for the most common station types (house, car, weather, aircraft, etc.) with zero asset dependencies. The `SymbolResolver` class is already in place with the full symbol-name mapping, so swapping in real sprite rendering at v1.0 is a contained UI change.
 
 **Symbol licensing:** The WB4APR APRS symbol definitions are part of the public APRS specification. Community SVG recreations of the symbol set will be evaluated at v1.0 under their respective licenses. Hessu's aprs.fi sprite sheets are explicitly excluded — licensing terms for redistribution are unclear. Any sprite assets added in future must be permissively licensed (public domain, CC0, or MIT/Apache-compatible).
+
+---
+
+## ADR-008: AprsPacket Sealed Class Hierarchy
+
+**Status:** Accepted
+
+**Decision:** Model all decoded APRS packet types as a sealed class hierarchy rooted at `AprsPacket`, with concrete subtypes for each packet type: PositionPacket, WeatherPacket, MessagePacket, ObjectPacket, ItemPacket, StatusPacket, MicEPacket, and UnknownPacket.
+
+**Rationale:** Sealed classes enable exhaustive switch dispatch at the UI layer without dynamic casting. The Dart compiler enforces that every subtype is handled at every switch site — omitting a case is a compile error, not a runtime surprise. The `UnknownPacket` catch-all ensures the parser never crashes on unrecognised input while still preserving the raw info field for debugging. This pattern scales cleanly as new packet types are added: adding a new subtype surfaces every switch that needs updating at compile time.
+
+---
+
+## ADR-009: AprsSymbolWidget — Deferred Symbol Rendering Swap
+
+**Status:** Accepted
+
+**Decision:** Abstract all APRS symbol rendering behind an `AprsSymbolWidget` widget. v0.2 uses Material icons (same approach as the v0.1 `SymbolResolver`). Full sprite sheet rendering is deferred to v1.0.
+
+**Rationale:** Integrating a proper APRS symbol sprite sheet requires bundling binary assets and resolving licensing for any community-produced atlas. For v0.2, continuing to use Material icons avoids blocking packet log delivery on asset pipeline work. The `AprsSymbolWidget` abstraction isolates the rendering implementation: all call sites on the map and in the packet log use the widget, so the swap to a proper APRS bitmap atlas or SVG set at v1.0 is a one-file change with no ripple across the codebase.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,8 @@
 | Milestone | Focus | Status |
 |---|---|---|
 | v0.1 — Foundation | Flutter scaffold, map, APRS-IS, station display with symbols | ✅ Complete |
-| v0.2 — Packets | AX.25/APRS parser, packet log, message decoding | ⬜ Planned |
-| v0.3 — TNC | KISS over USB serial, desktop first | ⬜ Planned |
+| v0.2 — Packets | AX.25/APRS parser, packet log, message decoding | ✅ Complete |
+| v0.3 — TNC | KISS over USB serial, desktop first | ▶ In Progress |
 | v0.4 — BLE | KISS over BLE, mobile platforms | ⬜ Planned |
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending | ⬜ Planned |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding | ⬜ Planned |
@@ -36,11 +36,14 @@ Goal: A working app that connects to APRS-IS, receives packets, and plots statio
 
 Goal: Comprehensive APRS packet parsing and a packet log view.
 
-- [ ] Full AX.25 frame parser (address, control, PID, info)
-- [ ] APRS info field parser: position (all formats), message, object, item, weather, telemetry, status
-- [ ] Packet log screen (raw + decoded view)
-- [ ] Message thread view
-- [ ] Unit test coverage for parser (Dire Wolf/aprslib test vectors)
+- [x] Full APRS parser with `AprsPacket` sealed class hierarchy (PositionPacket, WeatherPacket, MessagePacket, ObjectPacket, ItemPacket, StatusPacket, MicEPacket, UnknownPacket)
+- [x] All DTI types supported: `!`, `=`, `/`, `@`, `;`, `)`, `:`, `_`, `>`, `` ` ``, `'`
+- [x] Packet log screen (real-time scrolling, type filter chips, tap-to-detail)
+- [x] PacketDetailSheet — full decoded field view with selectable raw packet line
+- [x] AprsSymbolWidget — abstract symbol rendering widget, replaces inline symbolIcon helpers
+- [x] StationService updated: `packetStream` + `recentPackets` (500-packet rolling buffer)
+- [x] Unit test coverage: 92 tests passing (69 parser tests + existing suite)
+- [ ] ~~Message thread view~~ — deferred to v0.3+
 
 ---
 

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -1,0 +1,306 @@
+/// Typed APRS packet model hierarchy.
+///
+/// Every decoded packet is one of the concrete subtypes below. Use pattern
+/// matching (switch / is) to dispatch on packet type in UI or service code.
+///
+/// The sealed base [AprsPacket] carries the fields present in every packet:
+/// the original raw APRS-IS line, the source callsign, the destination, the
+/// digipeater path, and a UTC receive timestamp.
+sealed class AprsPacket {
+  /// Original APRS-IS line as received.
+  final String rawLine;
+
+  /// Source callsign, e.g. "W1AW-9".
+  final String source;
+
+  /// Destination field, e.g. "APRS" or a Mic-E encoded string.
+  final String destination;
+
+  /// Digipeater path, e.g. ["WIDE1-1", "WIDE2-1"].
+  final List<String> path;
+
+  /// UTC timestamp at which this packet was received / parsed.
+  final DateTime receivedAt;
+
+  const AprsPacket({
+    required this.rawLine,
+    required this.source,
+    required this.destination,
+    required this.path,
+    required this.receivedAt,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Position
+// ---------------------------------------------------------------------------
+
+/// An APRS position report (DTI: ! = / @).
+///
+/// [hasMessaging] is true when the DTI was `=` or `@` (indicates the station
+/// supports APRS messaging).
+class PositionPacket extends AprsPacket {
+  final double lat;
+  final double lon;
+  final String symbolTable;
+  final String symbolCode;
+  final String comment;
+  final double? altitude;
+  final int? course;
+  final double? speed;
+  final bool hasMessaging;
+
+  /// Timestamp encoded inside the APRS info field (not the receive time).
+  final DateTime? timestamp;
+
+  const PositionPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.lat,
+    required this.lon,
+    required this.symbolTable,
+    required this.symbolCode,
+    required this.comment,
+    this.altitude,
+    this.course,
+    this.speed,
+    required this.hasMessaging,
+    this.timestamp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Weather
+// ---------------------------------------------------------------------------
+
+/// An APRS weather report (DTI: _) or weather embedded in a position packet.
+class WeatherPacket extends AprsPacket {
+  final double? lat;
+  final double? lon;
+  final String symbolTable;
+  final String symbolCode;
+
+  /// Temperature in degrees Fahrenheit (as transmitted; convert for display).
+  final double? temperature;
+
+  /// Relative humidity 0-100 %.
+  final int? humidity;
+
+  /// Barometric pressure in millibars / hPa.
+  final double? pressure;
+
+  /// Sustained wind speed in mph.
+  final double? windSpeed;
+
+  /// Wind direction in degrees true (0-360).
+  final int? windDirection;
+
+  /// Wind gust in mph.
+  final double? windGust;
+
+  /// Rainfall in the last hour, in hundredths of an inch.
+  final double? rainfall1h;
+
+  /// Rainfall in the last 24 hours, in hundredths of an inch.
+  final double? rainfall24h;
+
+  const WeatherPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    this.lat,
+    this.lon,
+    this.symbolTable = '_',
+    this.symbolCode = '_',
+    this.temperature,
+    this.humidity,
+    this.pressure,
+    this.windSpeed,
+    this.windDirection,
+    this.windGust,
+    this.rainfall1h,
+    this.rainfall24h,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Message
+// ---------------------------------------------------------------------------
+
+/// An APRS message packet (DTI: :).
+class MessagePacket extends AprsPacket {
+  /// The callsign this message is addressed to (padded to 9 chars in wire
+  /// format; stored here already trimmed).
+  final String addressee;
+
+  /// The message text.
+  final String message;
+
+  /// Optional message ID (the `{NNN}` suffix), null if absent.
+  final String? messageId;
+
+  const MessagePacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.addressee,
+    required this.message,
+    this.messageId,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Object
+// ---------------------------------------------------------------------------
+
+/// An APRS object report (DTI: ;).
+class ObjectPacket extends AprsPacket {
+  /// Object name, exactly 9 chars in wire format; stored trimmed.
+  final String objectName;
+  final double lat;
+  final double lon;
+  final String symbolTable;
+  final String symbolCode;
+  final String comment;
+
+  /// True when the object is "alive" (asterisk in wire format), false when
+  /// it has been killed (underscore).
+  final bool isAlive;
+
+  const ObjectPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.objectName,
+    required this.lat,
+    required this.lon,
+    required this.symbolTable,
+    required this.symbolCode,
+    required this.comment,
+    required this.isAlive,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Item
+// ---------------------------------------------------------------------------
+
+/// An APRS item report (DTI: )).
+class ItemPacket extends AprsPacket {
+  /// Item name, 3-9 chars.
+  final String itemName;
+  final double lat;
+  final double lon;
+  final String symbolTable;
+  final String symbolCode;
+  final String comment;
+
+  /// True when the item is alive (`!`), false when killed (`_`).
+  final bool isAlive;
+
+  const ItemPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.itemName,
+    required this.lat,
+    required this.lon,
+    required this.symbolTable,
+    required this.symbolCode,
+    required this.comment,
+    required this.isAlive,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+/// An APRS status report (DTI: >).
+class StatusPacket extends AprsPacket {
+  final String status;
+
+  /// Optional DHM/HMS timestamp encoded in the status field.
+  final DateTime? timestamp;
+
+  const StatusPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.status,
+    this.timestamp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mic-E
+// ---------------------------------------------------------------------------
+
+/// A Mic-E compressed position/status packet (DTI: ` or ').
+class MicEPacket extends AprsPacket {
+  final double lat;
+  final double lon;
+  final double? altitude;
+  final int? course;
+  final double? speed;
+  final String symbolTable;
+  final String symbolCode;
+  final String comment;
+
+  /// Human-readable Mic-E status message decoded from the destination field
+  /// (e.g. "En Route", "In Service", "Off Duty").
+  final String micEMessage;
+
+  const MicEPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.lat,
+    required this.lon,
+    this.altitude,
+    this.course,
+    this.speed,
+    required this.symbolTable,
+    required this.symbolCode,
+    required this.comment,
+    required this.micEMessage,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Unknown / catch-all
+// ---------------------------------------------------------------------------
+
+/// Returned for any packet that could not be decoded into a typed subclass.
+///
+/// The [reason] field explains why decoding failed (for debugging/logging).
+/// [rawInfo] holds the info field if it could be extracted.
+class UnknownPacket extends AprsPacket {
+  final String reason;
+  final String rawInfo;
+
+  const UnknownPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    required this.reason,
+    this.rawInfo = '',
+  });
+}

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -353,10 +353,8 @@ class AprsParser {
       );
     }
 
-    final lat =
-        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
-    final lon =
-        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
     final symbolTable = m.group(3)!;
     final symbolCode = m.group(6)!;
     var comment = m.group(7)!;
@@ -576,10 +574,8 @@ class AprsParser {
       );
     }
 
-    final lat =
-        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
-    final lon =
-        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
 
     return ObjectPacket(
       rawLine: rawLine,
@@ -715,10 +711,8 @@ class AprsParser {
       );
     }
 
-    final lat =
-        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
-    final lon =
-        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
 
     return ItemPacket(
       rawLine: rawLine,
@@ -1123,7 +1117,8 @@ class AprsParser {
   /// Convert DDMM.HH string to decimal degrees.
   double _ddmm(String s, {required bool isLat}) {
     final d = isLat ? 2 : 3;
-    return double.parse(s.substring(0, d)) + double.parse(s.substring(d)) / 60.0;
+    return double.parse(s.substring(0, d)) +
+        double.parse(s.substring(d)) / 60.0;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1,0 +1,1151 @@
+import 'dart:typed_data';
+
+import 'aprs_packet.dart';
+
+/// Full APRS packet parser.
+///
+/// [parse] accepts an APRS-IS text line and returns a typed [AprsPacket].
+/// It never throws — malformed input always yields [UnknownPacket].
+///
+/// [parseFrame] accepts raw AX.25 frame bytes (stub; APRS-IS is the current
+/// use case). Returns [UnknownPacket] for now.
+class AprsParser {
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /// Parse one APRS-IS line.
+  ///
+  /// Format: `SOURCE>DEST,PATH:INFO`
+  AprsPacket parse(String line) {
+    // Ignore blank lines and server comment lines.
+    if (line.isEmpty || line.startsWith('#')) {
+      return _unknown(line, '', '', [], 'Server comment or empty line');
+    }
+
+    // Split header from info field at the first colon.
+    final colonIdx = line.indexOf(':');
+    if (colonIdx < 0 || colonIdx + 1 > line.length) {
+      return _unknown(line, '', '', [], 'No colon separator found');
+    }
+
+    final header = line.substring(0, colonIdx);
+    final info = colonIdx + 1 < line.length ? line.substring(colonIdx + 1) : '';
+
+    // Parse header: SOURCE>DEST,p1,p2,...
+    final gtIdx = header.indexOf('>');
+    if (gtIdx <= 0) {
+      return _unknown(line, '', '', [], 'No > in header');
+    }
+    final source = header.substring(0, gtIdx);
+    final destAndPath = header.substring(gtIdx + 1);
+    final pathParts = destAndPath.split(',');
+    final destination = pathParts.isNotEmpty ? pathParts.first : '';
+    final path = pathParts.length > 1 ? pathParts.sublist(1) : <String>[];
+
+    if (info.isEmpty) {
+      return _unknown(line, source, destination, path, 'Empty info field');
+    }
+
+    final dti = info[0];
+    final now = DateTime.now().toUtc();
+
+    try {
+      return _dispatch(
+        dti: dti,
+        info: info,
+        rawLine: line,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: now,
+      );
+    } catch (_) {
+      // Belt-and-suspenders: never propagate exceptions.
+      return UnknownPacket(
+        rawLine: line,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: now,
+        reason: 'Unhandled parse exception',
+        rawInfo: info,
+      );
+    }
+  }
+
+  /// Parse raw AX.25 frame bytes.
+  ///
+  /// Stub implementation — returns [UnknownPacket] until AX.25 framing support
+  /// is added in a future milestone.
+  AprsPacket parseFrame(Uint8List frameBytes) {
+    return UnknownPacket(
+      rawLine: '',
+      source: '',
+      destination: '',
+      path: const [],
+      receivedAt: DateTime.now().toUtc(),
+      reason: 'AX.25 frame parsing not yet implemented',
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // DTI dispatch
+  // ---------------------------------------------------------------------------
+
+  AprsPacket _dispatch({
+    required String dti,
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    switch (dti) {
+      // Position without timestamp — no messaging (!) or messaging (=)
+      case '!':
+      case '=':
+        return _parsePosition(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          hasTimestamp: false,
+          hasMessaging: dti == '=',
+        );
+
+      // Position with timestamp — no messaging (/) or messaging (@)
+      case '/':
+      case '@':
+        return _parsePosition(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          hasTimestamp: true,
+          hasMessaging: dti == '@',
+        );
+
+      case ';':
+        return _parseObject(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      case ')':
+        return _parseItem(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      case ':':
+        return _parseMessage(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      case '_':
+        return _parseWeather(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      case '>':
+        return _parseStatus(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      // Mic-E
+      case '`':
+      case "'":
+        return _parseMicE(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+        );
+
+      // Telemetry — parsed as Unknown for now (v0.2 scope)
+      case 'T':
+        return UnknownPacket(
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          reason: 'Telemetry not yet implemented',
+          rawInfo: info,
+        );
+
+      default:
+        return _unknown(
+          rawLine,
+          source,
+          destination,
+          path,
+          'Unrecognised DTI: $dti',
+          info,
+        );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Position parsing
+  // ---------------------------------------------------------------------------
+
+  // Uncompressed position regex.
+  // Groups: (lat DDMM.HH)(N|S)(symTable)(lon DDDMM.HH)(E|W)(symCode)(comment)
+  static final _uncompressedPosRe = RegExp(
+    r'^(\d{4}\.\d{2})(N|S)(.)(\d{5}\.\d{2})(E|W)(.)(.*)$',
+    dotAll: true,
+  );
+
+  // Course/speed/altitude comment extensions.
+  // Course/speed: "CCC/SSS" — 3-digit course, slash, 3-digit speed (knots).
+  static final _courseSpeedRe = RegExp(r'^(\d{3})/(\d{3})');
+
+  // Altitude: "/A=XXXXXX" anywhere in comment (feet).
+  static final _altRe = RegExp(r'/A=(\d+)');
+
+  // DHM timestamp: DDHHMMz (UTC) or DDHHMMh (local — treated as UTC).
+  static final _dhmRe = RegExp(r'^(\d{2})(\d{2})(\d{2})[zh]$');
+
+  AprsPacket _parsePosition({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required bool hasTimestamp,
+    required bool hasMessaging,
+  }) {
+    // info[0] is the DTI. After that, optionally a 7-char timestamp, then position.
+    String posStr;
+    DateTime? packetTimestamp;
+
+    if (hasTimestamp) {
+      // Need at least DTI + 7 timestamp chars + something for position.
+      if (info.length < 9) {
+        return _unknown(
+          rawLine,
+          source,
+          destination,
+          path,
+          'Timestamped position too short',
+          info,
+        );
+      }
+      final tsStr = info.substring(1, 8); // 7 chars
+      packetTimestamp = _parseTimestamp(tsStr, receivedAt);
+      posStr = info.substring(8);
+    } else {
+      posStr = info.substring(1);
+    }
+
+    if (posStr.isEmpty) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'No position data after DTI/timestamp',
+        info,
+      );
+    }
+
+    // Detect compressed vs uncompressed.
+    // Compressed position: posStr[0] is the symbol table character (/ \ or
+    // overlay), posStr[1..4] are 4 base-91 lat chars (ASCII 33-124),
+    // posStr[5..8] are 4 base-91 lon chars, posStr[9] is symbol code.
+    // The APRS spec says compressed lat/lon chars are in range [33, 122]
+    // (printable ASCII except space and '{'-'~'). We use the presence of
+    // base-91 chars to distinguish. A quick heuristic: if posStr[1] is a
+    // digit it's uncompressed lat (DDmm.mm format always starts with a digit).
+    final bool isCompressed =
+        posStr.length >= 10 && !_isUncompressedPos(posStr);
+
+    if (isCompressed) {
+      return _parseCompressedPosition(
+        posStr: posStr,
+        info: info,
+        rawLine: rawLine,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: receivedAt,
+        hasMessaging: hasMessaging,
+        packetTimestamp: packetTimestamp,
+      );
+    } else {
+      return _parseUncompressedPosition(
+        posStr: posStr,
+        info: info,
+        rawLine: rawLine,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: receivedAt,
+        hasMessaging: hasMessaging,
+        packetTimestamp: packetTimestamp,
+      );
+    }
+  }
+
+  /// Heuristic to distinguish uncompressed from compressed position strings.
+  /// Uncompressed lat always begins with a digit (DDMM.HH pattern).
+  bool _isUncompressedPos(String posStr) {
+    if (posStr.isEmpty) return false;
+    // Skip the symbol table char at index 0 for compressed; for uncompressed
+    // the entire posStr is the position data starting with digit.
+    // Uncompressed posStr starts with digits like '4903.50N...'
+    return posStr[0].codeUnitAt(0) >= 0x30 && posStr[0].codeUnitAt(0) <= 0x39;
+  }
+
+  AprsPacket _parseUncompressedPosition({
+    required String posStr,
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required bool hasMessaging,
+    required DateTime? packetTimestamp,
+  }) {
+    final m = _uncompressedPosRe.firstMatch(posStr);
+    if (m == null) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Uncompressed position regex did not match',
+        info,
+      );
+    }
+
+    final lat =
+        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon =
+        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final symbolTable = m.group(3)!;
+    final symbolCode = m.group(6)!;
+    var comment = m.group(7)!;
+
+    // Extract course/speed from beginning of comment.
+    int? course;
+    double? speed;
+    final csMatch = _courseSpeedRe.firstMatch(comment);
+    if (csMatch != null) {
+      final c = int.tryParse(csMatch.group(1)!);
+      final s = int.tryParse(csMatch.group(2)!);
+      if (c != null && s != null && !(c == 0 && s == 0)) {
+        course = c;
+        speed = s.toDouble(); // knots
+      }
+    }
+
+    // Extract altitude from comment.
+    double? altitude;
+    final altMatch = _altRe.firstMatch(comment);
+    if (altMatch != null) {
+      final feet = int.tryParse(altMatch.group(1)!);
+      if (feet != null) altitude = feet.toDouble();
+      // Strip the altitude extension from the comment display.
+      comment = comment.replaceFirst(_altRe, '').trim();
+    }
+
+    return PositionPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      lat: lat,
+      lon: lon,
+      symbolTable: symbolTable,
+      symbolCode: symbolCode,
+      comment: comment,
+      altitude: altitude,
+      course: course,
+      speed: speed,
+      hasMessaging: hasMessaging,
+      timestamp: packetTimestamp,
+    );
+  }
+
+  AprsPacket _parseCompressedPosition({
+    required String posStr,
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required bool hasMessaging,
+    required DateTime? packetTimestamp,
+  }) {
+    // Compressed format (APRS spec chapter 9):
+    // posStr: symTable(1) + latChars(4) + lonChars(4) + symCode(1) + csT(3) + comment
+    // Each base-91 group: value = (c1-33)*91^3 + (c2-33)*91^2 + (c3-33)*91 + (c4-33)
+    if (posStr.length < 10) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Compressed position string too short',
+        info,
+      );
+    }
+
+    final symbolTable = posStr[0];
+    final latChars = posStr.substring(1, 5);
+    final lonChars = posStr.substring(5, 9);
+    final symbolCode = posStr[9];
+    final remainder = posStr.length > 10 ? posStr.substring(10) : '';
+
+    // Decode base-91 lat: L = 90 - (value / 380926)  degrees
+    final latVal = _base91Decode4(latChars);
+    final lonVal = _base91Decode4(lonChars);
+    if (latVal == null || lonVal == null) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Invalid base-91 encoding in compressed position',
+        info,
+      );
+    }
+
+    final lat = 90.0 - latVal / 380926.0;
+    final lon = -180.0 + lonVal / 190463.0;
+
+    // Optional cs bytes: remainder[0] = course byte, remainder[1] = speed byte,
+    // remainder[2] = compression-type byte.
+    int? course;
+    double? speed;
+    String comment = remainder;
+    if (remainder.length >= 3) {
+      final csType = remainder[2].codeUnitAt(0) - 33;
+      // Bits 4-5 of csType byte indicate what c and s represent.
+      // If bit 5 set: GGA altitude; if bits 4-5 = 01: course/speed.
+      final comprType = (csType >> 4) & 0x3;
+      if (comprType == 1) {
+        // course/speed
+        final cByte = remainder[0].codeUnitAt(0) - 33;
+        final sByte = remainder[1].codeUnitAt(0) - 33;
+        final c = cByte * 4; // degrees (0-360 encoded as 0-90 * 4)
+        // Spec: speed = 1.08^sByte - 1 knots. Simplified safe calc:
+        if (cByte != 0 || sByte != 0) {
+          course = c == 360 ? 0 : c;
+          // Compute 1.08^sByte
+          double spd = 0;
+          for (int i = 0; i < sByte; i++) {
+            spd = spd == 0 ? 1.08 : spd * 1.08;
+          }
+          speed = spd - 1;
+        }
+        comment = remainder.length > 3 ? remainder.substring(3) : '';
+      } else if (comprType == 2) {
+        // Altitude encoded in cs bytes (1.002^altVal feet).
+        // Skipped for now — advance past the 3 cs bytes.
+        comment = remainder.length > 3 ? remainder.substring(3) : '';
+      }
+    }
+
+    return PositionPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      lat: lat,
+      lon: lon,
+      symbolTable: symbolTable,
+      symbolCode: symbolCode,
+      comment: comment,
+      altitude: null,
+      course: course,
+      speed: speed,
+      hasMessaging: hasMessaging,
+      timestamp: packetTimestamp,
+    );
+  }
+
+  /// Decode 4 base-91 characters to an integer value.
+  int? _base91Decode4(String s) {
+    if (s.length != 4) return null;
+    int v = 0;
+    for (int i = 0; i < 4; i++) {
+      final c = s.codeUnitAt(i) - 33;
+      if (c < 0 || c > 90) return null;
+      v = v * 91 + c;
+    }
+    return v;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Object parsing  (DTI: ;)
+  // ---------------------------------------------------------------------------
+
+  // Object format: ;NNNNNNNNN*DDHHMMzDDMM.HHN/DDDMM.HHWsymcomment
+  // or with killed: ;NNNNNNNNN_timestamp...
+  // Name is exactly 9 characters (chars 1-9 of info field, after DTI).
+  AprsPacket _parseObject({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    // Minimum: ; + 9 name + alive/killed + 7 timestamp + position (~18 chars)
+    if (info.length < 18) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Object packet too short',
+        info,
+      );
+    }
+
+    final objectName = info.substring(1, 10).trimRight();
+    final aliveChar = info[10]; // '*' = alive, '_' = killed
+    final isAlive = aliveChar == '*';
+
+    // After alive/killed char: 7-char timestamp + position
+    if (info.length < 18) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Object packet missing timestamp/position',
+        info,
+      );
+    }
+
+    // Timestamp is chars 11-17 (7 chars), position starts at 18.
+    final posStr = info.substring(18);
+    final m = _uncompressedPosRe.firstMatch(posStr);
+    if (m == null) {
+      // Try compressed
+      return _tryObjectCompressed(
+        posStr: posStr,
+        objectName: objectName,
+        isAlive: isAlive,
+        rawLine: rawLine,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: receivedAt,
+        info: info,
+      );
+    }
+
+    final lat =
+        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon =
+        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+
+    return ObjectPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      objectName: objectName,
+      lat: lat,
+      lon: lon,
+      symbolTable: m.group(3)!,
+      symbolCode: m.group(6)!,
+      comment: m.group(7)!,
+      isAlive: isAlive,
+    );
+  }
+
+  AprsPacket _tryObjectCompressed({
+    required String posStr,
+    required String objectName,
+    required bool isAlive,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required String info,
+  }) {
+    if (posStr.length < 10) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Object compressed position too short',
+        info,
+      );
+    }
+    final symbolTable = posStr[0];
+    final latChars = posStr.substring(1, 5);
+    final lonChars = posStr.substring(5, 9);
+    final symbolCode = posStr[9];
+    final comment = posStr.length > 10 ? posStr.substring(10) : '';
+
+    final latVal = _base91Decode4(latChars);
+    final lonVal = _base91Decode4(lonChars);
+    if (latVal == null || lonVal == null) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Object compressed position decode failed',
+        info,
+      );
+    }
+
+    return ObjectPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      objectName: objectName,
+      lat: 90.0 - latVal / 380926.0,
+      lon: -180.0 + lonVal / 190463.0,
+      symbolTable: symbolTable,
+      symbolCode: symbolCode,
+      comment: comment,
+      isAlive: isAlive,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Item parsing  (DTI: ))
+  // ---------------------------------------------------------------------------
+
+  // Item format: )NAME!position  or  )NAME_position (killed)
+  // Name is 3-9 chars, terminated by '!' (alive) or '_' (killed).
+  AprsPacket _parseItem({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    if (info.length < 5) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Item packet too short',
+        info,
+      );
+    }
+
+    // Find the alive/killed delimiter ('!' or '_') after the DTI.
+    final nameField = info.substring(1);
+    int delimIdx = -1;
+    bool isAlive = true;
+    for (int i = 2; i < nameField.length && i <= 9; i++) {
+      if (nameField[i] == '!' || nameField[i] == '_') {
+        delimIdx = i;
+        isAlive = nameField[i] == '!';
+        break;
+      }
+    }
+    if (delimIdx < 0) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Item name delimiter not found',
+        info,
+      );
+    }
+
+    final itemName = nameField.substring(0, delimIdx).trimRight();
+    final posStr = nameField.substring(delimIdx + 1);
+
+    final m = _uncompressedPosRe.firstMatch(posStr);
+    if (m == null) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Item position parse failed',
+        info,
+      );
+    }
+
+    final lat =
+        _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
+    final lon =
+        _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+
+    return ItemPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      itemName: itemName,
+      lat: lat,
+      lon: lon,
+      symbolTable: m.group(3)!,
+      symbolCode: m.group(6)!,
+      comment: m.group(7)!,
+      isAlive: isAlive,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Message parsing  (DTI: :)
+  // ---------------------------------------------------------------------------
+
+  // Message format: :ADDRESSEE :message text{id}
+  // Addressee is exactly 9 chars (space-padded), followed by ':', then message.
+  // Optional message ID is the last '{NNN}' suffix.
+  AprsPacket _parseMessage({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    // info[0] is ':', addressee is info[1..9], info[10] must be ':'.
+    if (info.length < 11 || info[10] != ':') {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Message format invalid (need :XXXXXXXXX:)',
+        info,
+      );
+    }
+
+    final addressee = info.substring(1, 10).trim();
+    var messageText = info.substring(11);
+
+    // Extract optional message ID: '{NNN}' at end.
+    String? messageId;
+    final idIdx = messageText.lastIndexOf('{');
+    if (idIdx >= 0) {
+      messageId = messageText.substring(idIdx + 1);
+      messageText = messageText.substring(0, idIdx);
+    }
+
+    return MessagePacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      addressee: addressee,
+      message: messageText,
+      messageId: messageId?.isEmpty == true ? null : messageId,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Weather parsing  (DTI: _)
+  // ---------------------------------------------------------------------------
+
+  // Standalone weather report: _MMDDHHMMcCCCsSSSgGGGtTTTrRRRpPPPPhhBBBBB
+  // Field codes: c=wind dir, s=sustained wind, g=gust, t=temp, r=rain/hr,
+  //              p=rain/24h, h=humidity, b=baro pressure
+  static final _weatherFieldRe = RegExp(
+    r'c(\d{3})|s(\d{3})|g(\d{3})|t(-?\d{3})|r(\d{3})|p(\d{3})|P(\d{3})|h(\d{2})|b(\d{5})',
+  );
+
+  AprsPacket _parseWeather({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    // Skip DTI and 8-char timestamp (MMDDhhmm).
+    // Some implementations omit the timestamp; handle both.
+    final weatherData = info.length > 9 ? info.substring(9) : info.substring(1);
+
+    int? windDir;
+    double? windSpeed;
+    double? windGust;
+    double? temperature;
+    int? humidity;
+    double? pressure;
+    double? rainfall1h;
+    double? rainfall24h;
+
+    for (final m in _weatherFieldRe.allMatches(weatherData)) {
+      if (m.group(1) != null) {
+        windDir = int.tryParse(m.group(1)!);
+      } else if (m.group(2) != null) {
+        windSpeed = double.tryParse(m.group(2)!);
+      } else if (m.group(3) != null) {
+        windGust = double.tryParse(m.group(3)!);
+      } else if (m.group(4) != null) {
+        temperature = double.tryParse(m.group(4)!);
+      } else if (m.group(5) != null) {
+        rainfall1h = double.tryParse(m.group(5)!);
+      } else if (m.group(6) != null) {
+        rainfall24h = double.tryParse(m.group(6)!);
+      } else if (m.group(8) != null) {
+        humidity = int.tryParse(m.group(8)!);
+      } else if (m.group(9) != null) {
+        final raw = int.tryParse(m.group(9)!);
+        if (raw != null) pressure = raw / 10.0; // tenths of mb → mb
+      }
+    }
+
+    return WeatherPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      temperature: temperature,
+      humidity: humidity,
+      pressure: pressure,
+      windSpeed: windSpeed,
+      windDirection: windDir,
+      windGust: windGust,
+      rainfall1h: rainfall1h,
+      rainfall24h: rainfall24h,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Status parsing  (DTI: >)
+  // ---------------------------------------------------------------------------
+
+  // Status format: >status text  or  >DHMzstatus text  (optional timestamp)
+  AprsPacket _parseStatus({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    var statusText = info.substring(1); // drop DTI
+    DateTime? packetTimestamp;
+
+    // Optional 7-char DHM timestamp at the beginning.
+    if (statusText.length >= 7) {
+      final possibleTs = statusText.substring(0, 7);
+      final tsResult = _parseTimestamp(possibleTs, receivedAt);
+      if (tsResult != null) {
+        packetTimestamp = tsResult;
+        statusText = statusText.substring(7);
+      }
+    }
+
+    return StatusPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      status: statusText,
+      timestamp: packetTimestamp,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mic-E parsing  (DTI: ` or ')
+  // ---------------------------------------------------------------------------
+
+  // Mic-E is one of the most complex APRS formats. The latitude, N/S, E/W
+  // longitude offset, and message bits are encoded in the 6-char AX.25
+  // destination field. The info field encodes longitude, speed, course, and
+  // symbol. Reference: APRS spec chapter 10, aprslib mic_e.py.
+  //
+  // Destination encoding per char:
+  //   char 0-5 of destination (uppercase, digits, space)
+  //   Each char encodes one nibble of lat and one message/flag bit.
+  //
+  // The destination callsign for Mic-E is NOT the usual APRS destination —
+  // it carries encoded data. We receive it already decoded from the APRS-IS
+  // header parser as [destination].
+
+  static const _micEMessages = [
+    'Off Duty',
+    'En Route',
+    'In Service',
+    'Returning',
+    'Committed',
+    'Special',
+    'Priority',
+    'Emergency',
+  ];
+
+  AprsPacket _parseMicE({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+  }) {
+    // Destination must be at least 6 chars.
+    if (destination.length < 6 || info.length < 9) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Mic-E packet too short',
+        info,
+      );
+    }
+
+    // Decode latitude and message bits from destination chars 0-5.
+    // Each char encodes one BCD digit of latitude (0-9) and flags.
+    // Digits: 0-9 → '0'-'9', space → ambiguous 0. A-J → 0-9 (message bit set).
+    // K, L, Z → 0 (with flag bits).
+    // N/S: char 3, 0 = North if digit is a letter (A-K), South otherwise.
+    // Lon offset: char 4, if letter add 100 to lon degrees.
+    // E/W: char 5, if letter West else East.
+    final dest = destination;
+    final latDigits = List<int>.filled(6, 0);
+    int messageBits = 0;
+    bool isNorth = false;
+    bool addLonOffset = false;
+    bool isWest = false;
+
+    for (int i = 0; i < 6; i++) {
+      final c = dest[i].codeUnitAt(0);
+      int digit;
+      bool msgBit = false;
+
+      if (c >= 0x30 && c <= 0x39) {
+        // '0'-'9': standard digit, message bit 0
+        digit = c - 0x30;
+        msgBit = false;
+      } else if (c >= 0x41 && c <= 0x4B) {
+        // 'A'-'K': digit 0-9 with message bit set (custom message)
+        digit = c - 0x41;
+        msgBit = true;
+      } else if (c == 0x4C || c == 0x5A) {
+        // 'L' or 'Z': 0, no message bit (ambiguous position)
+        digit = 0;
+        msgBit = false;
+      } else if (c == 0x50) {
+        // 'P': space → 0 (some implementations)
+        digit = 0;
+        msgBit = true;
+      } else {
+        // Space or other
+        digit = 0;
+        msgBit = false;
+      }
+
+      latDigits[i] = digit;
+      if (i < 3 && msgBit) messageBits |= (1 << (2 - i));
+
+      // Flag bits from specific positions.
+      if (i == 3) isNorth = msgBit; // letter = North
+      if (i == 4) addLonOffset = msgBit; // letter = +100 lon degrees
+      if (i == 5) isWest = msgBit; // letter = West
+    }
+
+    // Latitude: DD MM.HH (BCD from 6 digits)
+    final latDeg = latDigits[0] * 10 + latDigits[1];
+    final latMin = latDigits[2] * 10 + latDigits[3];
+    final latHundredths = latDigits[4] * 10 + latDigits[5];
+    final latAbs = latDeg + (latMin + latHundredths / 100.0) / 60.0;
+    final lat = isNorth ? latAbs : -latAbs;
+
+    // Info field: DTI(1) + lon(3 bytes) + speed/course(2 bytes) + symCode(1) +
+    //             symTable(1) + remainder
+    // Bytes are raw ASCII with offsets per spec.
+    //
+    // Longitude: info[1] - 28 (then +100 if addLonOffset), degrees offset math.
+    // Speed: info[4] (hundreds+tens) and info[5] (units) with offsets.
+    // Course: info[5] (remainder from speed) and info[6] with offsets.
+
+    final b1 = info.codeUnitAt(1) - 28;
+    final b2 = info.codeUnitAt(2) - 28;
+    final b3 = info.codeUnitAt(3) - 28;
+    final b4 = info.codeUnitAt(4) - 28;
+    final b5 = info.codeUnitAt(5) - 28;
+    final b6 = info.codeUnitAt(6) - 28;
+
+    // Longitude degrees
+    int lonDeg = b1 + (addLonOffset ? 100 : 0);
+    // Correct per spec ambiguities
+    if (lonDeg >= 180 && lonDeg <= 189) lonDeg -= 80;
+    if (lonDeg >= 190 && lonDeg <= 199) lonDeg -= 190;
+
+    // Longitude minutes
+    int lonMin = b2;
+    if (lonMin >= 60) lonMin -= 60;
+
+    // Longitude hundredths of minutes
+    final lonHundredths = b3;
+
+    final lonAbs = lonDeg + (lonMin + lonHundredths / 100.0) / 60.0;
+    final lon = isWest ? -lonAbs : lonAbs;
+
+    // Speed: sp = b4 * 10 + b5 / 10
+    final speedHundreds = b4 * 10;
+    final speedUnits = b5 ~/ 10;
+    int speedKnots = speedHundreds + speedUnits;
+    if (speedKnots >= 800) speedKnots -= 800;
+
+    // Course: dc = (b5 % 10) * 100 + b6
+    int course = (b5 % 10) * 100 + b6;
+    if (course >= 400) course -= 400;
+
+    // Symbol
+    final symbolCode = info.length > 7 ? info[7] : '>';
+    final symbolTable = info.length > 8 ? info[8] : '/';
+
+    // Comment (everything after the 9 fixed bytes, excluding any telemetry prefix)
+    var comment = info.length > 9 ? info.substring(9) : '';
+    // Strip leading Mic-E telemetry sequence indicators if present.
+    if (comment.startsWith("'") ||
+        comment.startsWith('`') ||
+        comment.startsWith('"')) {
+      // Optional status/telemetry text marker — leave it in comment as-is.
+    }
+
+    // Mic-E message from the 3 message bits (standard messages).
+    // Bits 2-0: A B C where A is most significant.
+    // Values 0-7 map to the 8 standard messages.
+    final micEMsg = _micEMessages.length > messageBits
+        ? _micEMessages[messageBits]
+        : 'Custom';
+
+    return MicEPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      lat: lat,
+      lon: lon,
+      course: course == 0 ? null : course,
+      speed: speedKnots.toDouble(),
+      symbolTable: symbolTable,
+      symbolCode: symbolCode,
+      comment: comment.trim(),
+      micEMessage: micEMsg,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Timestamp helpers
+  // ---------------------------------------------------------------------------
+
+  /// Parse a 7-char APRS timestamp string.
+  ///
+  /// Supported formats:
+  ///   DDHHMMz — day/hour/minute UTC
+  ///   DDHHMMh — day/hour/minute local (treated as UTC)
+  ///   HHMMSSh — hour/minute/second
+  ///
+  /// Returns null if the string does not match any known format.
+  DateTime? _parseTimestamp(String ts, DateTime reference) {
+    if (ts.length != 7) return null;
+    final suffix = ts[6];
+
+    if (suffix == 'z' || suffix == 'h') {
+      // DDHHMMz or DDHHMMh
+      final m = _dhmRe.firstMatch(ts);
+      if (m != null) {
+        final day = int.tryParse(m.group(1)!);
+        final hour = int.tryParse(m.group(2)!);
+        final minute = int.tryParse(m.group(3)!);
+        if (day != null && hour != null && minute != null) {
+          // Construct a DateTime using reference year/month; handle day rollover.
+          final dt = DateTime.utc(
+            reference.year,
+            reference.month,
+            day,
+            hour,
+            minute,
+          );
+          return dt;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Coordinate helpers
+  // ---------------------------------------------------------------------------
+
+  /// Convert DDMM.HH string to decimal degrees.
+  double _ddmm(String s, {required bool isLat}) {
+    final d = isLat ? 2 : 3;
+    return double.parse(s.substring(0, d)) + double.parse(s.substring(d)) / 60.0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unknown packet factory
+  // ---------------------------------------------------------------------------
+
+  UnknownPacket _unknown(
+    String rawLine,
+    String source,
+    String destination,
+    List<String> path,
+    String reason, [
+    String rawInfo = '',
+  ]) {
+    return UnknownPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: DateTime.now().toUtc(),
+      reason: reason,
+      rawInfo: rawInfo,
+    );
+  }
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -127,9 +127,7 @@ class _MapScreenState extends State<MapScreen> {
       floatingActionButton: FloatingActionButton(
         onPressed: () => Navigator.push(
           context,
-          MaterialPageRoute(
-            builder: (_) => PacketLogScreen(service: _service),
-          ),
+          MaterialPageRoute(builder: (_) => PacketLogScreen(service: _service)),
         ),
         tooltip: 'Packet Log',
         child: const Icon(Icons.list_alt),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -7,7 +7,9 @@ import 'package:latlong2/latlong.dart';
 import '../core/packet/station.dart';
 import '../core/transport/aprs_is_transport.dart';
 import '../services/station_service.dart';
+import '../ui/widgets/aprs_symbol_widget.dart';
 import '../ui/widgets/station_info_sheet.dart';
+import 'packet_log_screen.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -94,10 +96,11 @@ class _MapScreenState extends State<MapScreen> {
       ),
       child: Tooltip(
         message: s.callsign,
-        child: Icon(
-          symbolIcon(s.symbolCode),
-          color: _markerColor(s.symbolCode),
+        child: AprsSymbolWidget(
+          symbolTable: s.symbolTable,
+          symbolCode: s.symbolCode,
           size: 36,
+          color: _markerColor(s.symbolCode),
         ),
       ),
     ),
@@ -120,6 +123,16 @@ class _MapScreenState extends State<MapScreen> {
           ),
           MarkerLayer(markers: _markers),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PacketLogScreen(service: _service),
+          ),
+        ),
+        tooltip: 'Packet Log',
+        child: const Icon(Icons.list_alt),
       ),
     );
   }

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -297,21 +297,19 @@ class _PacketRow extends StatelessWidget {
 
   static String _summary(AprsPacket p) {
     return switch (p) {
-      PositionPacket() =>
-        '${_latStr(p.lat)}, ${_lonStr(p.lon)}',
-      MessagePacket() =>
-        '\u2192 ${p.addressee}: ${p.message}',
+      PositionPacket() => '${_latStr(p.lat)}, ${_lonStr(p.lon)}',
+      MessagePacket() => '\u2192 ${p.addressee}: ${p.message}',
       WeatherPacket() => _wxSummary(p),
       ObjectPacket() =>
         '${p.objectName} @ ${_latStr(p.lat)}, ${_lonStr(p.lon)}',
-      ItemPacket() =>
-        '${p.itemName} @ ${_latStr(p.lat)}, ${_lonStr(p.lon)}',
+      ItemPacket() => '${p.itemName} @ ${_latStr(p.lat)}, ${_lonStr(p.lon)}',
       StatusPacket() => p.status,
       MicEPacket() =>
         '${_latStr(p.lat)}, ${_lonStr(p.lon)} \u2022 ${p.micEMessage}',
-      UnknownPacket() => p.rawLine.length > 40
-          ? '${p.rawLine.substring(0, 40)}\u2026'
-          : p.rawLine,
+      UnknownPacket() =>
+        p.rawLine.length > 40
+            ? '${p.rawLine.substring(0, 40)}\u2026'
+            : p.rawLine,
     };
   }
 
@@ -331,7 +329,8 @@ class _PacketRow extends StatelessWidget {
       final f = p.temperature!.toStringAsFixed(0);
       parts.add('$f \u00b0F');
     }
-    if (p.windSpeed != null) parts.add('${p.windSpeed!.toStringAsFixed(0)} mph wind');
+    if (p.windSpeed != null)
+      parts.add('${p.windSpeed!.toStringAsFixed(0)} mph wind');
     if (p.humidity != null) parts.add('${p.humidity}% RH');
     return parts.isEmpty ? 'Weather' : parts.join(' / ');
   }

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -1,0 +1,368 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../core/packet/aprs_packet.dart';
+import '../services/station_service.dart';
+import '../ui/widgets/packet_detail_sheet.dart';
+
+/// All filterable packet type labels shown in the filter bar.
+enum _PacketFilter {
+  all('ALL'),
+  pos('POS'),
+  msg('MSG'),
+  wx('WX'),
+  obj('OBJ'),
+  status('STATUS'),
+  micE('MIC-E');
+
+  const _PacketFilter(this.label);
+  final String label;
+}
+
+/// Full-screen real-time scrolling log of decoded APRS packets.
+///
+/// Receives [StationService] from the caller so it shares the same live
+/// connection — no second TCP session is opened.
+class PacketLogScreen extends StatefulWidget {
+  const PacketLogScreen({super.key, required this.service});
+
+  final StationService service;
+
+  @override
+  State<PacketLogScreen> createState() => _PacketLogScreenState();
+}
+
+class _PacketLogScreenState extends State<PacketLogScreen> {
+  /// Rolling buffer mirroring [StationService.recentPackets].
+  final List<AprsPacket> _packets = [];
+
+  _PacketFilter _filter = _PacketFilter.all;
+
+  final _scrollController = ScrollController();
+
+  /// Whether the user has scrolled up (away from the bottom).
+  bool _userScrolledUp = false;
+
+  static final _timeFmt = DateFormat('HH:mm:ss');
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Seed from the rolling buffer so the list isn't empty on entry.
+    _packets.addAll(widget.service.recentPackets);
+
+    // Listen for new packets.
+    widget.service.packetStream.listen(_onPacket);
+
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onPacket(AprsPacket packet) {
+    if (!mounted) return;
+    setState(() {
+      // Newest first — mirror StationService ordering.
+      _packets.insert(0, packet);
+      if (_packets.length > 500) _packets.removeRange(500, _packets.length);
+    });
+
+    // Auto-scroll only when the user hasn't scrolled up.
+    if (!_userScrolledUp && _scrollController.hasClients) {
+      // The list is newest-first so "newest" is at index 0 — top of the list.
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    // Consider the user to have scrolled up when they are not at the top
+    // (newest) item.
+    _userScrolledUp = _scrollController.offset > 40;
+  }
+
+  List<AprsPacket> get _filtered {
+    if (_filter == _PacketFilter.all) return _packets;
+    return _packets.where((p) => _matchesFilter(p, _filter)).toList();
+  }
+
+  static bool _matchesFilter(AprsPacket p, _PacketFilter f) {
+    return switch (f) {
+      _PacketFilter.all => true,
+      _PacketFilter.pos => p is PositionPacket,
+      _PacketFilter.msg => p is MessagePacket,
+      _PacketFilter.wx => p is WeatherPacket,
+      _PacketFilter.obj => p is ObjectPacket || p is ItemPacket,
+      _PacketFilter.status => p is StatusPacket,
+      _PacketFilter.micE => p is MicEPacket,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final filtered = _filtered;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Packet Log'),
+        actions: [
+          if (_userScrolledUp)
+            IconButton(
+              icon: const Icon(Icons.vertical_align_top),
+              tooltip: 'Jump to newest',
+              onPressed: () {
+                _userScrolledUp = false;
+                if (_scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0,
+                    duration: const Duration(milliseconds: 300),
+                    curve: Curves.easeOut,
+                  );
+                }
+              },
+            ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _FilterBar(
+            selected: _filter,
+            onChanged: (f) => setState(() {
+              _filter = f;
+              _userScrolledUp = false;
+            }),
+          ),
+          Expanded(
+            child: filtered.isEmpty
+                ? Center(
+                    child: Text(
+                      'No packets yet',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  )
+                : ListView.builder(
+                    controller: _scrollController,
+                    itemCount: filtered.length,
+                    itemBuilder: (context, index) => _PacketRow(
+                      packet: filtered[index],
+                      timeFmt: _timeFmt,
+                      onTap: () =>
+                          showPacketDetailSheet(context, filtered[index]),
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filter bar
+// ---------------------------------------------------------------------------
+
+class _FilterBar extends StatelessWidget {
+  const _FilterBar({required this.selected, required this.onChanged});
+
+  final _PacketFilter selected;
+  final ValueChanged<_PacketFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 48,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        children: _PacketFilter.values
+            .map(
+              (f) => Padding(
+                padding: const EdgeInsets.only(right: 6),
+                child: ChoiceChip(
+                  label: Text(f.label),
+                  selected: selected == f,
+                  onSelected: (_) => onChanged(f),
+                ),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Packet row
+// ---------------------------------------------------------------------------
+
+class _PacketRow extends StatelessWidget {
+  const _PacketRow({
+    required this.packet,
+    required this.timeFmt,
+    required this.onTap,
+  });
+
+  final AprsPacket packet;
+  final DateFormat timeFmt;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    final typeLabel = _typeLabel(packet);
+    final summary = _summary(packet);
+    final timeStr = timeFmt.format(packet.receivedAt.toLocal());
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Timestamp
+            SizedBox(
+              width: 68,
+              child: Text(
+                timeStr,
+                style: textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+
+            // Type chip
+            _TypeBadge(label: typeLabel, colorScheme: colorScheme),
+
+            const SizedBox(width: 8),
+
+            // Callsign + summary
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    packet.source,
+                    style: textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colorScheme.onSurface,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (summary.isNotEmpty)
+                    Text(
+                      summary,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _typeLabel(AprsPacket p) {
+    return switch (p) {
+      PositionPacket() => 'POS',
+      MessagePacket() => 'MSG',
+      WeatherPacket() => 'WX',
+      ObjectPacket() => 'OBJ',
+      ItemPacket() => 'ITEM',
+      StatusPacket() => 'STATUS',
+      MicEPacket() => 'MIC-E',
+      UnknownPacket() => '???',
+    };
+  }
+
+  static String _summary(AprsPacket p) {
+    return switch (p) {
+      PositionPacket() =>
+        '${_latStr(p.lat)}, ${_lonStr(p.lon)}',
+      MessagePacket() =>
+        '\u2192 ${p.addressee}: ${p.message}',
+      WeatherPacket() => _wxSummary(p),
+      ObjectPacket() =>
+        '${p.objectName} @ ${_latStr(p.lat)}, ${_lonStr(p.lon)}',
+      ItemPacket() =>
+        '${p.itemName} @ ${_latStr(p.lat)}, ${_lonStr(p.lon)}',
+      StatusPacket() => p.status,
+      MicEPacket() =>
+        '${_latStr(p.lat)}, ${_lonStr(p.lon)} \u2022 ${p.micEMessage}',
+      UnknownPacket() => p.rawLine.length > 40
+          ? '${p.rawLine.substring(0, 40)}\u2026'
+          : p.rawLine,
+    };
+  }
+
+  static String _latStr(double lat) {
+    final dir = lat >= 0 ? 'N' : 'S';
+    return '${lat.abs().toStringAsFixed(3)}\u00b0 $dir';
+  }
+
+  static String _lonStr(double lon) {
+    final dir = lon >= 0 ? 'E' : 'W';
+    return '${lon.abs().toStringAsFixed(3)}\u00b0 $dir';
+  }
+
+  static String _wxSummary(WeatherPacket p) {
+    final parts = <String>[];
+    if (p.temperature != null) {
+      final f = p.temperature!.toStringAsFixed(0);
+      parts.add('$f \u00b0F');
+    }
+    if (p.windSpeed != null) parts.add('${p.windSpeed!.toStringAsFixed(0)} mph wind');
+    if (p.humidity != null) parts.add('${p.humidity}% RH');
+    return parts.isEmpty ? 'Weather' : parts.join(' / ');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Type badge
+// ---------------------------------------------------------------------------
+
+class _TypeBadge extends StatelessWidget {
+  const _TypeBadge({required this.label, required this.colorScheme});
+
+  final String label;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: colorScheme.onSecondaryContainer,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.3,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -329,9 +329,12 @@ class _PacketRow extends StatelessWidget {
       final f = p.temperature!.toStringAsFixed(0);
       parts.add('$f \u00b0F');
     }
-    if (p.windSpeed != null)
+    if (p.windSpeed != null) {
       parts.add('${p.windSpeed!.toStringAsFixed(0)} mph wind');
-    if (p.humidity != null) parts.add('${p.humidity}% RH');
+    }
+    if (p.humidity != null) {
+      parts.add('${p.humidity}% RH');
+    }
     return parts.isEmpty ? 'Weather' : parts.join(' / ');
   }
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -27,8 +27,7 @@ class StationService {
   final _stations = <String, Station>{};
 
   // Broadcast controllers.
-  final _stationController =
-      StreamController<Map<String, Station>>.broadcast();
+  final _stationController = StreamController<Map<String, Station>>.broadcast();
   final _packetController = StreamController<AprsPacket>.broadcast();
 
   // Rolling packet buffer (newest at index 0).
@@ -97,9 +96,7 @@ class StationService {
 
     // If this is a position packet, also update the station map.
     if (packet is PositionPacket) {
-      debugPrint(
-        'PARSED: ${packet.source} @ ${packet.lat}, ${packet.lon}',
-      );
+      debugPrint('PARSED: ${packet.source} @ ${packet.lat}, ${packet.lon}');
       final station = _stationFromPosition(packet);
       _stations[station.callsign] = station;
       _stationController.add(Map.unmodifiable(_stations));

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -1,20 +1,61 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart' show debugPrint;
 
+import '../core/packet/aprs_packet.dart';
+import '../core/packet/aprs_parser.dart';
 import '../core/packet/position_parser.dart';
 import '../core/packet/result.dart';
 import '../core/packet/station.dart';
 import '../core/transport/aprs_transport.dart';
 
+/// Service that ingests raw APRS-IS lines from [AprsTransport], decodes them
+/// with [AprsParser], and exposes two streams:
+///
+///   - [packetStream] — every decoded [AprsPacket] (all types)
+///   - [stationUpdates] — a snapshot of the station map, updated each time a
+///     position packet is received (backward-compatible with v0.1 UI)
+///
+/// [recentPackets] holds a rolling buffer of the 500 most recently received
+/// packets, newest-first.
 class StationService {
+  static const int _maxRecentPackets = 500;
+
   final AprsTransport _transport;
+  final _parser = AprsParser();
+
+  // Station map — callsign → most-recently-heard Station.
   final _stations = <String, Station>{};
-  final _controller = StreamController<Map<String, Station>>.broadcast();
+
+  // Broadcast controllers.
+  final _stationController =
+      StreamController<Map<String, Station>>.broadcast();
+  final _packetController = StreamController<AprsPacket>.broadcast();
+
+  // Rolling packet buffer (newest at index 0).
+  final _recentPackets = <AprsPacket>[];
 
   StationService(this._transport);
 
-  Stream<Map<String, Station>> get stationUpdates => _controller.stream;
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /// All decoded packets as they arrive.
+  Stream<AprsPacket> get packetStream => _packetController.stream;
+
+  /// Station map snapshots. Emitted whenever a position packet updates a
+  /// station. Backward-compatible with the v0.1 map screen.
+  Stream<Map<String, Station>> get stationUpdates => _stationController.stream;
+
+  /// Current station map (unmodifiable).
   Map<String, Station> get currentStations => Map.unmodifiable(_stations);
+
+  /// Rolling buffer of the 500 most recently decoded packets, newest first.
+  List<AprsPacket> get recentPackets => List.unmodifiable(_recentPackets);
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
 
   Future<void> start() async {
     await _transport.connect();
@@ -29,20 +70,68 @@ class StationService {
 
   Future<void> stop() async {
     await _transport.disconnect();
-    await _controller.close();
+    await _stationController.close();
+    await _packetController.close();
   }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
 
   void _handleLine(String raw) {
     debugPrint(raw);
-    final result = parseAprsLine(raw);
-    if (result is Ok<Station>) {
-      debugPrint(
-        'PARSED: ${result.value.callsign} @ ${result.value.lat}, ${result.value.lon}',
-      );
-      _stations[result.value.callsign] = result.value;
-      _controller.add(Map.unmodifiable(_stations));
-    } else if (result is Err<Station>) {
-      debugPrint('SKIP: ${result.message} -- $raw');
+
+    // Skip server comment lines — not packets.
+    if (raw.isEmpty || raw.startsWith('#')) return;
+
+    final packet = _parser.parse(raw);
+
+    // Add to rolling buffer.
+    _recentPackets.insert(0, packet);
+    if (_recentPackets.length > _maxRecentPackets) {
+      _recentPackets.removeRange(_maxRecentPackets, _recentPackets.length);
     }
+
+    // Emit on packet stream.
+    _packetController.add(packet);
+
+    // If this is a position packet, also update the station map.
+    if (packet is PositionPacket) {
+      debugPrint(
+        'PARSED: ${packet.source} @ ${packet.lat}, ${packet.lon}',
+      );
+      final station = _stationFromPosition(packet);
+      _stations[station.callsign] = station;
+      _stationController.add(Map.unmodifiable(_stations));
+    } else if (packet is UnknownPacket) {
+      // Fall back to the legacy parser for packets that the full parser could
+      // not decode — this gives the old position parser a second chance for
+      // any edge cases not yet handled.
+      final legacy = parseAprsLine(raw);
+      if (legacy is Ok<Station>) {
+        final station = legacy.value;
+        debugPrint(
+          'LEGACY PARSED: ${station.callsign} @ ${station.lat}, ${station.lon}',
+        );
+        _stations[station.callsign] = station;
+        _stationController.add(Map.unmodifiable(_stations));
+      } else {
+        debugPrint('SKIP: ${(packet).reason} -- $raw');
+      }
+    }
+  }
+
+  /// Convert a [PositionPacket] to a [Station] for the legacy station map.
+  Station _stationFromPosition(PositionPacket p) {
+    return Station(
+      callsign: p.source,
+      lat: p.lat,
+      lon: p.lon,
+      rawPacket: p.rawLine,
+      lastHeard: p.receivedAt,
+      symbolTable: p.symbolTable,
+      symbolCode: p.symbolCode,
+      comment: p.comment,
+    );
   }
 }

--- a/lib/ui/widgets/aprs_symbol_widget.dart
+++ b/lib/ui/widgets/aprs_symbol_widget.dart
@@ -31,16 +31,11 @@ class AprsSymbolWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(
-      _iconData(symbolCode),
-      size: size,
-      color: color,
-    );
+    return Icon(_iconData(symbolCode), size: size, color: color);
   }
 
   /// Maps an APRS symbol code to the best available Material icon.
-  static IconData iconDataForSymbol(String symbolCode) =>
-      _iconData(symbolCode);
+  static IconData iconDataForSymbol(String symbolCode) => _iconData(symbolCode);
 }
 
 IconData _iconData(String symbolCode) {

--- a/lib/ui/widgets/aprs_symbol_widget.dart
+++ b/lib/ui/widgets/aprs_symbol_widget.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+/// A widget that renders an APRS symbol as a Material icon.
+///
+/// APRS symbols are identified by a [symbolTable] character ('/' for the
+/// primary table, '\' for the alternate) and a [symbolCode] character.
+///
+/// This widget abstracts symbol rendering so the underlying approach (Material
+/// icons, custom sprites, APRS symbol sheet bitmaps, etc.) can be swapped
+/// without touching call sites.
+class AprsSymbolWidget extends StatelessWidget {
+  const AprsSymbolWidget({
+    super.key,
+    required this.symbolTable,
+    required this.symbolCode,
+    this.size = 24.0,
+    this.color,
+  });
+
+  /// APRS symbol table identifier: '/' (primary) or '\' (alternate).
+  final String symbolTable;
+
+  /// APRS symbol code — a single printable ASCII character.
+  final String symbolCode;
+
+  /// Rendered size in logical pixels.
+  final double size;
+
+  /// Icon color. Defaults to the ambient [IconTheme] color when null.
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      _iconData(symbolCode),
+      size: size,
+      color: color,
+    );
+  }
+
+  /// Maps an APRS symbol code to the best available Material icon.
+  static IconData iconDataForSymbol(String symbolCode) =>
+      _iconData(symbolCode);
+}
+
+IconData _iconData(String symbolCode) {
+  switch (symbolCode) {
+    case '-':
+      return Icons.home;
+    case '>':
+      return Icons.directions_car;
+    case 'k':
+    case 'u':
+      return Icons.local_shipping;
+    case 'U':
+      return Icons.directions_bus;
+    case 'a':
+      return Icons.local_hospital;
+    case 'X':
+      return Icons.flight;
+    case "'":
+    case '^':
+      return Icons.flight;
+    case 'O':
+      return Icons.circle_outlined;
+    case '_':
+      return Icons.wb_cloudy;
+    case 'b':
+      return Icons.directions_bike;
+    case 'h':
+      return Icons.local_hospital;
+    case 'f':
+    case 'd':
+      return Icons.local_fire_department;
+    case '<':
+      return Icons.two_wheeler;
+    case 'Y':
+    case 's':
+      return Icons.sailing;
+    case 'P':
+    case '!':
+      return Icons.local_police;
+    case '[':
+      return Icons.directions_walk;
+    case '#':
+      return Icons.cell_tower;
+    default:
+      return Icons.location_on;
+  }
+}

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -110,11 +110,8 @@ class PacketDetailSheet extends StatelessWidget {
                   ),
                   const SizedBox(height: 4),
                   ...fields.entries.map(
-                    (e) => _FieldRow(
-                      label: e.key,
-                      value: e.value,
-                      theme: theme,
-                    ),
+                    (e) =>
+                        _FieldRow(label: e.key, value: e.value, theme: theme),
                   ),
                 ],
               ),
@@ -146,7 +143,11 @@ class PacketDetailSheet extends StatelessWidget {
     m['Source'] = p.source;
     m['Destination'] = p.destination;
     if (p.path.isNotEmpty) m['Path'] = p.path.join(', ');
-    m['Received'] = p.receivedAt.toUtc().toString().replaceFirst('.000', '').replaceAll('T', ' ');
+    m['Received'] = p.receivedAt
+        .toUtc()
+        .toString()
+        .replaceFirst('.000', '')
+        .replaceAll('T', ' ');
 
     switch (p) {
       case PositionPacket():
@@ -157,7 +158,8 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol code'] = p.symbolCode;
         if (p.course != null) m['Course'] = '${p.course}\u00b0';
         if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
-        if (p.altitude != null) m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        if (p.altitude != null)
+          m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
         m['Messaging'] = p.hasMessaging ? 'Yes' : 'No';
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
         if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
@@ -174,15 +176,22 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.lon != null) m['Longitude'] = _formatLon(p.lon!);
         if (p.temperature != null) {
           final c = (p.temperature! - 32) * 5 / 9;
-          m['Temperature'] = '${p.temperature!.toStringAsFixed(1)} \u00b0F (${c.toStringAsFixed(1)} \u00b0C)';
+          m['Temperature'] =
+              '${p.temperature!.toStringAsFixed(1)} \u00b0F (${c.toStringAsFixed(1)} \u00b0C)';
         }
         if (p.humidity != null) m['Humidity'] = '${p.humidity}%';
-        if (p.pressure != null) m['Pressure'] = '${p.pressure!.toStringAsFixed(1)} hPa';
-        if (p.windSpeed != null) m['Wind speed'] = '${p.windSpeed!.toStringAsFixed(1)} mph';
-        if (p.windDirection != null) m['Wind direction'] = '${p.windDirection}\u00b0';
-        if (p.windGust != null) m['Wind gust'] = '${p.windGust!.toStringAsFixed(1)} mph';
-        if (p.rainfall1h != null) m['Rainfall 1h'] = '${(p.rainfall1h! / 100).toStringAsFixed(2)} in';
-        if (p.rainfall24h != null) m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
+        if (p.pressure != null)
+          m['Pressure'] = '${p.pressure!.toStringAsFixed(1)} hPa';
+        if (p.windSpeed != null)
+          m['Wind speed'] = '${p.windSpeed!.toStringAsFixed(1)} mph';
+        if (p.windDirection != null)
+          m['Wind direction'] = '${p.windDirection}\u00b0';
+        if (p.windGust != null)
+          m['Wind gust'] = '${p.windGust!.toStringAsFixed(1)} mph';
+        if (p.rainfall1h != null)
+          m['Rainfall 1h'] = '${(p.rainfall1h! / 100).toStringAsFixed(2)} in';
+        if (p.rainfall24h != null)
+          m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
 
       case ObjectPacket():
         m['Type'] = 'Object';
@@ -218,7 +227,8 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol code'] = p.symbolCode;
         if (p.course != null) m['Course'] = '${p.course}\u00b0';
         if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
-        if (p.altitude != null) m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        if (p.altitude != null)
+          m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
       case UnknownPacket():

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -158,8 +158,9 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol code'] = p.symbolCode;
         if (p.course != null) m['Course'] = '${p.course}\u00b0';
         if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
-        if (p.altitude != null)
+        if (p.altitude != null) {
           m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        }
         m['Messaging'] = p.hasMessaging ? 'Yes' : 'No';
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
         if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
@@ -180,18 +181,24 @@ class PacketDetailSheet extends StatelessWidget {
               '${p.temperature!.toStringAsFixed(1)} \u00b0F (${c.toStringAsFixed(1)} \u00b0C)';
         }
         if (p.humidity != null) m['Humidity'] = '${p.humidity}%';
-        if (p.pressure != null)
+        if (p.pressure != null) {
           m['Pressure'] = '${p.pressure!.toStringAsFixed(1)} hPa';
-        if (p.windSpeed != null)
+        }
+        if (p.windSpeed != null) {
           m['Wind speed'] = '${p.windSpeed!.toStringAsFixed(1)} mph';
-        if (p.windDirection != null)
+        }
+        if (p.windDirection != null) {
           m['Wind direction'] = '${p.windDirection}\u00b0';
-        if (p.windGust != null)
+        }
+        if (p.windGust != null) {
           m['Wind gust'] = '${p.windGust!.toStringAsFixed(1)} mph';
-        if (p.rainfall1h != null)
+        }
+        if (p.rainfall1h != null) {
           m['Rainfall 1h'] = '${(p.rainfall1h! / 100).toStringAsFixed(2)} in';
-        if (p.rainfall24h != null)
+        }
+        if (p.rainfall24h != null) {
           m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
+        }
 
       case ObjectPacket():
         m['Type'] = 'Object';
@@ -227,8 +234,9 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol code'] = p.symbolCode;
         if (p.course != null) m['Course'] = '${p.course}\u00b0';
         if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
-        if (p.altitude != null)
+        if (p.altitude != null) {
           m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        }
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
       case UnknownPacket():

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+
+import '../../core/packet/aprs_packet.dart';
+import 'aprs_symbol_widget.dart';
+
+/// Shows a modal bottom sheet with the full decoded detail of an [AprsPacket].
+///
+/// Usage:
+/// ```dart
+/// showPacketDetailSheet(context, packet);
+/// ```
+void showPacketDetailSheet(BuildContext context, AprsPacket packet) {
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => PacketDetailSheet(packet: packet),
+  );
+}
+
+class PacketDetailSheet extends StatelessWidget {
+  const PacketDetailSheet({super.key, required this.packet});
+
+  final AprsPacket packet;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    final fields = _decodedFields(packet);
+    final symbol = _symbolFor(packet);
+
+    return SafeArea(
+      child: DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.55,
+        minChildSize: 0.3,
+        maxChildSize: 0.9,
+        builder: (_, controller) => Column(
+          children: [
+            // Drag handle
+            Center(
+              child: Container(
+                width: 32,
+                height: 4,
+                margin: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: colorScheme.onSurfaceVariant.withAlpha(80),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+
+            // Header row: symbol + callsign + close button
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 8, 8),
+              child: Row(
+                children: [
+                  if (symbol case (final st, final sc)) ...[
+                    AprsSymbolWidget(
+                      symbolTable: st,
+                      symbolCode: sc,
+                      size: 24,
+                      color: colorScheme.primary,
+                    ),
+                    const SizedBox(width: 10),
+                  ],
+                  Expanded(
+                    child: Text(
+                      packet.source,
+                      style: textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                ],
+              ),
+            ),
+
+            const Divider(height: 1),
+
+            Expanded(
+              child: ListView(
+                controller: controller,
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                children: [
+                  // Raw packet line
+                  _SectionLabel(label: 'Raw packet', colorScheme: colorScheme),
+                  const SizedBox(height: 4),
+                  SelectableText(
+                    packet.rawLine,
+                    style: textTheme.bodySmall?.copyWith(
+                      fontFamily: 'monospace',
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // Decoded fields
+                  _SectionLabel(
+                    label: 'Decoded fields',
+                    colorScheme: colorScheme,
+                  ),
+                  const SizedBox(height: 4),
+                  ...fields.entries.map(
+                    (e) => _FieldRow(
+                      label: e.key,
+                      value: e.value,
+                      theme: theme,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Returns (symbolTable, symbolCode) for packet types that carry a symbol,
+  /// or null for those that do not.
+  (String, String)? _symbolFor(AprsPacket p) {
+    return switch (p) {
+      PositionPacket() => (p.symbolTable, p.symbolCode),
+      WeatherPacket() => (p.symbolTable, p.symbolCode),
+      ObjectPacket() => (p.symbolTable, p.symbolCode),
+      ItemPacket() => (p.symbolTable, p.symbolCode),
+      MicEPacket() => (p.symbolTable, p.symbolCode),
+      _ => null,
+    };
+  }
+
+  /// Builds an ordered map of label → value for all meaningful decoded fields.
+  Map<String, String> _decodedFields(AprsPacket p) {
+    final m = <String, String>{};
+
+    // Common header fields
+    m['Source'] = p.source;
+    m['Destination'] = p.destination;
+    if (p.path.isNotEmpty) m['Path'] = p.path.join(', ');
+    m['Received'] = p.receivedAt.toUtc().toString().replaceFirst('.000', '').replaceAll('T', ' ');
+
+    switch (p) {
+      case PositionPacket():
+        m['Type'] = 'Position';
+        m['Latitude'] = _formatLat(p.lat);
+        m['Longitude'] = _formatLon(p.lon);
+        m['Symbol table'] = p.symbolTable;
+        m['Symbol code'] = p.symbolCode;
+        if (p.course != null) m['Course'] = '${p.course}\u00b0';
+        if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
+        if (p.altitude != null) m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        m['Messaging'] = p.hasMessaging ? 'Yes' : 'No';
+        if (p.comment.isNotEmpty) m['Comment'] = p.comment;
+        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
+
+      case MessagePacket():
+        m['Type'] = 'Message';
+        m['Addressee'] = p.addressee;
+        m['Message'] = p.message;
+        if (p.messageId != null) m['Message ID'] = p.messageId!;
+
+      case WeatherPacket():
+        m['Type'] = 'Weather';
+        if (p.lat != null) m['Latitude'] = _formatLat(p.lat!);
+        if (p.lon != null) m['Longitude'] = _formatLon(p.lon!);
+        if (p.temperature != null) {
+          final c = (p.temperature! - 32) * 5 / 9;
+          m['Temperature'] = '${p.temperature!.toStringAsFixed(1)} \u00b0F (${c.toStringAsFixed(1)} \u00b0C)';
+        }
+        if (p.humidity != null) m['Humidity'] = '${p.humidity}%';
+        if (p.pressure != null) m['Pressure'] = '${p.pressure!.toStringAsFixed(1)} hPa';
+        if (p.windSpeed != null) m['Wind speed'] = '${p.windSpeed!.toStringAsFixed(1)} mph';
+        if (p.windDirection != null) m['Wind direction'] = '${p.windDirection}\u00b0';
+        if (p.windGust != null) m['Wind gust'] = '${p.windGust!.toStringAsFixed(1)} mph';
+        if (p.rainfall1h != null) m['Rainfall 1h'] = '${(p.rainfall1h! / 100).toStringAsFixed(2)} in';
+        if (p.rainfall24h != null) m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
+
+      case ObjectPacket():
+        m['Type'] = 'Object';
+        m['Object name'] = p.objectName;
+        m['Latitude'] = _formatLat(p.lat);
+        m['Longitude'] = _formatLon(p.lon);
+        m['Symbol table'] = p.symbolTable;
+        m['Symbol code'] = p.symbolCode;
+        m['Alive'] = p.isAlive ? 'Yes' : 'No (killed)';
+        if (p.comment.isNotEmpty) m['Comment'] = p.comment;
+
+      case ItemPacket():
+        m['Type'] = 'Item';
+        m['Item name'] = p.itemName;
+        m['Latitude'] = _formatLat(p.lat);
+        m['Longitude'] = _formatLon(p.lon);
+        m['Symbol table'] = p.symbolTable;
+        m['Symbol code'] = p.symbolCode;
+        m['Alive'] = p.isAlive ? 'Yes' : 'No (killed)';
+        if (p.comment.isNotEmpty) m['Comment'] = p.comment;
+
+      case StatusPacket():
+        m['Type'] = 'Status';
+        m['Status'] = p.status;
+        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
+
+      case MicEPacket():
+        m['Type'] = 'Mic-E';
+        m['Latitude'] = _formatLat(p.lat);
+        m['Longitude'] = _formatLon(p.lon);
+        m['Mic-E status'] = p.micEMessage;
+        m['Symbol table'] = p.symbolTable;
+        m['Symbol code'] = p.symbolCode;
+        if (p.course != null) m['Course'] = '${p.course}\u00b0';
+        if (p.speed != null) m['Speed'] = '${p.speed!.toStringAsFixed(1)} kt';
+        if (p.altitude != null) m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
+        if (p.comment.isNotEmpty) m['Comment'] = p.comment;
+
+      case UnknownPacket():
+        m['Type'] = 'Unknown';
+        m['Reason'] = p.reason;
+        if (p.rawInfo.isNotEmpty) m['Raw info'] = p.rawInfo;
+    }
+
+    return m;
+  }
+}
+
+String _formatLat(double lat) {
+  final dir = lat >= 0 ? 'N' : 'S';
+  return '${lat.abs().toStringAsFixed(6)}\u00b0 $dir';
+}
+
+String _formatLon(double lon) {
+  final dir = lon >= 0 ? 'E' : 'W';
+  return '${lon.abs().toStringAsFixed(6)}\u00b0 $dir';
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label, required this.colorScheme});
+
+  final String label;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label.toUpperCase(),
+      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+        color: colorScheme.primary,
+        letterSpacing: 0.8,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
+class _FieldRow extends StatelessWidget {
+  const _FieldRow({
+    required this.label,
+    required this.value,
+    required this.theme,
+  });
+
+  final String label;
+  final String value;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/station_info_sheet.dart
+++ b/lib/ui/widgets/station_info_sheet.dart
@@ -2,53 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/packet/station.dart';
 import '../../core/packet/symbol_resolver.dart';
-
-/// Returns a Material icon appropriate for the given APRS symbol code.
-IconData symbolIcon(String symbolCode) {
-  switch (symbolCode) {
-    case '-':
-      return Icons.home;
-    case '>':
-      return Icons.directions_car;
-    case 'k':
-    case 'u':
-      return Icons.local_shipping;
-    case 'U':
-      return Icons.directions_bus;
-    case 'a':
-      return Icons.local_hospital;
-    case 'X':
-      return Icons.flight;
-    case "'":
-    case '^':
-      return Icons.flight;
-    case 'O':
-      return Icons.circle_outlined;
-    case '_':
-      return Icons.wb_cloudy;
-    case 'b':
-      return Icons.directions_bike;
-    case 'h':
-      return Icons.local_hospital;
-    case 'f':
-    case 'd':
-      return Icons.local_fire_department;
-    case '<':
-      return Icons.two_wheeler;
-    case 'Y':
-    case 's':
-      return Icons.sailing;
-    case 'P':
-    case '!':
-      return Icons.local_police;
-    case '[':
-      return Icons.directions_walk;
-    case '#':
-      return Icons.cell_tower;
-    default:
-      return Icons.location_on;
-  }
-}
+import 'aprs_symbol_widget.dart';
 
 String _formatLastHeard(DateTime lastHeard) {
   final diff = DateTime.now().difference(lastHeard);
@@ -82,7 +36,6 @@ class StationInfoSheet extends StatelessWidget {
       station.symbolTable,
       station.symbolCode,
     );
-    final icon = symbolIcon(station.symbolCode);
     final relativeTime = _formatLastHeard(station.lastHeard);
     final hasComment = station.comment.isNotEmpty;
 
@@ -120,7 +73,12 @@ class StationInfoSheet extends StatelessWidget {
             // Symbol type row
             Row(
               children: [
-                Icon(icon, size: 18, color: colorScheme.primary),
+                AprsSymbolWidget(
+                  symbolTable: station.symbolTable,
+                  symbolCode: station.symbolCode,
+                  size: 18,
+                  color: colorScheme.primary,
+                ),
                 const SizedBox(width: 8),
                 Text(
                   symbolName,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -228,7 +228,7 @@ packages:
     source: hosted
     version: "4.1.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_map: ^8.2.2
   latlong2: ^0.9.1
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -18,7 +18,8 @@ void main() {
     expect(
       packet,
       isA<T>(),
-      reason: 'Expected ${T.toString()} but got '
+      reason:
+          'Expected ${T.toString()} but got '
           '${packet.runtimeType}: '
           '${packet is UnknownPacket ? packet.reason : ""}',
     );
@@ -78,8 +79,14 @@ void main() {
         'N0CALL>APRS:!4903.50N/07201.75W-Test',
       );
       final after = DateTime.now().toUtc();
-      expect(p.receivedAt.isAfter(before) || p.receivedAt.isAtSameMomentAs(before), isTrue);
-      expect(p.receivedAt.isBefore(after) || p.receivedAt.isAtSameMomentAs(after), isTrue);
+      expect(
+        p.receivedAt.isAfter(before) || p.receivedAt.isAtSameMomentAs(before),
+        isTrue,
+      );
+      expect(
+        p.receivedAt.isBefore(after) || p.receivedAt.isAtSameMomentAs(after),
+        isTrue,
+      );
     });
 
     test('rawLine is preserved exactly', () {
@@ -301,9 +308,7 @@ void main() {
     });
 
     test('strips padding from addressee', () {
-      final p = expectPacketType<MessagePacket>(
-        'W1ABC>APRS::KB2DEF   :Hi',
-      );
+      final p = expectPacketType<MessagePacket>('W1ABC>APRS::KB2DEF   :Hi');
       expect(p.addressee, equals('KB2DEF'));
       expect(p.addressee, isNot(contains(' ')));
     });
@@ -317,9 +322,7 @@ void main() {
 
     test('handles ACK message', () {
       // ACK format: :CALLSIGN :ackNNN
-      final p = expectPacketType<MessagePacket>(
-        'W1ABC>APRS::KB2DEF   :ack001',
-      );
+      final p = expectPacketType<MessagePacket>('W1ABC>APRS::KB2DEF   :ack001');
       expect(p.addressee, equals('KB2DEF'));
     });
   });
@@ -466,9 +469,7 @@ void main() {
     // Real-world Mic-E packet: WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`
     // WB4APR is the inventor of APRS; his beacon is a good test vector.
     test('parses Mic-E packet (backtick DTI)', () {
-      final packet = parser.parse(
-        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
-      );
+      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
       // The destination T2SR6Y encodes Mic-E data; packet should be MicEPacket
       // or at minimum not crash. In some edge cases the destination may not
       // be a valid Mic-E encoding and will return UnknownPacket — that is also
@@ -477,9 +478,7 @@ void main() {
     });
 
     test('Mic-E lat is in valid range', () {
-      final packet = parser.parse(
-        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
-      );
+      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
       if (packet is MicEPacket) {
         expect(packet.lat, greaterThanOrEqualTo(-90));
         expect(packet.lat, lessThanOrEqualTo(90));
@@ -489,9 +488,7 @@ void main() {
     });
 
     test('Mic-E micEMessage is populated', () {
-      final packet = parser.parse(
-        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
-      );
+      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
       if (packet is MicEPacket) {
         expect(packet.micEMessage, isNotEmpty);
       }
@@ -516,10 +513,7 @@ void main() {
     });
 
     test('server comment line returns UnknownPacket', () {
-      expect(
-        parser.parse('# logresp NOCALL unverified'),
-        isA<UnknownPacket>(),
-      );
+      expect(parser.parse('# logresp NOCALL unverified'), isA<UnknownPacket>());
     });
 
     test('line with no colon returns UnknownPacket', () {

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1,0 +1,639 @@
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/core/packet/aprs_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AprsParser parser;
+
+  setUp(() {
+    parser = AprsParser();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helper
+  // ---------------------------------------------------------------------------
+
+  T expectPacketType<T extends AprsPacket>(String line) {
+    final packet = parser.parse(line);
+    expect(
+      packet,
+      isA<T>(),
+      reason: 'Expected ${T.toString()} but got '
+          '${packet.runtimeType}: '
+          '${packet is UnknownPacket ? packet.reason : ""}',
+    );
+    return packet as T;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Header parsing (common to all packet types)
+  // ---------------------------------------------------------------------------
+
+  group('header parsing', () {
+    test('extracts source callsign from position packet', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W-Test station',
+      );
+      expect(p.source, equals('N0CALL'));
+    });
+
+    test('extracts source callsign with SSID', () {
+      final p = expectPacketType<PositionPacket>(
+        'W1AW-9>APRS,WIDE1-1,WIDE2-1:!3456.78N/07654.32W>Test comment',
+      );
+      expect(p.source, equals('W1AW-9'));
+    });
+
+    test('extracts destination', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APDU25,WIDE2-2:!4903.50N/07201.75W-Test',
+      );
+      expect(p.destination, equals('APDU25'));
+    });
+
+    test('extracts digipeater path', () {
+      final p = expectPacketType<PositionPacket>(
+        'W1AW-9>APRS,WIDE1-1,WIDE2-1:!3456.78N/07654.32W>Test comment',
+      );
+      expect(p.path, equals(['WIDE1-1', 'WIDE2-1']));
+    });
+
+    test('path is empty when only destination present', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W-Test',
+      );
+      expect(p.path, isEmpty);
+    });
+
+    test('path includes qAC entry', () {
+      final p = expectPacketType<PositionPacket>(
+        'WB4APR-14>APWW10,TCPIP*,qAC,T2MCI:=3855.34N/07701.13W-Test',
+      );
+      expect(p.path, containsAll(['TCPIP*', 'qAC', 'T2MCI']));
+    });
+
+    test('receivedAt is a recent UTC time', () {
+      final before = DateTime.now().toUtc();
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W-Test',
+      );
+      final after = DateTime.now().toUtc();
+      expect(p.receivedAt.isAfter(before) || p.receivedAt.isAtSameMomentAs(before), isTrue);
+      expect(p.receivedAt.isBefore(after) || p.receivedAt.isAtSameMomentAs(after), isTrue);
+    });
+
+    test('rawLine is preserved exactly', () {
+      const raw = 'N0CALL>APRS:!4903.50N/07201.75W-Test';
+      final p = expectPacketType<PositionPacket>(raw);
+      expect(p.rawLine, equals(raw));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PositionPacket — uncompressed
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket uncompressed', () {
+    group('DTI ! (no timestamp, no messaging)', () {
+      test('decodes lat/lon', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test',
+        );
+        expect(p.lat, closeTo(49.0583, 0.001));
+        expect(p.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('hasMessaging is false', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test',
+        );
+        expect(p.hasMessaging, isFalse);
+      });
+
+      test('timestamp field is null', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test',
+        );
+        expect(p.timestamp, isNull);
+      });
+
+      test('extracts symbol table and code', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test station',
+        );
+        expect(p.symbolTable, equals('/'));
+        expect(p.symbolCode, equals('-'));
+      });
+
+      test('extracts comment', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test station',
+        );
+        expect(p.comment, equals('Test station'));
+      });
+
+      test('empty comment', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-',
+        );
+        expect(p.comment, equals(''));
+      });
+
+      test('South latitude is negative', () {
+        final p = expectPacketType<PositionPacket>(
+          'VK2TEST>APRS:!3351.00S/15112.00E-Sydney',
+        );
+        expect(p.lat, isNegative);
+        expect(p.lon, isPositive);
+      });
+
+      test('real-world packet W1AW-9', () {
+        final p = expectPacketType<PositionPacket>(
+          'W1AW-9>APRS,WIDE1-1,WIDE2-1:!3456.78N/07654.32W>Test comment',
+        );
+        // 34°56.78' N = 34 + 56.78/60
+        expect(p.lat, closeTo(34.946, 0.001));
+        // 076°54.32' W = -(76 + 54.32/60)
+        expect(p.lon, closeTo(-76.905, 0.001));
+        expect(p.symbolCode, equals('>'));
+        expect(p.comment, equals('Test comment'));
+      });
+    });
+
+    group('DTI = (no timestamp, with messaging)', () {
+      test('hasMessaging is true', () {
+        final p = expectPacketType<PositionPacket>(
+          'WB4APR-14>APWW10,TCPIP*,qAC,T2MCI:=3855.34N/07701.13W-Direwolf',
+        );
+        expect(p.hasMessaging, isTrue);
+      });
+
+      test('decodes lat/lon', () {
+        final p = expectPacketType<PositionPacket>(
+          'WB4APR-14>APWW10,TCPIP*,qAC,T2MCI:=3855.34N/07701.13W-Direwolf',
+        );
+        expect(p.lat, closeTo(38.922, 0.001));
+        expect(p.lon, closeTo(-77.019, 0.001));
+      });
+    });
+
+    group('DTI / (with timestamp, no messaging)', () {
+      test('decodes lat/lon', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:/221509z4903.50N/07201.75W-Test',
+        );
+        expect(p.lat, closeTo(49.0583, 0.001));
+        expect(p.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('hasMessaging is false', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:/221509z4903.50N/07201.75W-Test',
+        );
+        expect(p.hasMessaging, isFalse);
+      });
+
+      test('timestamp field is populated', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:/221509z4903.50N/07201.75W-Test',
+        );
+        expect(p.timestamp, isNotNull);
+        expect(p.timestamp!.day, equals(22));
+        expect(p.timestamp!.hour, equals(15));
+        expect(p.timestamp!.minute, equals(9));
+      });
+    });
+
+    group('DTI @ (with timestamp, with messaging)', () {
+      test('decodes lat/lon', () {
+        final p = expectPacketType<PositionPacket>(
+          'KB1ABC>APDU25,WIDE2-2:@092345z4903.50N/07201.75W>059/003/A=001234Test',
+        );
+        expect(p.lat, closeTo(49.0583, 0.001));
+        expect(p.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('hasMessaging is true', () {
+        final p = expectPacketType<PositionPacket>(
+          'KB1ABC>APDU25,WIDE2-2:@092345z4903.50N/07201.75W>059/003/A=001234Test',
+        );
+        expect(p.hasMessaging, isTrue);
+      });
+
+      test('extracts altitude from /A= extension', () {
+        final p = expectPacketType<PositionPacket>(
+          'KB1ABC>APDU25,WIDE2-2:@092345z4903.50N/07201.75W>059/003/A=001234Test',
+        );
+        expect(p.altitude, equals(1234.0));
+      });
+
+      test('extracts course and speed', () {
+        final p = expectPacketType<PositionPacket>(
+          'KB1ABC>APDU25,WIDE2-2:@092345z4903.50N/07201.75W>059/003/A=001234Test',
+        );
+        expect(p.course, equals(59));
+        expect(p.speed, equals(3.0));
+      });
+    });
+
+    group('alternate symbol table', () {
+      test(r'extracts \ symbol table', () {
+        final p = expectPacketType<PositionPacket>(
+          r'N0CALL>APRS:!4903.50N\07201.75W#Digipeater',
+        );
+        expect(p.symbolTable, equals(r'\'));
+        expect(p.symbolCode, equals('#'));
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PositionPacket — compressed
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket compressed', () {
+    test('decodes compressed position', () {
+      // "N0CALL>APRS:=/5L!!<*e7>7P[Test compressed"
+      // This is a real compressed position from the APRS spec examples.
+      // Compressed: symTable=/ lat=5L!! lon=<*e7 symCode=> comment=7P[Test
+      // The exact lat/lon values depend on correct base-91 decode.
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:=/5L!!<*e7>7P[Test compressed',
+      );
+      // Lat should be in reasonable North America range.
+      expect(p.lat, greaterThan(0));
+      expect(p.lat, lessThan(90));
+      expect(p.lon, lessThan(0)); // West
+      expect(p.lon, greaterThan(-180));
+      expect(p.symbolTable, equals('/'));
+      expect(p.hasMessaging, isTrue); // DTI =
+    });
+
+    test('returns PositionPacket not UnknownPacket for compressed', () {
+      // Validate we don't fall through to UnknownPacket.
+      final packet = parser.parse('N0CALL>APRS:=/5L!!<*e7>7P[Test compressed');
+      expect(packet, isA<PositionPacket>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MessagePacket
+  // ---------------------------------------------------------------------------
+
+  group('MessagePacket', () {
+    test('parses message with message ID', () {
+      final p = expectPacketType<MessagePacket>(
+        'KD9ABC>APRSTO,WIDE2-1::KB1XYZ   :Hello there{001',
+      );
+      expect(p.source, equals('KD9ABC'));
+      expect(p.addressee, equals('KB1XYZ'));
+      expect(p.message, equals('Hello there'));
+      expect(p.messageId, equals('001'));
+    });
+
+    test('parses message without message ID', () {
+      final p = expectPacketType<MessagePacket>(
+        'W1ABC>APRS::KB2DEF   :Just a message',
+      );
+      expect(p.addressee, equals('KB2DEF'));
+      expect(p.message, equals('Just a message'));
+      expect(p.messageId, isNull);
+    });
+
+    test('strips padding from addressee', () {
+      final p = expectPacketType<MessagePacket>(
+        'W1ABC>APRS::KB2DEF   :Hi',
+      );
+      expect(p.addressee, equals('KB2DEF'));
+      expect(p.addressee, isNot(contains(' ')));
+    });
+
+    test('preserves message text exactly', () {
+      final p = expectPacketType<MessagePacket>(
+        'W1ABC>APRS::KB2DEF   :Hello, World! 73 de W1ABC',
+      );
+      expect(p.message, equals('Hello, World! 73 de W1ABC'));
+    });
+
+    test('handles ACK message', () {
+      // ACK format: :CALLSIGN :ackNNN
+      final p = expectPacketType<MessagePacket>(
+        'W1ABC>APRS::KB2DEF   :ack001',
+      );
+      expect(p.addressee, equals('KB2DEF'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // WeatherPacket
+  // ---------------------------------------------------------------------------
+
+  group('WeatherPacket', () {
+    test('parses standalone weather report', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.source, equals('WX4XYZ'));
+    });
+
+    test('decodes wind direction', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.windDirection, equals(220));
+    });
+
+    test('decodes wind speed', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.windSpeed, equals(4.0));
+    });
+
+    test('decodes wind gust', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.windGust, equals(8.0));
+    });
+
+    test('decodes temperature in Fahrenheit', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.temperature, equals(60.0));
+    });
+
+    test('decodes humidity', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.humidity, equals(68));
+    });
+
+    test('decodes barometric pressure in mb', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      // b10125 → 10125 / 10 = 1012.5 mb
+      expect(p.pressure, closeTo(1012.5, 0.01));
+    });
+
+    test('decodes rainfall 1h', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_10090556c220s004g008t060r000p000P000h68b10125',
+      );
+      expect(p.rainfall1h, equals(0.0));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ObjectPacket
+  // ---------------------------------------------------------------------------
+
+  group('ObjectPacket', () {
+    test('parses alive object', () {
+      final p = expectPacketType<ObjectPacket>(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
+      expect(p.objectName, equals('HOSPITAL'));
+      expect(p.isAlive, isTrue);
+    });
+
+    test('decodes object lat/lon', () {
+      final p = expectPacketType<ObjectPacket>(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
+      expect(p.lat, closeTo(49.0583, 0.001));
+      expect(p.lon, closeTo(-72.0292, 0.001));
+    });
+
+    test('extracts object symbol', () {
+      final p = expectPacketType<ObjectPacket>(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
+      expect(p.symbolTable, equals('/'));
+      expect(p.symbolCode, equals('/'));
+    });
+
+    test('parses killed object', () {
+      final p = expectPacketType<ObjectPacket>(
+        'W1ABC>APRS:;HOSPITAL _092345z4903.50N/07201.75W/',
+      );
+      expect(p.isAlive, isFalse);
+    });
+
+    test('trims object name whitespace', () {
+      // Name is padded to 9 chars in the wire format.
+      final p = expectPacketType<ObjectPacket>(
+        'W1ABC>APRS:;TEST     *092345z4903.50N/07201.75W/',
+      );
+      expect(p.objectName, equals('TEST'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // StatusPacket
+  // ---------------------------------------------------------------------------
+
+  group('StatusPacket', () {
+    test('parses status report', () {
+      final p = expectPacketType<StatusPacket>(
+        'W1ABC>APRS:>Net Control Station',
+      );
+      expect(p.source, equals('W1ABC'));
+      expect(p.status, equals('Net Control Station'));
+    });
+
+    test('empty status', () {
+      final p = expectPacketType<StatusPacket>('W1ABC>APRS:>');
+      expect(p.status, equals(''));
+    });
+
+    test('status with special characters', () {
+      final p = expectPacketType<StatusPacket>(
+        'W1ABC>APRS:>QRV on 144.390 MHz / APRS',
+      );
+      expect(p.status, contains('144.390'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MicEPacket
+  // ---------------------------------------------------------------------------
+
+  group('MicEPacket', () {
+    // Real-world Mic-E packet: WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`
+    // WB4APR is the inventor of APRS; his beacon is a good test vector.
+    test('parses Mic-E packet (backtick DTI)', () {
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+      );
+      // The destination T2SR6Y encodes Mic-E data; packet should be MicEPacket
+      // or at minimum not crash. In some edge cases the destination may not
+      // be a valid Mic-E encoding and will return UnknownPacket — that is also
+      // acceptable as long as it does not throw.
+      expect(packet, anyOf(isA<MicEPacket>(), isA<UnknownPacket>()));
+    });
+
+    test('Mic-E lat is in valid range', () {
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+      );
+      if (packet is MicEPacket) {
+        expect(packet.lat, greaterThanOrEqualTo(-90));
+        expect(packet.lat, lessThanOrEqualTo(90));
+        expect(packet.lon, greaterThanOrEqualTo(-180));
+        expect(packet.lon, lessThanOrEqualTo(180));
+      }
+    });
+
+    test('Mic-E micEMessage is populated', () {
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+      );
+      if (packet is MicEPacket) {
+        expect(packet.micEMessage, isNotEmpty);
+      }
+    });
+
+    test("Mic-E with single-quote DTI is handled", () {
+      // Single-quote DTI variant
+      final packet = parser.parse(
+        "KD0ABC-9>S3QRYU,WIDE1-1,WIDE2-1:'(_fn\"Oj/`",
+      );
+      expect(packet, anyOf(isA<MicEPacket>(), isA<UnknownPacket>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // UnknownPacket (malformed / unrecognised)
+  // ---------------------------------------------------------------------------
+
+  group('UnknownPacket and malformed input', () {
+    test('blank line returns UnknownPacket', () {
+      expect(parser.parse(''), isA<UnknownPacket>());
+    });
+
+    test('server comment line returns UnknownPacket', () {
+      expect(
+        parser.parse('# logresp NOCALL unverified'),
+        isA<UnknownPacket>(),
+      );
+    });
+
+    test('line with no colon returns UnknownPacket', () {
+      expect(parser.parse('GARBAGE LINE WITH NO COLON'), isA<UnknownPacket>());
+    });
+
+    test('line with no > in header returns UnknownPacket', () {
+      expect(parser.parse('BADCALL>:info'), isA<UnknownPacket>());
+    });
+
+    test('completely garbage input returns UnknownPacket', () {
+      expect(parser.parse(':::'), isA<UnknownPacket>());
+    });
+
+    test('empty info field returns UnknownPacket', () {
+      // Header OK but nothing after the colon.
+      expect(parser.parse('N0CALL>APRS:'), isA<UnknownPacket>());
+    });
+
+    test('unrecognised DTI returns UnknownPacket', () {
+      // DTI 'Z' is not defined.
+      expect(parser.parse('N0CALL>APRS:Znot a packet'), isA<UnknownPacket>());
+    });
+
+    test('telemetry packet (T) returns UnknownPacket', () {
+      expect(
+        parser.parse('N0CALL>APRS:T#001,100,200,050,000,255,00000001'),
+        isA<UnknownPacket>(),
+      );
+    });
+
+    test('never throws for any malformed input', () {
+      final inputs = [
+        '',
+        'BADPACKET',
+        'NOCALL>:',
+        ':::',
+        'a>b:',
+        'GARBAGE LINE WITH NO COLON',
+        '\x00\x01\x02',
+        'N0CALL>APRS:',
+        '!',
+        'a' * 1000,
+      ];
+      for (final s in inputs) {
+        expect(() => parser.parse(s), returnsNormally, reason: 'Input: $s');
+      }
+    });
+
+    test('UnknownPacket has reason field', () {
+      final p = parser.parse('') as UnknownPacket;
+      expect(p.reason, isNotEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ItemPacket
+  // ---------------------------------------------------------------------------
+
+  group('ItemPacket', () {
+    test('parses alive item', () {
+      final p = expectPacketType<ItemPacket>(
+        'W1ABC>APRS:)RELAY !4903.50N/07201.75W-',
+      );
+      expect(p.itemName, equals('RELAY'));
+      expect(p.isAlive, isTrue);
+    });
+
+    test('decodes item position', () {
+      final p = expectPacketType<ItemPacket>(
+        'W1ABC>APRS:)RELAY !4903.50N/07201.75W-',
+      );
+      expect(p.lat, closeTo(49.0583, 0.001));
+      expect(p.lon, closeTo(-72.0292, 0.001));
+    });
+
+    test('parses killed item', () {
+      final p = expectPacketType<ItemPacket>(
+        'W1ABC>APRS:)RELAY _4903.50N/07201.75W-',
+      );
+      expect(p.isAlive, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases / real-world packets
+  // ---------------------------------------------------------------------------
+
+  group('real-world edge cases', () {
+    test('position with course/speed but no altitude', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W>059/030Comment here',
+      );
+      expect(p.course, equals(59));
+      expect(p.speed, equals(30.0));
+      expect(p.altitude, isNull);
+    });
+
+    test('position with zero course/speed is not stored', () {
+      // 000/000 means no course/speed info
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W>000/000Comment',
+      );
+      expect(p.course, isNull);
+      expect(p.speed, isNull);
+    });
+
+    test('APRS-IS line with TCPIP path is parsed correctly', () {
+      final p = expectPacketType<PositionPacket>(
+        'WB4APR-14>APWW10,TCPIP*,qAC,T2MCI:=3855.34N/07701.13W-Direwolf',
+      );
+      expect(p.source, equals('WB4APR-14'));
+      expect(p.destination, equals('APWW10'));
+      expect(p.path, contains('TCPIP*'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **AprsPacket sealed class hierarchy** — `PositionPacket`, `WeatherPacket`, `MessagePacket`, `ObjectPacket`, `ItemPacket`, `StatusPacket`, `MicEPacket`, `UnknownPacket` in `lib/core/packet/aprs_packet.dart`
- **AprsParser** — full DTI dispatch for all supported packet types: `!`, `=`, `/`, `@`, `;`, `)`, `:`, `_`, `>`, `` ` ``, `'`. Handles compressed and uncompressed position, Mic-E, weather, objects, items, messages, and status. Never crashes — malformed input yields `UnknownPacket`
- **StationService** updated with `packetStream` (broadcast) and `recentPackets` (500-packet rolling buffer, newest-first)
- **PacketLogScreen** — real-time scrollable packet list with type filter chips (ALL / POS / MSG / WX / OBJ / STATUS / MIC-E), auto-scroll with user-scroll detection, tap-to-detail
- **PacketDetailSheet** — full decoded field view with selectable monospace raw packet line
- **AprsSymbolWidget** — abstract symbol rendering widget consolidating all inline `symbolIcon` helpers; rendering approach can be swapped at v1.0 without touching call sites
- **FAB on MapScreen** to navigate to PacketLogScreen
- **92 tests passing**, zero analyzer issues (69 new parser tests + existing suite)

## Decisions

- Message thread view deferred to v0.3+ (out of scope for v0.2)
- Symbol rendering continues with Material icons behind `AprsSymbolWidget` abstraction; sprite sheet work deferred to v1.0 (see ADR-009)
- `intl` added for `DateFormat` timestamp formatting in the packet log

## Test plan

- [ ] `flutter test` — 92 tests pass
- [ ] `flutter analyze` — zero issues
- [ ] Navigate to packet log: packets appear in real time, filter chips work, tap opens detail sheet
- [ ] Map markers still render with correct icons
- [ ] Station info sheet still opens on marker tap