### PR TITLE
feat: iOS theme tier — Cupertino foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding |
 
-**Current status: v0.3 TNC in progress on `feat/v0.3-serial-tnc`.**
+**Current status: v0.3 TNC merged. iOS theme tier structurally complete (`feat/ios-theme`): `buildIosTheme()` implemented, `CupertinoApp`/`MaterialApp` branching in place at app root. Pending iOS simulator validation.**
 
 See `docs/ROADMAP.md` for per-milestone task breakdowns.
 
@@ -123,14 +123,14 @@ Keep these files current as the project evolves:
 
 ### Theme System (`lib/theme/`) — Three-Tier Platform Architecture
 
-Android tier implemented; iOS and desktop stubs in place for future PRs.
+Android tier implemented; iOS tier structurally complete (pending simulator validation); desktop stub in place for future PR.
 
 | File | Class | Description |
 |---|---|---|
 | `meridian_colors.dart` | `MeridianColors` | Brand color constants: `primary`, `primaryDark`, `signal`, `warning`, `danger` |
 | `theme_controller.dart` | `ThemeController` | ChangeNotifier for `themeMode` + `seedColor`; persists both to SharedPreferences |
 | `android_theme.dart` | `buildAndroidTheme()` | Builds Android ThemeData pair; uses `DynamicColorBuilder` schemes or seed fallback; applies M3 Expressive via `m3e_design` |
-| `ios_theme.dart` | — | Stub — Cupertino tier, implement in `feat/ios-theme` |
+| `ios_theme.dart` | `buildIosTheme()` | Returns `CupertinoThemeData` for given brightness; `primaryColor` = Meridian Blue; structurally complete, pending iOS simulator validation |
 | `desktop_theme.dart` | — | Stub — M3 static brand tier, implement in `feat/desktop-theme` |
 
 ### Layout System (`lib/ui/layout/`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,6 +181,19 @@ Semantic tokens (`signal`, `warning`, `danger`) carry APRS protocol meaning and 
 
 `ThemeController extends ChangeNotifier` manages two pieces of state: `themeMode` (`ThemeMode`, persisted as int under key `'theme_mode'`) and `seedColor` (`Color`, persisted as `toARGB32()` int under key `'seed_color'`). Provided at the app root via `provider`.
 
+### App Root Platform Branching
+
+`MeridianApp.build()` in `lib/main.dart` branches on platform before constructing the app widget:
+
+```dart
+if (!kIsWeb && Platform.isIOS) {
+  // Returns CupertinoApp with buildIosTheme(brightness: resolvedBrightness)
+}
+// Android + Desktop: DynamicColorBuilder + MaterialApp with buildAndroidTheme()
+```
+
+`_resolveIosBrightness(ThemeMode)` maps `ThemeController.themeMode` to a `Brightness` for `CupertinoThemeData`. `ThemeMode.system` reads `WidgetsBinding.instance.platformDispatcher.platformBrightness`.
+
 ### Android Tier (`lib/theme/android_theme.dart`)
 
 `buildAndroidTheme({ColorScheme? dynamicLight, ColorScheme? dynamicDark, required Color seedColor})` builds the light/dark `ThemeData` pair:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -235,3 +235,16 @@ A single `ThemeController` manages `themeMode` and `seedColor` as shared state. 
 | `dynamic_color` | Android | Wallpaper-derived ColorScheme on Android 12+ |
 | `m3e_design` | Android | M3 Expressive ThemeExtension tokens |
 | `flutter_m3shapes` | Android | M3 Expressive shape library |
+
+---
+
+## ADR-017: iOS Liquid Glass deferred pending Flutter framework support
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+**Decision:** iOS Liquid Glass (Apple's glassmorphism design language, shipping with iOS 26 / visionOS 3) is intentionally not implemented in the v0.x iOS theme tier. The current `buildIosTheme()` function in `lib/theme/ios_theme.dart` provides the structural Cupertino foundation — `CupertinoApp`, `CupertinoThemeData`, Meridian brand primary color — without any Liquid Glass-specific APIs.
+
+**Rationale:** Flutter's framework support for Liquid Glass is not yet available in the stable channel. The `docs/THEME_PLATFORM_STRATEGY.md` document outlines the intended upgrade path once stable framework APIs land.
+
+**Consequences:** iOS UI uses standard Cupertino styling (system backgrounds, SF Pro) until an `ios-liquid-glass` feature branch is opened. No changes to the theme architecture are required when upgrading — `buildIosTheme()` will be extended in place.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,12 @@
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:io' show Platform;
 
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/transport/aprs_is_transport.dart';
 import 'screens/map_screen.dart';
@@ -10,9 +14,21 @@ import 'screens/onboarding/onboarding_screen.dart';
 import 'services/station_service.dart';
 import 'services/tnc_service.dart';
 import 'theme/android_theme.dart';
+import 'theme/ios_theme.dart';
 import 'theme/theme_controller.dart';
 
 const String _kVersion = '0.1.0';
+
+/// Resolves the active [Brightness] from [ThemeMode] for [CupertinoApp].
+///
+/// [ThemeMode.system] reads [WidgetsBinding.instance.platformDispatcher.platformBrightness]
+/// directly. Full reactive brightness for [ThemeMode.system] will be verified
+/// during iOS simulator testing.
+Brightness _resolveIosBrightness(ThemeMode mode) {
+  if (mode == ThemeMode.light) return Brightness.light;
+  if (mode == ThemeMode.dark) return Brightness.dark;
+  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
+}
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -87,6 +103,32 @@ class MeridianApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<ThemeController>();
+
+    if (!kIsWeb && Platform.isIOS) {
+      final brightness = _resolveIosBrightness(controller.themeMode);
+      return CupertinoApp(
+        title: 'Meridian APRS',
+        theme: buildIosTheme(brightness: brightness),
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US')],
+        home: onboardingComplete
+            ? MapScreen(
+                service: service,
+                tncService: tncService,
+                callsign: userCallsign,
+                ssid: userSsid,
+                initialLat: mapLat,
+                initialLon: mapLon,
+                initialZoom: mapZoom,
+              )
+            : const OnboardingScreen(),
+      );
+    }
 
     return DynamicColorBuilder(
       builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {

--- a/lib/theme/ios_theme.dart
+++ b/lib/theme/ios_theme.dart
@@ -1,3 +1,20 @@
-// iOS theme tier — Cupertino implementation.
-// See docs/THEME_PLATFORM_STRATEGY.md for full spec.
-// TODO: Implement in feat/ios-theme task.
+import 'package:flutter/cupertino.dart';
+
+import 'meridian_colors.dart';
+
+/// Builds the iOS [CupertinoThemeData] for the given [brightness].
+///
+/// Uses fixed Meridian brand colors — no dynamic color or seed color on iOS.
+/// San Francisco font is applied automatically by Flutter on iOS; no
+/// [CupertinoTextThemeData] override is needed.
+///
+/// Light/dark switching is controlled by the [brightness] parameter, which
+/// the app root resolves from [ThemeController.themeMode] before calling this
+/// function. [CupertinoColors] system colors (e.g. systemBackground) resolve
+/// automatically for the given brightness.
+CupertinoThemeData buildIosTheme({required Brightness brightness}) {
+  return CupertinoThemeData(
+    brightness: brightness,
+    primaryColor: MeridianColors.primary,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -198,6 +198,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_m3shapes:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_map: ^8.2.2
   latlong2: ^0.9.1
   intl: ^0.20.2


### PR DESCRIPTION
## Summary

- Implements `buildIosTheme()` in `lib/theme/ios_theme.dart`: returns a `CupertinoThemeData` with Meridian Blue as `primaryColor` and brightness controlled by the caller; San Francisco font applied automatically by Flutter on device.
- Branches `MeridianApp.build()` at the app root (`lib/main.dart`): iOS gets `CupertinoApp + buildIosTheme()`; Android and desktop continue to use `DynamicColorBuilder + MaterialApp + buildAndroidTheme()`. The branch is guarded by `!kIsWeb && Platform.isIOS` so it is dead code on all non-iOS targets.
- Adds `flutter_localizations` SDK dependency for `GlobalMaterialLocalizations`, `GlobalWidgetsLocalizations`, and `GlobalCupertinoLocalizations` delegates required by `CupertinoApp`.
- Adds `_resolveIosBrightness(ThemeMode)` top-level helper that maps `ThemeController.themeMode` → `Brightness` for `CupertinoThemeData`. `ThemeMode.system` reads `WidgetsBinding.instance.platformDispatcher.platformBrightness`.
- Logs ADR-017 deferring iOS Liquid Glass pending Flutter stable channel support.
- Documents app root platform branching pattern in `docs/ARCHITECTURE.md`.
- Updates `CLAUDE.md` iOS tier status row and current milestone status.

## Deferred checklist (iOS simulator phase)

- [ ] Boot iOS simulator, verify `CupertinoApp` renders correctly on iPhone 16 Pro target
- [ ] Verify `ThemeMode.system` brightness reactivity: toggle OS appearance in simulator, confirm app follows without restart (may need `WidgetsBindingObserver` if `platformDispatcher.platformBrightness` is not reactive)
- [ ] Audit navigation transitions: explicit `MaterialPageRoute` calls in `map_screen.dart` are **not** intercepted by `CupertinoApp` and will not produce native iOS slide transitions — replace with `CupertinoPageRoute` or migrate to `go_router` (which auto-selects platform transitions) in a follow-up; note that `go_router` is not currently used in this project
- [ ] Confirm `StationInfoSheet`, `MeridianBottomSheet`, and `PacketDetailSheet` (all `showModalBottomSheet` callers) surface without errors under `CupertinoApp` — Material modal sheets are compatible but may need `Material` ancestor wrapping if any widget reads `Theme.of(context)` without a fallback

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 107 tests passed
- [ ] iOS simulator boot + manual smoke test (deferred, no simulator available in CI at this stage)

## Notes

`go_router` is not used in this project. Explicit `MaterialPageRoute` calls in `map_screen.dart` will not be intercepted by `CupertinoApp`. Native iOS page transitions (right-to-left slide with swipe-back gesture) are a follow-up task for the iOS simulator phase, not a blocker for merging this structural foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)