### PR TITLE
feat: Desktop theme tier — Material 3 static brand theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding |
 
-**Current status: v0.3 TNC merged. iOS theme tier structurally complete (`feat/ios-theme`): `buildIosTheme()` implemented, `CupertinoApp`/`MaterialApp` branching in place at app root. Pending iOS simulator validation.**
+**Current status: v0.3 TNC merged. Three-tier platform theme architecture complete — Android (M3 Expressive + Dynamic Color), iOS (Cupertino, pending iOS simulator validation), Desktop (M3 static brand). All three tiers implemented; desktop branch at app root active on Linux/macOS/Windows.**
 
 See `docs/ROADMAP.md` for per-milestone task breakdowns.
 
@@ -123,7 +123,7 @@ Keep these files current as the project evolves:
 
 ### Theme System (`lib/theme/`) — Three-Tier Platform Architecture
 
-Android tier implemented; iOS tier structurally complete (pending simulator validation); desktop stub in place for future PR.
+All three tiers fully implemented. iOS pending simulator validation.
 
 | File | Class | Description |
 |---|---|---|
@@ -131,7 +131,7 @@ Android tier implemented; iOS tier structurally complete (pending simulator vali
 | `theme_controller.dart` | `ThemeController` | ChangeNotifier for `themeMode` + `seedColor`; persists both to SharedPreferences |
 | `android_theme.dart` | `buildAndroidTheme()` | Builds Android ThemeData pair; uses `DynamicColorBuilder` schemes or seed fallback; applies M3 Expressive via `m3e_design` |
 | `ios_theme.dart` | `buildIosTheme()` | Returns `CupertinoThemeData` for given brightness; `primaryColor` = Meridian Blue; structurally complete, pending iOS simulator validation |
-| `desktop_theme.dart` | — | Stub — M3 static brand tier, implement in `feat/desktop-theme` |
+| `desktop_theme.dart` | `buildDesktopTheme()` | Returns M3 static brand ThemeData pair; fixed `MeridianColors.primary` seed; no dynamic color; Windows/macOS/Linux |
 
 ### Layout System (`lib/ui/layout/`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,7 +148,7 @@ The UI layer uses three scaffold variants selected at runtime by window width:
 
 ## Theme System — Three-Tier Platform Architecture
 
-Meridian uses a three-tier platform theme architecture. Each tier can evolve independently while sharing a common brand identity. The Android tier is implemented; iOS and desktop stubs are in place for future PRs.
+Meridian uses a three-tier platform theme architecture. Each tier can evolve independently while sharing a common brand identity. All three tiers are fully implemented.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -189,10 +189,23 @@ Semantic tokens (`signal`, `warning`, `danger`) carry APRS protocol meaning and 
 if (!kIsWeb && Platform.isIOS) {
   // Returns CupertinoApp with buildIosTheme(brightness: resolvedBrightness)
 }
-// Android + Desktop: DynamicColorBuilder + MaterialApp with buildAndroidTheme()
+if (!kIsWeb && (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
+  // Returns MaterialApp with buildDesktopTheme(seedColor: MeridianColors.primary)
+  // No DynamicColorBuilder — desktop platforms do not support wallpaper color extraction
+}
+// Android: DynamicColorBuilder + MaterialApp with buildAndroidTheme()
 ```
 
 `_resolveIosBrightness(ThemeMode)` maps `ThemeController.themeMode` to a `Brightness` for `CupertinoThemeData`. `ThemeMode.system` reads `WidgetsBinding.instance.platformDispatcher.platformBrightness`.
+
+### Desktop Tier (`lib/theme/desktop_theme.dart`)
+
+`buildDesktopTheme({required Color seedColor})` builds the light/dark `ThemeData` pair for Windows, macOS, and Linux:
+
+- Material 3 (`useMaterial3: true`) with `ColorScheme.fromSeed(seedColor: seedColor)`.
+- Fixed seed: callers always pass `MeridianColors.primary` — no user-configurable color picker on desktop.
+- No `DynamicColorBuilder` wrapper, no M3 Expressive `ThemeExtension`.
+- `themeMode` from `ThemeController` is respected for light/dark/system switching, identical to the Android branch.
 
 ### Android Tier (`lib/theme/android_theme.dart`)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -248,3 +248,16 @@ A single `ThemeController` manages `themeMode` and `seedColor` as shared state. 
 **Rationale:** Flutter's framework support for Liquid Glass is not yet available in the stable channel. The `docs/THEME_PLATFORM_STRATEGY.md` document outlines the intended upgrade path once stable framework APIs land.
 
 **Consequences:** iOS UI uses standard Cupertino styling (system backgrounds, SF Pro) until an `ios-liquid-glass` feature branch is opened. No changes to the theme architecture are required when upgrading — `buildIosTheme()` will be extended in place.
+
+---
+
+## ADR-018: Desktop theme tier bypasses DynamicColorBuilder
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+**Decision:** The desktop branch in `MeridianApp.build()` calls `buildDesktopTheme(seedColor: MeridianColors.primary)` directly without wrapping it in `DynamicColorBuilder`.
+
+**Rationale:** `DynamicColorBuilder` returns null schemes on all desktop platforms (Windows, macOS, Linux); the wallpaper color extraction API is Android-only. Previously desktop fell through to the Android branch, which handled null schemes via the seed fallback — functional but implicit. Giving desktop its own explicit branch in `MeridianApp.build()` (`Platform.isWindows || Platform.isMacOS || Platform.isLinux`) makes the three-tier architecture fully explicit and removes the `DynamicColorBuilder` overhead on platforms where it does nothing. The desktop seed color is always `MeridianColors.primary` — there is no user-configurable color picker on desktop (the App Color section in Settings is Android-only).
+
+**Consequences:** The three-tier platform theme architecture is now fully implemented. All three tiers — Android, iOS, Desktop — have dedicated `build*Theme()` functions and explicit platform branches at the app root. `DynamicColorBuilder` is used only in the Android branch.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,7 @@ Goal: A complete design system, adaptive layouts, core widget library, settings 
 - [x] Settings screen shell (Appearance section functional — theme switching works; all other sections stubbed)
 - [x] Onboarding flow (3-screen PageView, first-launch gated via SharedPreferences)
 - [x] MapScreen updated to use ResponsiveLayout; service lifecycle remains in MapScreen
+- [x] Three-tier platform theme architecture — Android (M3 Expressive + Dynamic Color), iOS (Cupertino), Desktop (M3 static brand) — all tiers complete
 
 ---
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,9 @@ import 'screens/onboarding/onboarding_screen.dart';
 import 'services/station_service.dart';
 import 'services/tnc_service.dart';
 import 'theme/android_theme.dart';
+import 'theme/desktop_theme.dart';
 import 'theme/ios_theme.dart';
+import 'theme/meridian_colors.dart';
 import 'theme/theme_controller.dart';
 
 const String _kVersion = '0.1.0';
@@ -109,6 +111,35 @@ class MeridianApp extends StatelessWidget {
       return CupertinoApp(
         title: 'Meridian APRS',
         theme: buildIosTheme(brightness: brightness),
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US')],
+        home: onboardingComplete
+            ? MapScreen(
+                service: service,
+                tncService: tncService,
+                callsign: userCallsign,
+                ssid: userSsid,
+                initialLat: mapLat,
+                initialLon: mapLon,
+                initialZoom: mapZoom,
+              )
+            : const OnboardingScreen(),
+      );
+    }
+
+    if (!kIsWeb &&
+        (Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
+      final themes = buildDesktopTheme(seedColor: MeridianColors.primary);
+      return MaterialApp(
+        title: 'Meridian APRS',
+        themeMode: controller.themeMode,
+        theme: themes.light,
+        darkTheme: themes.dark,
         debugShowCheckedModeBanner: false,
         localizationsDelegates: const [
           GlobalMaterialLocalizations.delegate,

--- a/lib/theme/desktop_theme.dart
+++ b/lib/theme/desktop_theme.dart
@@ -1,3 +1,24 @@
-// Desktop theme tier — Material 3 static brand theme (Windows / macOS / Linux).
-// See docs/THEME_PLATFORM_STRATEGY.md for full spec.
-// TODO: Implement in feat/desktop-theme task.
+import 'package:flutter/material.dart';
+
+import 'meridian_colors.dart';
+
+/// Builds the desktop theme pair (light + dark) for Windows, macOS, and Linux.
+///
+/// Material 3 with a fixed [seedColor] — no dynamic color, no M3 Expressive
+/// ThemeExtension (Android-only). Callers always pass [MeridianColors.primary].
+({ThemeData light, ThemeData dark}) buildDesktopTheme({
+  required Color seedColor,
+}) {
+  final lightScheme = ColorScheme.fromSeed(
+    seedColor: seedColor,
+    brightness: Brightness.light,
+  );
+  final darkScheme = ColorScheme.fromSeed(
+    seedColor: seedColor,
+    brightness: Brightness.dark,
+  );
+  return (
+    light: ThemeData(useMaterial3: true, colorScheme: lightScheme),
+    dark: ThemeData(useMaterial3: true, colorScheme: darkScheme),
+  );
+}


### PR DESCRIPTION
## Summary

- Implements `buildDesktopTheme({required Color seedColor})` in `lib/theme/desktop_theme.dart` — Material 3 light/dark pair with a fixed `MeridianColors.primary` seed; no dynamic color, no M3 Expressive ThemeExtension
- Adds an explicit desktop branch in `MeridianApp.build()` (`Platform.isWindows || Platform.isMacOS || Platform.isLinux`) that calls `buildDesktopTheme` directly — desktop no longer falls through the `DynamicColorBuilder` path
- All three platform theme tiers are now fully in place: Android (M3 Expressive + Dynamic Color), iOS (Cupertino), Desktop (M3 static brand)
- ADR-018 added: rationale for bypassing `DynamicColorBuilder` on desktop
- `ARCHITECTURE.md`, `ROADMAP.md`, `CLAUDE.md` updated to reflect completion

## What changed

**`lib/theme/desktop_theme.dart`** — replaces 3-line TODO stub with real implementation.

**`lib/main.dart`** — new desktop branch between the iOS branch and the `DynamicColorBuilder` return. Android is now the only path that uses `DynamicColorBuilder`.

**Settings → Appearance** — verified: App Color (seed) row is already hidden on desktop via the existing `kIsWeb || !Platform.isAndroid` gate in `_AppColorSection`; no code changes needed.

## Test plan

- [x] `flutter analyze` — no new warnings
- [x] `dart format` — no changes
- [x] `flutter test` — all 107 tests pass
- [ ] Linux desktop smoke test:
  - [ ] App launches; desktop branch active (`Platform.isLinux` = true)
  - [ ] Default Meridian Blue M3 color scheme in light mode
  - [ ] Dark mode renders correctly
  - [ ] System mode follows OS preference
  - [ ] Settings → Appearance: theme mode toggle works; App Color row not visible
  - [ ] Map screen and packet log render correctly in both modes
  - [ ] ThemeMode preference persists after restart