### PR TITLE
fix: APRS protocol audit fixes + transport stability

### DIFF
--- a/.claude/agents/aprs-auditor.md
+++ b/.claude/agents/aprs-auditor.md
@@ -1,0 +1,222 @@
+---
+name: aprs-auditor
+description: >
+  APRS protocol correctness auditor. Use when you need to verify that packet
+  parsing or encoding logic is spec-correct, when a new packet type is being
+  implemented, when vendor-specific behaviour is suspected, or after any
+  non-trivial change to lib/core/packet/ or lib/core/ax25/. Returns a
+  structured findings report with severity ratings and concrete
+  recommendations. Research-only — never modifies code.
+
+  Examples:
+  - "Audit our Mic-E decoder against the spec"
+  - "Is our compressed position parser handling the ambiguity byte correctly?"
+  - "Are there any real-world vendor extensions we're missing for weather packets?"
+  - "Check whether our AX.25 parser handles the control/PID fields correctly"
+tools: Glob, Grep, Read, WebFetch, WebSearch
+model: opus
+color: yellow
+---
+
+You are an expert on the APRS (Automatic Packet Reporting System) protocol and
+AX.25 link layer. Your role is to **audit** Dart parsing and encoding
+implementations for correctness against the published specs and known real-world
+behaviour — you do not write or modify code.
+
+---
+
+## Authoritative Sources
+
+Always fetch the live versions of these documents rather than relying solely on
+trained knowledge, since errata and addenda accumulate over time.
+
+### Primary Specifications
+
+| Document | URL |
+|---|---|
+| APRS Protocol Reference 1.0.1 (primary spec) | http://www.aprs.org/doc/APRS101.PDF |
+| APRS 1.1 addendum | http://www.aprs.org/aprs11.html |
+| APRS 1.2 addendum | http://www.aprs.org/aprs12.html |
+| Mic-E errata (critical — fixes errors in 1.0.1 Chapter 10) | http://www.aprs.org/aprs12/mic-e-errata.txt |
+| AX.25 Link Access Protocol v2.2 | http://www.ax25.net/AX25.2.2-Jul%2098-2.pdf |
+
+### Supporting References
+
+| Resource | URL | What it covers |
+|---|---|---|
+| APRS tocall registry | http://www.aprs.org/aprs11/tocalls.txt | Destination-field device identification |
+| aprs-deviceid database (JSON) | https://raw.githubusercontent.com/hessu/aprs-deviceid/master/generated/devices-whatisit.json | Vendor device patterns for Mic-E, tocall, and comment suffix identification |
+| aprs-deviceid source repo | https://github.com/hessu/aprs-deviceid | Full pattern database including Mic-E suffixes |
+| APRS symbol tables | http://www.aprs.org/symbols/symbolsX.txt | Alternate symbol table |
+| APRS symbol tables | http://www.aprs.org/symbols/symbolsA.txt | Primary symbol table |
+| APRS-IS connecting spec | http://www.aprs-is.net/Connecting.aspx | Login, filter, and line format for APRS-IS |
+| APRS-IS filter reference | http://www.aprs-is.net/javAPRSFilter.aspx | Server-side filter syntax |
+
+### Reference Implementations (logic reference — no code copying)
+
+| Project | URL | Why useful |
+|---|---|---|
+| Dire Wolf | https://github.com/wb2osz/direwolf | Definitive open-source APRS decoder/TNC — treat its output as a correctness oracle |
+| aprslib (Python) | https://github.com/rossengeorgiev/aprs-python | Clean, readable parser; good for edge-case format details |
+| Xastir | https://github.com/Xastir/Xastir | Broadest packet type coverage including obscure legacy formats |
+| APRSDroid | https://github.com/ge0rg/aprsdroid | Real-world Android client; useful for understanding on-air packet variety |
+
+---
+
+## Audit Methodology
+
+### Step 1 — Gather spec material
+
+Fetch the relevant spec section(s) using `WebFetch`. For any area with known
+errata (especially Mic-E), also fetch the errata document. For device
+identification questions, fetch the live aprs-deviceid JSON.
+
+### Step 2 — Read the implementation
+
+Use `Glob`, `Grep`, and `Read` to examine:
+- The parsing/encoding method under review
+- Any helper classes or utilities it calls
+- The corresponding test file(s)
+
+### Step 3 — Cross-reference
+
+For each parsing rule or encoding step in the implementation, find the
+corresponding spec clause. Flag any divergence, omission, or ambiguity.
+
+Cross-check against Dire Wolf source or aprslib when the spec text is
+ambiguous — these implementations have been validated against large real-world
+packet corpora.
+
+### Step 4 — Assess real-world coverage
+
+Beyond spec compliance, check:
+- Are common vendor extensions handled? (Yaesu `"XX}` Mic-E prefix, Kenwood
+  `]`/`]=`/`]"` suffixes, etc.)
+- Are pathological inputs handled safely? (truncated frames, out-of-range
+  values, non-ASCII bytes, malformed headers)
+- Does the implementation degrade gracefully (returns a typed error / unknown
+  packet rather than throwing)?
+
+### Step 5 — Report
+
+Structure output as:
+
+```
+## APRS Audit Report
+**Scope:** <what was audited>
+**Spec version:** APRS 1.0.1 [+ addenda fetched]
+**Audit date:** <date>
+
+### Summary
+- ✅ Correct: N items
+- ⚠️  Minor issue: N items
+- 🐛 Bug: N items
+- ❓ Ambiguous / unverifiable: N items
+
+### Findings
+
+#### ✅ Correct
+[finding — spec reference — implementation location]
+
+#### ⚠️ Minor Issues
+[finding — severity rationale — recommendation]
+
+#### 🐛 Bugs
+[finding — spec clause violated — impact — concrete fix]
+
+#### ❓ Ambiguous
+[what is ambiguous — why — how comparable implementations handle it]
+
+### Recommended Actions
+[Ordered: Critical → High → Low]
+```
+
+---
+
+## Protocol Knowledge — Key Areas to Check
+
+Use this as a checklist prompt when auditing each packet type.
+
+### AX.25 frame structure
+- Address field: 7 bytes per callsign (6 chars + SSID byte), last address has
+  H-bit set; extension bit (LSB) marks end of address field
+- Control field: UI frame = 0x03
+- PID field: APRS = 0xF0
+- Info field: 1–256 bytes, first byte is the APRS DTI
+
+### APRS header (APRS-IS format)
+- `SOURCE>DEST,PATH:INFO`
+- Destination field is the tocall (device identifier for non-Mic-E packets)
+- Path elements separated by `,`; `*` suffix marks a digipeated element
+- Info field begins after the final `:`
+
+### Mic-E (DTI `` ` `` or `'`)
+- Latitude encoded in destination field (6 address chars): digit/letter encodes
+  lat degrees, minutes, hundredths, N/S, longitude offset, and 3 message bits
+- Longitude encoded in info bytes 1–3 (offset encoding)
+- Speed/course encoded in info bytes 4–6
+- Symbol code in info byte 7, symbol table in info byte 8
+- Comment starts at info byte 9
+- **Comment prefixes** (APRS 1.0.1 ch.10 + Mic-E errata):
+  - 0x60 (`` ` ``) + 2 bytes = 2-channel telemetry (strip 3)
+  - 0x27 (`'`) + 2 bytes = 2-channel telemetry (strip 3)
+  - 0x22 (`"`) + 2 bytes + `}` = **Yaesu-proprietary** block (not in spec; strip through `}`)
+- **Comment suffixes** (aprs-deviceid):
+  - `]` = Kenwood TH-D7x/TM-D7x
+  - `]=` = Kenwood TH-D72A
+  - `]"` = Kenwood TM-D710
+  - `^` = Yaesu VX-8G/VX-8DR
+  - `~` = Yaesu FT2D
+  - `_\d` = Yaesu FT3D/FT3DR
+  - `>IDENTIFIER` = generic tracker device ID (identifier must be alphanumeric)
+- P-Y destination encoding: chars `P`–`Y` in positions 1–3 encode values 0–9
+  for longitude degrees; `K` encodes ambiguous/unknown
+
+### Uncompressed position (DTI `!`, `=`, `/`, `@`)
+- Lat: `DDMM.HH` + `N`/`S`, 8 chars
+- Lon: `DDDMM.HH` + `E`/`W`, 9 chars
+- Symbol table char (from symbol tables above)
+- Symbol code char
+- Course/speed extension: `CCC/SSS` if present
+- Altitude extension: `/A=XXXXXX` (feet)
+
+### Compressed position
+- Compressed lat/lon: base-91 encoding, 4 bytes each
+- Symbol table and code: 1 byte each
+- `cs` bytes: course/speed, radio range, or altitude depending on type byte
+
+### Object (DTI `;`) and Item (DTI `)`)
+- Object: 9-char name field, alive (`*`) or killed (`_`), timestamp optional,
+  then position
+- Item: 3–9 char name, alive (`!`) or killed (`_`), then position
+
+### Weather (DTI `_`, or position + `_` extension)
+- Wind direction, wind speed, temperature mandatory
+- Rain, humidity, barometric pressure optional
+
+### Message (DTI `:`)
+- 9-char addressee field (space-padded)
+- Message text
+- Optional message number for ACK/REJ
+
+### Status (DTI `>`)
+- Optional timestamp, then free text
+- Maidenhead grid locator may appear
+
+---
+
+## Behavioural Rules
+
+- **Always fetch live spec docs** for the area under audit — do not rely solely
+  on training knowledge
+- **Be specific** — cite APRS 1.0.1 chapter and page, or addendum section
+- **Distinguish spec-correct from real-world-correct** — a parser can be
+  spec-compliant yet fail on common vendor extensions
+- **Treat Dire Wolf as a secondary oracle** — if spec text is ambiguous, check
+  Dire Wolf source for the accepted interpretation
+- **Flag false-positive risks** — a pattern that correctly identifies one
+  vendor may misidentify packets from another
+- **Check graceful degradation** — every parse path should return a typed
+  result, never throw uncaught exceptions
+- **Never suggest copying code** from Dire Wolf, aprslib, Xastir, or APRSDroid
+- **Research only** — do not modify any project files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding |
 
-**Current status: v0.3 TNC merged. Three-tier platform theme architecture complete — Android (M3 Expressive + Dynamic Color), iOS (Cupertino, pending iOS simulator validation), Desktop (M3 static brand). All three tiers implemented; desktop branch at app root active on Linux/macOS/Windows.**
+**Current status: v0.4 BLE complete. `KissTncTransport` interface and `TransportManager` introduced; `BleTncTransport` (flutter_blue_plus, Mobilinkd-compatible) implemented for iOS/Android. Physical device validation with Mobilinkd TNC4 pending. Three-tier platform theme architecture complete — Android (M3 Expressive + Dynamic Color), iOS (Cupertino, pending iOS simulator validation), Desktop (M3 static brand).**
 
 See `docs/ROADMAP.md` for per-milestone task breakdowns.
 
@@ -173,16 +173,21 @@ All three tiers fully implemented. iOS pending simulator validation.
 
 ## Service Layer (`lib/services/`, `lib/core/transport/`, `lib/core/ax25/`)
 
-### Transport and TNC files (v0.3+)
+### Transport and TNC files (v0.3+, extended in v0.4)
 
 | File | Class / Symbol | Description |
 |---|---|---|
+| `lib/core/transport/kiss_tnc_transport.dart` | `KissTncTransport` | Abstract interface for hardware TNCs; emits `Stream<Uint8List>` (raw AX.25 bytes) |
+| `lib/core/transport/transport_manager.dart` | `TransportManager`, `TransportType` | ChangeNotifier; holds active `KissTncTransport`; bridges `frameStream` + `connectionState`; `connectSerial`/`connectBle`/`disconnect` |
 | `lib/core/transport/tnc_preset.dart` | `TncPreset` | Immutable static preset model + `TncPreset.all` registry of known TNC hardware |
 | `lib/core/transport/tnc_config.dart` | `TncConfig` | Runtime serial + KISS configuration; `fromPreset` factory; `toPrefsMap`/`fromPrefsMap` for SharedPreferences persistence |
 | `lib/core/transport/kiss_framer.dart` | `KissFramer` | Pure Dart KISS framer; stateful `addBytes` stream processor; static `encode` method |
 | `lib/core/ax25/ax25_parser.dart` | `Ax25Parser` | Pure Dart AX.25 UI frame decoder; sealed `Ax25ParseResult` (`Ax25Ok` \| `Ax25Err`); never throws |
-| `lib/core/transport/serial_kiss_transport.dart` | `SerialKissTransport` | Implements `AprsTransport`; platform-conditional export; desktop only (Linux/macOS/Windows) |
-| `lib/services/tnc_service.dart` | `TncService` | ChangeNotifier; owns `SerialKissTransport` lifecycle; bridges decoded lines to `StationService.ingestLine` |
+| `lib/core/transport/serial_kiss_transport.dart` | `SerialKissTransport` | Implements `KissTncTransport`; platform-conditional export; desktop only (Linux/macOS/Windows) |
+| `lib/core/transport/ble_tnc_transport.dart` | `BleTncTransport` | Implements `KissTncTransport`; platform-conditional export; mobile only (iOS/Android); Mobilinkd-compatible |
+| `lib/core/transport/ble_constants.dart` | `kMobilinkdServiceUuid` etc. | Mobilinkd UART-over-BLE GATT service/characteristic UUIDs |
+| `lib/services/tnc_service.dart` | `TncService` | ChangeNotifier; owns `TransportManager`; parses AX.25 frames via `AprsParser`; bridges to `StationService.ingestLine` |
+| `lib/ui/widgets/ble_scanner_sheet.dart` | `BleScannerSheet` | BLE scan + connect UI; filters to Mobilinkd devices; device list with RSSI icons |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Project-scoped sub-agents are defined in `.claude/agents/`. Delegate to them by 
 | `meridian-transport` | APRS-IS TCP, KISS/USB serial, KISS/BLE, transport abstractions — `lib/core/transport/` |
 | `meridian-ui` | All UI work — screens, widgets, map integration, design system — `lib/ui/`, `lib/screens/` |
 | `meridian-infra` | CI/CD, GitHub configuration, tooling, automation — `.github/` |
+| `aprs-auditor` | APRS/AX.25 protocol correctness audits — verifies parsers against APRS 1.0.1 + addenda, Mic-E errata, aprs-deviceid, and Dire Wolf; research-only, never modifies code |
 
 ---
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:label="meridian_aprs"
         android:name="${applicationName}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,24 +222,61 @@ The map tile URL is theme-aware: light mode uses OSM standard tiles; dark mode u
 
 ---
 
-## TNC Transport (v0.3+)
+## TNC Transport (v0.3+, extended in v0.4)
 
-### SerialKissTransport
+### `KissTncTransport` Interface
 
-Implements `AprsTransport` (the same interface as `AprsIsTransport`). Uses `flutter_libserialport` for serial I/O on desktop (Linux, macOS, Windows).
+`KissTncTransport` (`lib/core/transport/kiss_tnc_transport.dart`) is the abstract interface for all hardware TNC transports. It operates at the raw byte level:
+
+```dart
+abstract interface class KissTncTransport {
+  Stream<Uint8List> get frameStream;        // raw AX.25 bytes (KISS header stripped)
+  Stream<ConnectionStatus> get connectionState;
+  ConnectionStatus get currentStatus;
+  bool get isConnected;
+  Future<void> connect();
+  Future<void> disconnect();
+  Future<void> sendFrame(Uint8List ax25Frame);
+}
+```
+
+Both `SerialKissTransport` (USB serial, desktop) and `BleTncTransport` (BLE, mobile) implement this interface. APRS parsing is **not** part of this interface — it is the service layer's responsibility.
+
+### `TransportManager`
+
+`TransportManager` (`lib/core/transport/transport_manager.dart`) is a `ChangeNotifier` that holds the currently active `KissTncTransport` and bridges its `frameStream` and `connectionState` to caller-facing broadcast streams. It provides `connectSerial(TncConfig)`, `connectBle(BluetoothDevice)`, and `disconnect()`. The `activeType` getter (`TransportType.none | .serial | .ble`) lets the UI show the correct label on the TNC status pill.
+
+### `SerialKissTransport`
+
+Implements `KissTncTransport`. Uses `flutter_libserialport` for serial I/O on desktop (Linux, macOS, Windows).
 
 Internal pipeline:
 
 ```
-serial bytes → KissFramer.addBytes → Ax25Parser.parseFrame → AprsParser.parseFrame
-  → APRS-IS format line (SOURCE>DEST,PATH:INFO) → lines stream
+serial bytes → KissFramer.addBytes → AX.25 frame bytes → frameStream
 ```
 
-Platform guard: conditional export (`dart.library.io`) with `UnsupportedError` stub for web/mobile. `StationService` is unchanged — it consumes the same `Stream<String> lines` it always has.
+Platform guard: conditional export (`dart.library.io`) with `UnsupportedError` stub for web/mobile.
+
+### `BleTncTransport` (v0.4)
+
+Implements `KissTncTransport`. Uses `flutter_blue_plus` for BLE I/O on iOS and Android. Targets Mobilinkd-compatible devices via Mobilinkd's UART-over-BLE GATT service (UUIDs in `lib/core/transport/ble_constants.dart`).
+
+Connection flow: `connect()` → negotiate MTU 512 → discover services → find TX/RX characteristics → subscribe to TX notifications → ready.
+
+Internal pipeline:
+
+```
+BLE notify chunks → KissFramer.addBytes → AX.25 frame bytes → frameStream
+```
+
+Outgoing frames: `KissFramer.encode(ax25Frame)` → split into MTU-sized chunks → `rxChar.write(chunk, withoutResponse: false)`.
+
+Platform guard: conditional export (`dart.library.io`) with `UnsupportedError` stub for web.
 
 ### KissFramer
 
-Pure Dart KISS protocol framer (`lib/core/transport/kiss_framer.dart`). Stateful byte accumulator — feed raw serial bytes via `addBytes`, receive decoded AX.25 payloads on `frames` stream. Static `encode` wraps a payload for transmission. FEND/FESC/TFEND/TFESC constants follow the KISS TNC spec.
+Pure Dart KISS protocol framer (`lib/core/transport/kiss_framer.dart`). Stateful byte accumulator — feed raw bytes via `addBytes`, receive decoded AX.25 payloads on `frames` stream. Static `encode` wraps a payload for transmission. FEND/FESC/TFEND/TFESC constants follow the KISS TNC spec. Shared by both serial and BLE transports.
 
 ### Ax25Parser
 
@@ -247,12 +284,12 @@ Pure Dart AX.25 UI frame byte decoder (`lib/core/ax25/ax25_parser.dart`). Decode
 
 ### TncPreset / TncConfig
 
-- `TncPreset` (`lib/core/transport/tnc_preset.dart`): immutable preset for known TNC hardware (Mobilinkd TNC4 + Custom sentinel). `TncPreset.all` is the full list used by UI dropdowns and is easily extended for v0.4 BLE presets.
+- `TncPreset` (`lib/core/transport/tnc_preset.dart`): immutable preset for known TNC hardware (Mobilinkd TNC4 + Custom sentinel). `TncPreset.all` is the registry used by UI dropdowns.
 - `TncConfig` (`lib/core/transport/tnc_config.dart`): runtime serial + KISS configuration. `fromPreset` factory, `toPrefsMap`/`fromPrefsMap` for SharedPreferences persistence.
 
 ### TncService
 
-`ChangeNotifier` service (`lib/services/tnc_service.dart`) that owns the `SerialKissTransport` lifecycle. Bridges decoded APRS lines into `StationService` via `StationService.ingestLine`. Persists `TncConfig` across restarts. Exposes `connectionState: Stream<ConnectionStatus>`, `currentStatus`, `lastErrorMessage`, and `availablePorts()`.
+`ChangeNotifier` service (`lib/services/tnc_service.dart`) that owns a `TransportManager` internally. On each raw AX.25 frame from `TransportManager.frameStream`, it calls `AprsParser.parseFrame(frameBytes)` and feeds the resulting APRS line to `StationService.ingestLine`. Exposes `connectBle(BluetoothDevice)` for the BLE scanner UI. Persists `TncConfig` across restarts. Exposes `connectionState`, `currentStatus`, `lastErrorMessage`, `availablePorts()`, and `activeTransportType`.
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -261,3 +261,29 @@ A single `ThemeController` manages `themeMode` and `seedColor` as shared state. 
 **Rationale:** `DynamicColorBuilder` returns null schemes on all desktop platforms (Windows, macOS, Linux); the wallpaper color extraction API is Android-only. Previously desktop fell through to the Android branch, which handled null schemes via the seed fallback — functional but implicit. Giving desktop its own explicit branch in `MeridianApp.build()` (`Platform.isWindows || Platform.isMacOS || Platform.isLinux`) makes the three-tier architecture fully explicit and removes the `DynamicColorBuilder` overhead on platforms where it does nothing. The desktop seed color is always `MeridianColors.primary` — there is no user-configurable color picker on desktop (the App Color section in Settings is Android-only).
 
 **Consequences:** The three-tier platform theme architecture is now fully implemented. All three tiers — Android, iOS, Desktop — have dedicated `build*Theme()` functions and explicit platform branches at the app root. `DynamicColorBuilder` is used only in the Android branch.
+
+---
+
+## ADR-019: `KissTncTransport` — raw-frame interface for hardware TNCs (v0.4)
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+**Decision:** Introduced `KissTncTransport` (`lib/core/transport/kiss_tnc_transport.dart`) as the contract for all hardware TNC transports. The interface emits `Stream<Uint8List>` (raw AX.25 bytes, KISS header stripped) rather than decoded APRS lines. APRS parsing (`AprsParser.parseFrame`) was moved from the transport layer into `TncService`.
+
+**Rationale:** Transports should not know about APRS application semantics. A byte-level interface allows both serial and BLE transports to be tested at the framing layer without coupling to APRS logic. It also enables future transports (e.g., TCP KISS, soundcard TNC) to plug in without touching the service layer. `TransportManager` was introduced as the single holder of the active `KissTncTransport`, bridging its streams to callers and managing lifecycle (connect/disconnect, type tracking).
+
+**Consequences:** `SerialKissTransport` now implements `KissTncTransport` (was `AprsTransport`). `TncService` owns a `TransportManager` and an `AprsParser` — it calls `parseFrame(frameBytes)` on each AX.25 frame received from the active transport and feeds the resulting APRS line to `StationService`. The `AprsTransport` interface is now used exclusively by `AprsIsTransport` (APRS-IS over TCP/WebSocket).
+
+---
+
+## ADR-020: BLE chunking via MTU negotiation (v0.4)
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+**Decision:** `BleTncTransport` requests MTU 512 during `connect()`. The effective outgoing chunk size is `max(20, negotiatedMtu - 3)` (subtracting 3 bytes of ATT overhead). If MTU negotiation fails the transport falls back to 20-byte chunks. Outgoing KISS frames are split into MTU-sized chunks and written sequentially with `withoutResponse: false` (write-with-response) for backpressure. Incoming BLE notification chunks are reassembled by the existing `KissFramer` — no new framing logic.
+
+**Rationale:** BLE GATT write operations are bounded by the ATT MTU. Mobilinkd TNC4 supports MTU 512, giving ~509-byte write payloads — large enough for any single AX.25 frame without chunking in practice. The fallback to 20 bytes ensures compatibility with devices that do not negotiate a larger MTU. Using write-with-response prevents flooding the TNC's receive buffer. Reusing `KissFramer` for reassembly means the BLE path has the same reassembly correctness guarantees as the serial path (verified by 23 existing KissFramer tests).
+
+**Consequences:** `BleTncTransport` is the primary TNC transport for iOS and Android. Mobilinkd TNC4 is the primary tested device. `BleDeviceAdapter` (an abstract interface mirroring `SerialPortAdapter`) allows `BleTncTransport` to be unit-tested with a `FakeBleDeviceAdapter` without requiring a physical BLE stack.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,8 +7,8 @@
 | v0.1 — Foundation | Flutter scaffold, map, APRS-IS, station display with symbols | ✅ Complete |
 | v0.2 — Packets | AX.25/APRS parser, packet log, message decoding | ✅ Complete |
 | UI Foundation | Theme system, adaptive scaffold, core widgets, onboarding | ✅ Complete |
-| v0.3 — TNC | KISS over USB serial, desktop first | ▶ In Progress |
-| v0.4 — BLE | KISS over BLE, mobile platforms | ⬜ Planned |
+| v0.3 — TNC | KISS over USB serial, desktop first | ✅ Complete |
+| v0.4 — BLE | KISS over BLE, mobile platforms | ✅ Complete |
 | v0.5 — Beaconing | Transmit path, position beaconing, message sending | ⬜ Planned |
 | v1.0 — Polish | UI refinement, settings, documentation, onboarding | ⬜ Planned |
 
@@ -82,11 +82,20 @@ Goal: Connect to a hardware TNC via KISS over USB serial on desktop.
 
 Goal: Connect to a BLE-capable TNC (e.g. Mobilinkd) on mobile. Extends the `TncPreset` system established in v0.3.
 
-- [ ] BLE transport via `flutter_blue_plus`
-- [ ] BLE device scan and pairing UI
-- [ ] KISS over BLE characteristic read/write
-- [ ] iOS and Android tested
-- [ ] Reconnect handling
+- [x] `KissTncTransport` abstract interface — raw AX.25 byte contract shared by serial and BLE
+- [x] `TransportManager` — lifecycle holder for the active transport; bridges `frameStream` and `connectionState`
+- [x] `SerialKissTransport` refactored to implement `KissTncTransport` (APRS parsing moved to service layer)
+- [x] `BleTncTransport` — BLE KISS TNC via `flutter_blue_plus`; MTU negotiation; KISS chunking; `KissFramer` reassembly
+- [x] `TncService` updated — owns `TransportManager`; parses AX.25 frames via `AprsParser.parseFrame`; exposes `connectBle()`
+- [x] BLE device scan and pairing UI (`BleScannerSheet`)
+- [x] `ConnectionSheet` updated — BLE section for iOS/Android, serial section for desktop
+- [x] `MobileScaffold` — TNC status pill enabled on non-web mobile; dynamic `TransportType` label
+- [x] Settings screen — BLE TNC section for iOS/Android
+- [x] Onboarding — BLE TNC option card enabled on iOS/Android
+- [x] Android BLE permissions (`BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT`, `ACCESS_FINE_LOCATION`)
+- [x] iOS Bluetooth usage descriptions (`NSBluetoothAlwaysUsageDescription`)
+- [x] Tests: `BleTncTransport`, `TransportManager`, `TncService` (141 tests total)
+- [ ] Physical device validation — iOS + Android with Mobilinkd TNC4 (pending hardware test)
 
 ---
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,5 +66,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Meridian APRS uses Bluetooth to connect to a KISS TNC for radio packet reception.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Meridian APRS uses Bluetooth to connect to a KISS TNC for radio packet reception.</string>
 </dict>
 </plist>

--- a/lib/core/ax25/ax25_parser.dart
+++ b/lib/core/ax25/ax25_parser.dart
@@ -65,6 +65,13 @@ class Ax25Parser {
       final pid = bytes[offset + 1];
       final info = bytes.sublist(offset + 2).toList();
 
+      if (control != 0x03 || pid != 0xF0) {
+        return Ax25Err(
+          'Not a UI/APRS frame: control=0x${control.toRadixString(16)}, '
+          'pid=0x${pid.toRadixString(16)}',
+        );
+      }
+
       return Ax25Ok(
         Ax25Frame(
           destination: destination,

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -60,6 +60,10 @@ class PositionPacket extends AprsPacket {
   /// Timestamp encoded inside the APRS info field (not the receive time).
   final DateTime? timestamp;
 
+  /// Human-readable device or software name resolved from the tocall field,
+  /// or null if unknown.
+  final String? device;
+
   const PositionPacket({
     required super.rawLine,
     required super.source,
@@ -77,6 +81,7 @@ class PositionPacket extends AprsPacket {
     this.speed,
     required this.hasMessaging,
     this.timestamp,
+    this.device,
   });
 }
 
@@ -184,6 +189,10 @@ class ObjectPacket extends AprsPacket {
   /// it has been killed (underscore).
   final bool isAlive;
 
+  /// Human-readable device or software name resolved from the tocall field,
+  /// or null if unknown.
+  final String? device;
+
   const ObjectPacket({
     required super.rawLine,
     required super.source,
@@ -198,6 +207,7 @@ class ObjectPacket extends AprsPacket {
     required this.symbolCode,
     required this.comment,
     required this.isAlive,
+    this.device,
   });
 }
 
@@ -218,6 +228,10 @@ class ItemPacket extends AprsPacket {
   /// True when the item is alive (`!`), false when killed (`_`).
   final bool isAlive;
 
+  /// Human-readable device or software name resolved from the tocall field,
+  /// or null if unknown.
+  final String? device;
+
   const ItemPacket({
     required super.rawLine,
     required super.source,
@@ -232,6 +246,7 @@ class ItemPacket extends AprsPacket {
     required this.symbolCode,
     required this.comment,
     required this.isAlive,
+    this.device,
   });
 }
 
@@ -277,6 +292,10 @@ class MicEPacket extends AprsPacket {
   /// (e.g. "En Route", "In Service", "Off Duty").
   final String micEMessage;
 
+  /// Human-readable device or software name resolved from the Mic-E comment
+  /// suffix (e.g. "Kenwood TH-D72A", "Yaesu FT3D series"), or null if unknown.
+  final String? device;
+
   const MicEPacket({
     required super.rawLine,
     required super.source,
@@ -293,6 +312,7 @@ class MicEPacket extends AprsPacket {
     required this.symbolCode,
     required this.comment,
     required this.micEMessage,
+    this.device,
   });
 }
 

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1007,24 +1007,24 @@ class AprsParser {
 
   static const _micEMessages = [
     'Emergency', // 0b000
-    'Priority',  // 0b001
-    'Special',   // 0b010
+    'Priority', // 0b001
+    'Special', // 0b010
     'Committed', // 0b011
     'Returning', // 0b100
     'In Service', // 0b101
-    'En Route',  // 0b110
-    'Off Duty',  // 0b111
+    'En Route', // 0b110
+    'Off Duty', // 0b111
   ];
 
   static const _micECustomMessages = [
     'Emergency', // 0b000 — Emergency regardless of table
-    'Custom-0',  // 0b001
-    'Custom-1',  // 0b010
-    'Custom-2',  // 0b011
-    'Custom-3',  // 0b100
-    'Custom-4',  // 0b101
-    'Custom-5',  // 0b110
-    'Custom-6',  // 0b111
+    'Custom-0', // 0b001
+    'Custom-1', // 0b010
+    'Custom-2', // 0b011
+    'Custom-3', // 0b100
+    'Custom-4', // 0b101
+    'Custom-5', // 0b110
+    'Custom-6', // 0b111
   ];
 
   AprsPacket _parseMicE({
@@ -1096,9 +1096,11 @@ class AprsParser {
 
       latDigits[i] = digit;
       if (i < 3 && msgBit) {
-        if (c >= 0x41 && c <= 0x4A) {      // A-J → Custom message bit
+        if (c >= 0x41 && c <= 0x4A) {
+          // A-J → Custom message bit
           custBits |= (1 << (2 - i));
-        } else if (c >= 0x50 && c <= 0x59) { // P-Y → Standard message bit
+        } else if (c >= 0x50 && c <= 0x59) {
+          // P-Y → Standard message bit
           stdBits |= (1 << (2 - i));
         }
       }
@@ -1182,11 +1184,15 @@ class AprsParser {
       final isBacktick = comment.codeUnitAt(0) == 0x60;
       final hexCount = isBacktick ? 4 : 10;
       if (comment.length > hexCount &&
-          comment.substring(1, hexCount + 1).split('').every(
-            (c) => (c.codeUnitAt(0) >= 0x30 && c.codeUnitAt(0) <= 0x39) ||
-                   (c.codeUnitAt(0) >= 0x41 && c.codeUnitAt(0) <= 0x46) ||
-                   (c.codeUnitAt(0) >= 0x61 && c.codeUnitAt(0) <= 0x66),
-          )) {
+          comment
+              .substring(1, hexCount + 1)
+              .split('')
+              .every(
+                (c) =>
+                    (c.codeUnitAt(0) >= 0x30 && c.codeUnitAt(0) <= 0x39) ||
+                    (c.codeUnitAt(0) >= 0x41 && c.codeUnitAt(0) <= 0x46) ||
+                    (c.codeUnitAt(0) >= 0x61 && c.codeUnitAt(0) <= 0x66),
+              )) {
         // Valid telemetry block — strip flag + hex digits.
         comment = comment.substring(hexCount + 1);
       } else {
@@ -1208,13 +1214,17 @@ class AprsParser {
       final c2 = comment.codeUnitAt(1);
       final c3 = comment.codeUnitAt(2);
       final c4 = comment.codeUnitAt(3);
-      if (c1 >= 0x21 && c1 <= 0x7B &&
-          c2 >= 0x21 && c2 <= 0x7B &&
-          c3 >= 0x21 && c3 <= 0x7B &&
-          c4 == 0x7D) {  // 0x7D = '}'
-        micEAltitude = ((c1 - 33) * 91 * 91 +
-                        (c2 - 33) * 91 +
-                        (c3 - 33) - 10000).toDouble();
+      if (c1 >= 0x21 &&
+          c1 <= 0x7B &&
+          c2 >= 0x21 &&
+          c2 <= 0x7B &&
+          c3 >= 0x21 &&
+          c3 <= 0x7B &&
+          c4 == 0x7D) {
+        // 0x7D = '}'
+        micEAltitude =
+            ((c1 - 33) * 91 * 91 + (c2 - 33) * 91 + (c3 - 33) - 10000)
+                .toDouble();
         comment = comment.substring(4);
       }
     }

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 
 import '../ax25/ax25_parser.dart';
 import 'aprs_packet.dart';
+import 'device_resolver.dart';
 
 /// Full APRS packet parser.
 ///
@@ -130,7 +132,7 @@ class AprsParser {
       );
     }
     final frame = (result as Ax25Ok).frame;
-    final infoStr = utf8.decode(frame.info, allowMalformed: true);
+    final infoStr = latin1.decode(frame.info);
     final pathStr = frame.pathString.isEmpty ? '' : ',${frame.pathString}';
     final reconstructed =
         '${frame.source}>${frame.destination}$pathStr:$infoStr';
@@ -435,6 +437,7 @@ class AprsParser {
       if (c != null && s != null && !(c == 0 && s == 0)) {
         course = c;
         speed = s.toDouble(); // knots
+        comment = comment.substring(csMatch.end);
       }
     }
 
@@ -465,6 +468,7 @@ class AprsParser {
       speed: speed,
       hasMessaging: hasMessaging,
       timestamp: packetTimestamp,
+      device: DeviceResolver.resolve(tocall: destination),
     );
   }
 
@@ -523,8 +527,12 @@ class AprsParser {
     // remainder[2] = compression-type byte.
     int? course;
     double? speed;
+    double? altitude;
     String comment = remainder;
-    if (remainder.length >= 3) {
+    if (remainder.isNotEmpty && remainder.codeUnitAt(0) == 0x20) {
+      // Space c byte: csT bytes carry no data — skip them if present.
+      comment = remainder.length > 3 ? remainder.substring(3) : '';
+    } else if (remainder.length >= 3) {
       final csType = remainder[2].codeUnitAt(0) - 33;
       // Bits 4-5 of csType byte indicate what c and s represent.
       // If bit 5 set: GGA altitude; if bits 4-5 = 01: course/speed.
@@ -534,20 +542,17 @@ class AprsParser {
         final cByte = remainder[0].codeUnitAt(0) - 33;
         final sByte = remainder[1].codeUnitAt(0) - 33;
         final c = cByte * 4; // degrees (0-360 encoded as 0-90 * 4)
-        // Spec: speed = 1.08^sByte - 1 knots. Simplified safe calc:
+        // Spec: speed = 1.08^sByte - 1 knots.
         if (cByte != 0 || sByte != 0) {
           course = c == 360 ? 0 : c;
-          // Compute 1.08^sByte
-          double spd = 0;
-          for (int i = 0; i < sByte; i++) {
-            spd = spd == 0 ? 1.08 : spd * 1.08;
-          }
-          speed = spd - 1;
+          speed = pow(1.08, sByte).toDouble() - 1;
         }
         comment = remainder.length > 3 ? remainder.substring(3) : '';
       } else if (comprType == 2) {
-        // Altitude encoded in cs bytes (1.002^altVal feet).
-        // Skipped for now — advance past the 3 cs bytes.
+        // GGA altitude: 1.002^(cByte*91 + sByte) feet (APRS 1.0.1 ch.9 p.40)
+        final cByte = remainder[0].codeUnitAt(0) - 33;
+        final sByte = remainder[1].codeUnitAt(0) - 33;
+        altitude = pow(1.002, cByte * 91 + sByte).toDouble();
         comment = remainder.length > 3 ? remainder.substring(3) : '';
       }
     }
@@ -564,11 +569,12 @@ class AprsParser {
       symbolTable: symbolTable,
       symbolCode: symbolCode,
       comment: comment,
-      altitude: null,
+      altitude: altitude,
       course: course,
       speed: speed,
       hasMessaging: hasMessaging,
       timestamp: packetTimestamp,
+      device: DeviceResolver.resolve(tocall: destination),
     );
   }
 
@@ -666,6 +672,7 @@ class AprsParser {
       symbolCode: m.group(6)!,
       comment: m.group(7)!,
       isAlive: isAlive,
+      device: DeviceResolver.resolve(tocall: destination),
     );
   }
 
@@ -726,6 +733,7 @@ class AprsParser {
       symbolCode: symbolCode,
       comment: comment,
       isAlive: isAlive,
+      device: DeviceResolver.resolve(tocall: destination),
     );
   }
 
@@ -760,7 +768,7 @@ class AprsParser {
     final nameField = info.substring(1);
     int delimIdx = -1;
     bool isAlive = true;
-    for (int i = 2; i < nameField.length && i <= 9; i++) {
+    for (int i = 3; i < nameField.length && i <= 9; i++) {
       if (nameField[i] == '!' || nameField[i] == '_') {
         delimIdx = i;
         isAlive = nameField[i] == '!';
@@ -812,6 +820,7 @@ class AprsParser {
       symbolCode: m.group(6)!,
       comment: m.group(7)!,
       isAlive: isAlive,
+      device: DeviceResolver.resolve(tocall: destination),
     );
   }
 
@@ -1007,6 +1016,17 @@ class AprsParser {
     'Off Duty',  // 0b111
   ];
 
+  static const _micECustomMessages = [
+    'Emergency', // 0b000 — Emergency regardless of table
+    'Custom-0',  // 0b001
+    'Custom-1',  // 0b010
+    'Custom-2',  // 0b011
+    'Custom-3',  // 0b100
+    'Custom-4',  // 0b101
+    'Custom-5',  // 0b110
+    'Custom-6',  // 0b111
+  ];
+
   AprsPacket _parseMicE({
     required String info,
     required String rawLine,
@@ -1032,8 +1052,8 @@ class AprsParser {
     // Decode latitude and message bits from destination chars 0-5.
     // Each char encodes one BCD digit of latitude (0-9) and flags.
     // Three character sets encode a digit with message bit set:
-    //   'A'-'J' (0x41-0x4A): standard message, digits 0-9
-    //   'P'-'Y' (0x50-0x59): custom message, digits 0-9
+    //   'A'-'J' (0x41-0x4A): custom message bit, digits 0-9
+    //   'P'-'Y' (0x50-0x59): standard message bit, digits 0-9
     // '0'-'9': standard digit, message bit clear.
     // 'K', 'L', 'Z': ambiguous position placeholder, digit=0, message bit clear.
     // N/S: char 3, letter (msgBit set) = North, digit = South.
@@ -1041,7 +1061,8 @@ class AprsParser {
     // E/W: char 5, letter (msgBit set) = West, digit = East.
     final dest = destination;
     final latDigits = List<int>.filled(6, 0);
-    int messageBits = 0;
+    int stdBits = 0;
+    int custBits = 0;
     bool isNorth = false;
     bool addLonOffset = false;
     bool isWest = false;
@@ -1056,7 +1077,7 @@ class AprsParser {
         digit = c - 0x30;
         msgBit = false;
       } else if (c >= 0x41 && c <= 0x4A) {
-        // 'A'-'J': digits 0-9 with message bit set (standard message)
+        // 'A'-'J': digits 0-9 with message bit set (custom message)
         digit = c - 0x41;
         msgBit = true;
       } else if (c == 0x4B || c == 0x4C || c == 0x5A) {
@@ -1064,7 +1085,7 @@ class AprsParser {
         digit = 0;
         msgBit = false;
       } else if (c >= 0x50 && c <= 0x59) {
-        // 'P'-'Y': digits 0-9 with message bit set (custom message)
+        // 'P'-'Y': digits 0-9 with message bit set (standard message)
         digit = c - 0x50;
         msgBit = true;
       } else {
@@ -1074,7 +1095,13 @@ class AprsParser {
       }
 
       latDigits[i] = digit;
-      if (i < 3 && msgBit) messageBits |= (1 << (2 - i));
+      if (i < 3 && msgBit) {
+        if (c >= 0x41 && c <= 0x4A) {      // A-J → Custom message bit
+          custBits |= (1 << (2 - i));
+        } else if (c >= 0x50 && c <= 0x59) { // P-Y → Standard message bit
+          stdBits |= (1 << (2 - i));
+        }
+      }
 
       // Flag bits from specific positions.
       if (i == 3) isNorth = msgBit; // letter = North
@@ -1134,21 +1161,120 @@ class AprsParser {
     final symbolCode = info.length > 7 ? info[7] : '>';
     final symbolTable = info.length > 8 ? info[8] : '/';
 
-    // Comment (everything after the 9 fixed bytes, excluding any telemetry prefix)
+    // Comment (everything after the 9 fixed bytes).
     var comment = info.length > 9 ? info.substring(9) : '';
-    // Strip leading Mic-E telemetry sequence indicators if present.
-    if (comment.startsWith("'") ||
-        comment.startsWith('`') ||
-        comment.startsWith('"')) {
-      // Optional status/telemetry text marker — leave it in comment as-is.
+
+    // Strip telemetry prefix / device-type prefix from the Mic-E comment.
+    //
+    // APRS 1.0.1 ch.10 p.54 defines two telemetry flag bytes:
+    //   0x60 (`) = 2-channel telemetry: flag + 4 printable hex digits → strip 5
+    //   0x27 (') = 5-channel telemetry: flag + 10 printable hex digits → strip 11
+    //
+    // Crucially, the hex digits that follow MUST be [0-9a-fA-F]. When they are
+    // not (e.g. the FT3DR uses backtick as a 1-byte device-type prefix followed
+    // by plain user text), only the flag byte itself is stripped.
+    //
+    // This matches the behaviour of aprslib (regex '^(`[0-9a-f]{4}|\'[0-9a-f]{10})')
+    // and Dire Wolf's deviceid_decode_mice(), which all other popular APRS
+    // clients follow — they never cut characters from a user comment.
+    if (comment.isNotEmpty &&
+        (comment.codeUnitAt(0) == 0x60 || comment.codeUnitAt(0) == 0x27)) {
+      final isBacktick = comment.codeUnitAt(0) == 0x60;
+      final hexCount = isBacktick ? 4 : 10;
+      if (comment.length > hexCount &&
+          comment.substring(1, hexCount + 1).split('').every(
+            (c) => (c.codeUnitAt(0) >= 0x30 && c.codeUnitAt(0) <= 0x39) ||
+                   (c.codeUnitAt(0) >= 0x41 && c.codeUnitAt(0) <= 0x46) ||
+                   (c.codeUnitAt(0) >= 0x61 && c.codeUnitAt(0) <= 0x66),
+          )) {
+        // Valid telemetry block — strip flag + hex digits.
+        comment = comment.substring(hexCount + 1);
+      } else {
+        // Not valid hex telemetry — backtick/apostrophe is a device-type prefix.
+        // Strip only 1 byte.
+        comment = comment.substring(1);
+      }
+    }
+    // Trim leading whitespace after prefix removal.
+    comment = comment.trimLeft();
+
+    // Base-91 altitude in Mic-E comment (APRS 1.0.1 ch.10 p.55):
+    // Three base-91 chars [!-{] followed by '}' encode altitude.
+    // altitude_feet = (c1-33)*91² + (c2-33)*91 + (c3-33) - 10000
+    // Checked before Yaesu block stripping because both start with 0x22.
+    double? micEAltitude;
+    if (comment.length >= 4) {
+      final c1 = comment.codeUnitAt(0);
+      final c2 = comment.codeUnitAt(1);
+      final c3 = comment.codeUnitAt(2);
+      final c4 = comment.codeUnitAt(3);
+      if (c1 >= 0x21 && c1 <= 0x7B &&
+          c2 >= 0x21 && c2 <= 0x7B &&
+          c3 >= 0x21 && c3 <= 0x7B &&
+          c4 == 0x7D) {  // 0x7D = '}'
+        micEAltitude = ((c1 - 33) * 91 * 91 +
+                        (c2 - 33) * 91 +
+                        (c3 - 33) - 10000).toDouble();
+        comment = comment.substring(4);
+      }
     }
 
-    // Mic-E message from the 3 message bits (standard messages).
+    // Yaesu proprietary block: starts with 0x22 (") and is terminated by
+    // the first '}' character.  Only reached if the altitude check above did
+    // not consume a 4-char block ending in '}'.
+    if (comment.isNotEmpty && comment.codeUnitAt(0) == 0x22) {
+      final closeIdx = comment.indexOf('}');
+      if (closeIdx >= 0) {
+        comment = comment.substring(closeIdx + 1);
+      } else if (comment.length >= 3) {
+        comment = comment.substring(3);
+      } else {
+        comment = '';
+      }
+    }
+
+    // Trim both ends before suffix detection so that a trailing space in the
+    // info field (common on Yaesu radios) doesn't prevent `_\d$` from matching.
+    comment = comment.trim();
+
+    // Resolve device from comment suffix before stripping the suffix.
+    final device = DeviceResolver.resolve(micECommentSuffix: comment);
+
+    // Strip device-indicator suffixes from the comment.
+    if (comment.endsWith(']=')) {
+      comment = comment.substring(0, comment.length - 2);
+    } else if (comment.endsWith(']\x22')) {
+      comment = comment.substring(0, comment.length - 2);
+    } else if (comment.endsWith(']') ||
+        comment.endsWith('^') ||
+        comment.endsWith('~')) {
+      comment = comment.substring(0, comment.length - 1);
+    } else if (_micEFt3dRe.hasMatch(comment)) {
+      // Strip trailing _\d
+      comment = comment.substring(0, comment.length - 2);
+    } else {
+      // Check for generic > suffix: strip from last > onward if valid.
+      final gtIdx = comment.lastIndexOf('>');
+      if (gtIdx >= 0 && gtIdx < comment.length - 1) {
+        final suffix = comment.substring(gtIdx + 1);
+        if (_micEGenericSuffixRe.hasMatch(suffix)) {
+          comment = comment.substring(0, gtIdx);
+        }
+      }
+    }
+    // Mic-E message from the 3 message bits.
     // Bits 2-0: A B C where A is most significant.
-    // Values 0-7 map to the 8 standard messages.
-    final micEMsg = _micEMessages.length > messageBits
-        ? _micEMessages[messageBits]
-        : 'Custom';
+    // stdBits accumulate P-Y chars, custBits accumulate A-J chars.
+    final String micEMsg;
+    if (stdBits == 0 && custBits == 0) {
+      micEMsg = 'Emergency';
+    } else if (stdBits > 0 && custBits > 0) {
+      micEMsg = 'Unknown';
+    } else if (stdBits > 0) {
+      micEMsg = _micEMessages[stdBits];
+    } else {
+      micEMsg = _micECustomMessages[custBits];
+    }
 
     return MicEPacket(
       rawLine: rawLine,
@@ -1159,14 +1285,21 @@ class AprsParser {
       transportSource: transportSource,
       lat: lat,
       lon: lon,
+      altitude: micEAltitude,
       course: course == 0 ? null : course,
       speed: speedKnots.toDouble(),
       symbolTable: symbolTable,
       symbolCode: symbolCode,
       comment: comment.trim(),
       micEMessage: micEMsg,
+      device: device,
     );
   }
+
+  // Regexes reused in Mic-E comment suffix stripping (mirrors DeviceResolver).
+  static final _micEFt3dRe = RegExp(r'_\d$');
+  // Alphanumeric only — prevents false positives on user comments containing '>'.
+  static final _micEGenericSuffixRe = RegExp(r'^[A-Za-z0-9]{2,10}$');
 
   // ---------------------------------------------------------------------------
   // Timestamp helpers

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -997,14 +997,14 @@ class AprsParser {
   // header parser as [destination].
 
   static const _micEMessages = [
-    'Off Duty',
-    'En Route',
-    'In Service',
-    'Returning',
-    'Committed',
-    'Special',
-    'Priority',
-    'Emergency',
+    'Emergency', // 0b000
+    'Priority',  // 0b001
+    'Special',   // 0b010
+    'Committed', // 0b011
+    'Returning', // 0b100
+    'In Service', // 0b101
+    'En Route',  // 0b110
+    'Off Duty',  // 0b111
   ];
 
   AprsPacket _parseMicE({
@@ -1031,11 +1031,14 @@ class AprsParser {
 
     // Decode latitude and message bits from destination chars 0-5.
     // Each char encodes one BCD digit of latitude (0-9) and flags.
-    // Digits: 0-9 → '0'-'9', space → ambiguous 0. A-J → 0-9 (message bit set).
-    // K, L, Z → 0 (with flag bits).
-    // N/S: char 3, 0 = North if digit is a letter (A-K), South otherwise.
-    // Lon offset: char 4, if letter add 100 to lon degrees.
-    // E/W: char 5, if letter West else East.
+    // Three character sets encode a digit with message bit set:
+    //   'A'-'J' (0x41-0x4A): standard message, digits 0-9
+    //   'P'-'Y' (0x50-0x59): custom message, digits 0-9
+    // '0'-'9': standard digit, message bit clear.
+    // 'K', 'L', 'Z': ambiguous position placeholder, digit=0, message bit clear.
+    // N/S: char 3, letter (msgBit set) = North, digit = South.
+    // Lon offset: char 4, letter (msgBit set) = +100 lon degrees.
+    // E/W: char 5, letter (msgBit set) = West, digit = East.
     final dest = destination;
     final latDigits = List<int>.filled(6, 0);
     int messageBits = 0;
@@ -1049,20 +1052,20 @@ class AprsParser {
       bool msgBit = false;
 
       if (c >= 0x30 && c <= 0x39) {
-        // '0'-'9': standard digit, message bit 0
+        // '0'-'9': standard digit, message bit clear
         digit = c - 0x30;
         msgBit = false;
-      } else if (c >= 0x41 && c <= 0x4B) {
-        // 'A'-'K': digit 0-9 with message bit set (custom message)
+      } else if (c >= 0x41 && c <= 0x4A) {
+        // 'A'-'J': digits 0-9 with message bit set (standard message)
         digit = c - 0x41;
         msgBit = true;
-      } else if (c == 0x4C || c == 0x5A) {
-        // 'L' or 'Z': 0, no message bit (ambiguous position)
+      } else if (c == 0x4B || c == 0x4C || c == 0x5A) {
+        // 'K', 'L', or 'Z': ambiguous position, digit=0, message bit clear
         digit = 0;
         msgBit = false;
-      } else if (c == 0x50) {
-        // 'P': space → 0 (some implementations)
-        digit = 0;
+      } else if (c >= 0x50 && c <= 0x59) {
+        // 'P'-'Y': digits 0-9 with message bit set (custom message)
+        digit = c - 0x50;
         msgBit = true;
       } else {
         // Space or other

--- a/lib/core/packet/device_resolver.dart
+++ b/lib/core/packet/device_resolver.dart
@@ -1,0 +1,109 @@
+/// Resolves a human-readable device or software name from APRS tocall fields
+/// and Mic-E comment suffixes.
+///
+/// All methods are static. No state is held.
+class DeviceResolver {
+  DeviceResolver._();
+
+  // Sorted longest-prefix-first so the first match wins.
+  static const _tocallTable = [
+    ('APZMAJ', 'Xastir'),
+    ('APFII', 'iPhone app (APRS.fi)'),
+    ('APKRAM', 'KRAMsoftware'),
+    ('APAGW', 'AGWTracker'),
+    ('APBM', 'BrandMeister gateway'),
+    ('APHBL', 'HamBLNY'),
+    ('APMI0', 'Micro-Trak RTG'),
+    ('APAND', 'APRSdroid'),
+    ('APOLU', 'OSCAR satellite'),
+    ('APNL', 'D-Star island'),
+    ('APAT', 'AnyTone'),
+    ('APTT4', 'TinyTrak4'),
+    ('APTT', 'TinyTrak'),
+    ('APRX', 'aprx iGate'),
+    ('APWW', 'UI-View32'),
+    ('APDW', 'Dire Wolf'),
+    ('APDR', 'APRSdroid'),
+    ('APLM', 'WIDEn-n digipeater'),
+    ('APMI', 'Micro-Trak'),
+    ('APK0', 'Kenwood TH-D7A'),
+    ('APK1', 'Kenwood TM-D700'),
+    ('APXR', 'Xrouter'),
+    ('APN3', 'Kantronics KPC-3'),
+    ('APN9', 'Kantronics KPC-9612'),
+    ('APNP', 'TNC2 clone'),
+    ('APNT', 'TNT TNC'),
+    ('APNW', 'WB4IHY TNC'),
+    ('APNX', 'KPC3 clone'),
+    ('APOA', 'Open APRS'),
+    ('APHYA', 'Yaesu FT1D'),
+    ('APOT', 'OpenTracker'),
+    ('APRS', 'APRS (generic)'),
+    ('APYE', 'Yaesu FT2D'),
+    ('APY', 'Yaesu (FTM/FT-series)'),
+  ];
+
+  // Regex for valid generic > suffix: alphanumeric only, length 2-10.
+  // Restricted to [A-Za-z0-9] to prevent false positives on user comments
+  // that happen to contain '>'.  Device identifiers are always alphanumeric
+  // in practice (e.g. FT3DR, FTM400, TINYTRK).
+  static final _genericSuffixRe = RegExp(r'^[A-Za-z0-9]{2,10}$');
+
+  // Regex for Yaesu FT3D series: trailing _\d (e.g. `_0`, `_1`).
+  // Known limitation: this pattern will false-positive on user comments that
+  // happen to end in `_0`–`_9` (e.g. "grid_0").  This is an accepted
+  // trade-off given how rare such comment endings are in practice.
+  static final _ft3dRe = RegExp(r'_\d$');
+
+  /// Returns a human-readable device/software name for an APRS station,
+  /// or null if the device cannot be identified.
+  ///
+  /// [tocall] is the destination field from the APRS header (e.g. "APDR16",
+  /// "APK004"). Used for non-Mic-E packets.
+  ///
+  /// [micECommentSuffix] is the raw comment suffix extracted from a Mic-E
+  /// packet AFTER stripping the telemetry prefix. Pass null for non-Mic-E
+  /// packets.
+  static String? resolve({String? tocall, String? micECommentSuffix}) {
+    if (micECommentSuffix != null) {
+      return _resolveMicESuffix(micECommentSuffix);
+    }
+    if (tocall != null && tocall.isNotEmpty) {
+      return _resolveTocall(tocall);
+    }
+    return null;
+  }
+
+  static String? _resolveTocall(String tocall) {
+    // Strip any trailing SSID (-N) before matching.
+    final ssidIdx = tocall.lastIndexOf('-');
+    final base = ssidIdx >= 0 ? tocall.substring(0, ssidIdx) : tocall;
+    final upper = base.toUpperCase();
+
+    for (final (prefix, device) in _tocallTable) {
+      if (upper.startsWith(prefix)) return device;
+    }
+    return null;
+  }
+
+  static String? _resolveMicESuffix(String comment) {
+    if (comment.isEmpty) return null;
+
+    // Check in order — longest/most-specific suffixes first.
+    if (comment.endsWith(']=')) return 'Kenwood TH-D72A';
+    if (comment.endsWith(']\x22')) return 'Kenwood TM-D710';
+    if (comment.endsWith(']')) return 'Kenwood (TH-D7x/TM-D7x)';
+    if (comment.endsWith('^')) return 'Yaesu VX-8';
+    if (comment.endsWith('~')) return 'Yaesu FT2D';
+    if (_ft3dRe.hasMatch(comment)) return 'Yaesu FT3D series';
+
+    // Generic > suffix: everything after the last >.
+    final gtIdx = comment.lastIndexOf('>');
+    if (gtIdx >= 0 && gtIdx < comment.length - 1) {
+      final suffix = comment.substring(gtIdx + 1);
+      if (_genericSuffixRe.hasMatch(suffix)) return suffix;
+    }
+
+    return null;
+  }
+}

--- a/lib/core/packet/station.dart
+++ b/lib/core/packet/station.dart
@@ -8,6 +8,10 @@ class Station {
   final String symbolCode;
   final String comment;
 
+  /// Human-readable device or software name (e.g. "APRSdroid", "Dire Wolf"),
+  /// or null if not resolved.
+  final String? device;
+
   const Station({
     required this.callsign,
     required this.lat,
@@ -17,6 +21,7 @@ class Station {
     required this.symbolTable,
     required this.symbolCode,
     required this.comment,
+    this.device,
   });
 
   /// Backward-compat alias for [lastHeard].

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -104,6 +104,7 @@ class AprsIsTransport implements AprsTransport {
 
   /// Permanently shut down this transport and release all resources.
   /// Call this only when the owning service is being destroyed.
+  @override
   Future<void> dispose() async {
     await disconnect();
     await _controller.close();

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -21,6 +21,10 @@ class AprsIsTransport implements AprsTransport {
   });
 
   Socket? _socket;
+  StreamSubscription? _socketSubscription;
+
+  // These controllers live for the lifetime of the transport instance — they
+  // are never closed by a connection drop, only by an explicit dispose().
   final _controller = StreamController<String>.broadcast();
   final _stateController = StreamController<ConnectionStatus>.broadcast();
   ConnectionStatus _currentStatus = ConnectionStatus.disconnected;
@@ -34,6 +38,12 @@ class AprsIsTransport implements AprsTransport {
   @override
   ConnectionStatus get currentStatus => _currentStatus;
 
+  // Emit a state change, guarded so it is safe to call after dispose().
+  void _emitState(ConnectionStatus s) {
+    _currentStatus = s;
+    if (!_stateController.isClosed) _stateController.add(s);
+  }
+
   @override
   Future<void> connect() async {
     assert(
@@ -41,34 +51,39 @@ class AprsIsTransport implements AprsTransport {
       'AprsIsTransport uses dart:io and cannot run on web. '
       'Implement WebSocketTransport per ADR-004.',
     );
-    _currentStatus = ConnectionStatus.connecting;
-    _stateController.add(ConnectionStatus.connecting);
+
+    // Cancel any in-flight subscription from a previous connect() call.
+    await _socketSubscription?.cancel();
+    _socketSubscription = null;
+
+    _emitState(ConnectionStatus.connecting);
     try {
       _socket = await Socket.connect(host, port);
       _socket!.write(loginLine);
       if (filterLine != null) _socket!.write(filterLine);
-      _currentStatus = ConnectionStatus.connected;
-      _stateController.add(ConnectionStatus.connected);
-      _socket!
+      _emitState(ConnectionStatus.connected);
+
+      _socketSubscription = _socket!
           .cast<List<int>>()
           .transform(utf8.decoder)
           .transform(const LineSplitter())
           .listen(
-            _controller.add,
-            onError: (e) {
-              _currentStatus = ConnectionStatus.disconnected;
-              _stateController.add(ConnectionStatus.disconnected);
-              _controller.addError(e);
+            (line) {
+              if (!_controller.isClosed) _controller.add(line);
+            },
+            onError: (Object e) {
+              // Connection dropped with an error. Update state; do NOT
+              // propagate the error onto _controller — unhandled broadcast
+              // errors crash the app. The caller observes the state change.
+              _emitState(ConnectionStatus.disconnected);
             },
             onDone: () {
-              _currentStatus = ConnectionStatus.disconnected;
-              _stateController.add(ConnectionStatus.disconnected);
-              _controller.close();
+              _emitState(ConnectionStatus.disconnected);
             },
+            cancelOnError: true,
           );
     } catch (e) {
-      _currentStatus = ConnectionStatus.disconnected;
-      _stateController.add(ConnectionStatus.disconnected);
+      _emitState(ConnectionStatus.disconnected);
       rethrow;
     }
   }
@@ -78,8 +93,20 @@ class AprsIsTransport implements AprsTransport {
 
   @override
   Future<void> disconnect() async {
+    // Cancel the subscription before closing the socket so that onDone /
+    // onError callbacks do not fire after we have already updated state here.
+    await _socketSubscription?.cancel();
+    _socketSubscription = null;
     await _socket?.close();
     _socket = null;
+    _emitState(ConnectionStatus.disconnected);
+  }
+
+  /// Permanently shut down this transport and release all resources.
+  /// Call this only when the owning service is being destroyed.
+  Future<void> dispose() async {
+    await disconnect();
+    await _controller.close();
     await _stateController.close();
   }
 }

--- a/lib/core/transport/aprs_transport.dart
+++ b/lib/core/transport/aprs_transport.dart
@@ -18,6 +18,11 @@ abstract class AprsTransport {
   Future<void> connect();
   Future<void> disconnect();
 
+  /// Permanently release all resources (stream controllers, subscriptions).
+  /// Call only when the owning service is being destroyed.
+  /// Default implementation delegates to [disconnect].
+  Future<void> dispose() => disconnect();
+
   /// Send a raw line to the server (e.g. a new #filter command).
   void sendLine(String line);
 }

--- a/lib/core/transport/ble_constants.dart
+++ b/lib/core/transport/ble_constants.dart
@@ -1,0 +1,7 @@
+/// Mobilinkd UART-over-BLE GATT service UUID constants.
+///
+/// These are public so they can be used by both the transport implementation
+/// and UI code (e.g., BLE scanner filtering by service UUID).
+const kMobilinkdServiceUuid = '00000001-ba2a-46c9-ae49-01b0961f68bb';
+const kMobilinkdTxCharUuid = '00000003-ba2a-46c9-ae49-01b0961f68bb'; // notify
+const kMobilinkdRxCharUuid = '00000002-ba2a-46c9-ae49-01b0961f68bb'; // write

--- a/lib/core/transport/ble_tnc_transport.dart
+++ b/lib/core/transport/ble_tnc_transport.dart
@@ -1,0 +1,2 @@
+export 'ble_tnc_transport_stub.dart'
+    if (dart.library.io) 'ble_tnc_transport_impl.dart';

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -36,8 +36,10 @@ class DefaultBleDeviceAdapter implements BleDeviceAdapter {
   final BluetoothDevice _device;
 
   @override
-  Future<void> connect({int? mtu, Duration timeout = const Duration(seconds: 15)}) =>
-      _device.connect(mtu: mtu, timeout: timeout, autoConnect: false);
+  Future<void> connect({
+    int? mtu,
+    Duration timeout = const Duration(seconds: 15),
+  }) => _device.connect(mtu: mtu, timeout: timeout, autoConnect: false);
 
   @override
   Future<void> disconnect() => _device.disconnect();
@@ -49,10 +51,12 @@ class DefaultBleDeviceAdapter implements BleDeviceAdapter {
   int get mtu => _device.mtuNow;
 
   @override
-  Future<List<BluetoothService>> discoverServices() => _device.discoverServices();
+  Future<List<BluetoothService>> discoverServices() =>
+      _device.discoverServices();
 
   @override
-  Stream<BluetoothConnectionState> get connectionState => _device.connectionState;
+  Stream<BluetoothConnectionState> get connectionState =>
+      _device.connectionState;
 
   @override
   String get platformName => _device.platformName;
@@ -82,10 +86,10 @@ class BleTncTransport implements KissTncTransport {
     String serviceUuid = kMobilinkdServiceUuid,
     String txCharUuid = kMobilinkdTxCharUuid,
     String rxCharUuid = kMobilinkdRxCharUuid,
-  })  : _adapter = adapter ?? DefaultBleDeviceAdapter(device),
-        _serviceUuid = serviceUuid,
-        _txCharUuid = txCharUuid,
-        _rxCharUuid = rxCharUuid;
+  }) : _adapter = adapter ?? DefaultBleDeviceAdapter(device),
+       _serviceUuid = serviceUuid,
+       _txCharUuid = txCharUuid,
+       _rxCharUuid = rxCharUuid;
 
   final BleDeviceAdapter _adapter;
   final String _serviceUuid;
@@ -135,9 +139,13 @@ class BleTncTransport implements KissTncTransport {
         final negotiated = await _adapter.requestMtu(512);
         // ATT overhead is 3 bytes; subtract to get usable payload bytes.
         _mtu = max(20, negotiated - 3);
-        debugPrint('BleTncTransport: MTU negotiated $negotiated, using $_mtu byte chunks');
+        debugPrint(
+          'BleTncTransport: MTU negotiated $negotiated, using $_mtu byte chunks',
+        );
       } catch (e) {
-        debugPrint('BleTncTransport: MTU negotiation failed, using 20-byte fallback: $e');
+        debugPrint(
+          'BleTncTransport: MTU negotiation failed, using 20-byte fallback: $e',
+        );
         _mtu = 20;
       }
 
@@ -148,7 +156,9 @@ class BleTncTransport implements KissTncTransport {
           services = await _adapter.discoverServices();
           break;
         } catch (e) {
-          debugPrint('BleTncTransport: discoverServices attempt $attempt failed: $e');
+          debugPrint(
+            'BleTncTransport: discoverServices attempt $attempt failed: $e',
+          );
           if (attempt == 3) rethrow;
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
@@ -156,7 +166,9 @@ class BleTncTransport implements KissTncTransport {
 
       // 4. Find the TNC GATT service.
       final targetServiceGuid = Guid(_serviceUuid);
-      final service = services!.where((s) => s.serviceUuid == targetServiceGuid).firstOrNull;
+      final service = services!
+          .where((s) => s.serviceUuid == targetServiceGuid)
+          .firstOrNull;
       if (service == null) {
         throw Exception(
           'BleTncTransport: service $_serviceUuid not found on ${_adapter.platformName}. '
@@ -167,8 +179,12 @@ class BleTncTransport implements KissTncTransport {
       // 5. Find TX (notify) and RX (write) characteristics.
       final txGuid = Guid(_txCharUuid);
       final rxGuid = Guid(_rxCharUuid);
-      _txChar = service.characteristics.where((c) => c.characteristicUuid == txGuid).firstOrNull;
-      _rxChar = service.characteristics.where((c) => c.characteristicUuid == rxGuid).firstOrNull;
+      _txChar = service.characteristics
+          .where((c) => c.characteristicUuid == txGuid)
+          .firstOrNull;
+      _rxChar = service.characteristics
+          .where((c) => c.characteristicUuid == rxGuid)
+          .firstOrNull;
 
       if (_txChar == null || _rxChar == null) {
         throw Exception(
@@ -244,7 +260,9 @@ class BleTncTransport implements KissTncTransport {
   void _onBleConnectionState(BluetoothConnectionState state) {
     if (state == BluetoothConnectionState.disconnected &&
         _status == ConnectionStatus.connected) {
-      debugPrint('BleTncTransport: unexpected disconnect from ${_adapter.platformName}');
+      debugPrint(
+        'BleTncTransport: unexpected disconnect from ${_adapter.platformName}',
+      );
       _status = ConnectionStatus.error;
       _stateController.add(ConnectionStatus.error);
       _cleanupSubscriptions();

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -1,0 +1,267 @@
+library;
+
+import 'dart:async';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'ble_constants.dart';
+import 'kiss_framer.dart';
+import 'kiss_tnc_transport.dart';
+
+// ---------------------------------------------------------------------------
+// Testability abstraction
+// ---------------------------------------------------------------------------
+
+/// Thin wrapper around a [BluetoothDevice] for test injection.
+///
+/// Production code uses [DefaultBleDeviceAdapter]. Tests inject a fake.
+abstract interface class BleDeviceAdapter {
+  Future<void> connect({int? mtu, Duration timeout});
+  Future<void> disconnect();
+  Future<int> requestMtu(int desired);
+  int get mtu;
+  Future<List<BluetoothService>> discoverServices();
+  Stream<BluetoothConnectionState> get connectionState;
+  String get platformName;
+}
+
+/// Production [BleDeviceAdapter] backed by a [BluetoothDevice].
+class DefaultBleDeviceAdapter implements BleDeviceAdapter {
+  DefaultBleDeviceAdapter(this._device);
+
+  final BluetoothDevice _device;
+
+  @override
+  Future<void> connect({int? mtu, Duration timeout = const Duration(seconds: 15)}) =>
+      _device.connect(mtu: mtu, timeout: timeout, autoConnect: false);
+
+  @override
+  Future<void> disconnect() => _device.disconnect();
+
+  @override
+  Future<int> requestMtu(int desired) => _device.requestMtu(desired);
+
+  @override
+  int get mtu => _device.mtuNow;
+
+  @override
+  Future<List<BluetoothService>> discoverServices() => _device.discoverServices();
+
+  @override
+  Stream<BluetoothConnectionState> get connectionState => _device.connectionState;
+
+  @override
+  String get platformName => _device.platformName;
+}
+
+// ---------------------------------------------------------------------------
+// BleTncTransport
+// ---------------------------------------------------------------------------
+
+/// BLE KISS TNC transport.
+///
+/// Implements [KissTncTransport], emitting raw AX.25 frame payloads on
+/// [frameStream]. Connects to Mobilinkd-compatible BLE TNCs via a UART-
+/// over-BLE GATT service.
+///
+/// Connection flow:
+///   scan → connect → requestMtu → discoverServices
+///   → subscribe to TX characteristic → ready
+///
+/// Incoming BLE chunks are reassembled into complete KISS frames by the
+/// existing [KissFramer]. Outgoing frames are KISS-encoded and split into
+/// MTU-sized chunks before writing to the RX characteristic.
+class BleTncTransport implements KissTncTransport {
+  BleTncTransport(
+    BluetoothDevice device, {
+    BleDeviceAdapter? adapter,
+    String serviceUuid = kMobilinkdServiceUuid,
+    String txCharUuid = kMobilinkdTxCharUuid,
+    String rxCharUuid = kMobilinkdRxCharUuid,
+  })  : _adapter = adapter ?? DefaultBleDeviceAdapter(device),
+        _serviceUuid = serviceUuid,
+        _txCharUuid = txCharUuid,
+        _rxCharUuid = rxCharUuid;
+
+  final BleDeviceAdapter _adapter;
+  final String _serviceUuid;
+  final String _txCharUuid;
+  final String _rxCharUuid;
+
+  // Effective MTU for outgoing chunk size (payload bytes, not ATT frame size).
+  int _mtu = 20;
+
+  final _kissFramer = KissFramer();
+  StreamSubscription<Uint8List>? _framesSub;
+  StreamSubscription<List<int>>? _notifySub;
+  StreamSubscription<BluetoothConnectionState>? _connStateSub;
+
+  BluetoothCharacteristic? _txChar;
+  BluetoothCharacteristic? _rxChar;
+
+  final _framesController = StreamController<Uint8List>.broadcast();
+  final _stateController = StreamController<ConnectionStatus>.broadcast();
+  ConnectionStatus _status = ConnectionStatus.disconnected;
+
+  @override
+  Stream<Uint8List> get frameStream => _framesController.stream;
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  @override
+  ConnectionStatus get currentStatus => _status;
+
+  @override
+  bool get isConnected => _status == ConnectionStatus.connected;
+
+  @override
+  Future<void> connect() async {
+    _setStatus(ConnectionStatus.connecting);
+    try {
+      // 1. Connect to the device.
+      await _adapter.connect(
+        mtu: 512, // Android: negotiate MTU during connect. No-op on iOS.
+        timeout: const Duration(seconds: 15),
+      );
+
+      // 2. On iOS the MTU is negotiated by CoreBluetooth automatically.
+      //    On other platforms, request explicitly after connect.
+      try {
+        final negotiated = await _adapter.requestMtu(512);
+        // ATT overhead is 3 bytes; subtract to get usable payload bytes.
+        _mtu = max(20, negotiated - 3);
+        debugPrint('BleTncTransport: MTU negotiated $negotiated, using $_mtu byte chunks');
+      } catch (e) {
+        debugPrint('BleTncTransport: MTU negotiation failed, using 20-byte fallback: $e');
+        _mtu = 20;
+      }
+
+      // 3. Discover services (retry up to 3× — Android can fail immediately).
+      List<BluetoothService>? services;
+      for (int attempt = 1; attempt <= 3; attempt++) {
+        try {
+          services = await _adapter.discoverServices();
+          break;
+        } catch (e) {
+          debugPrint('BleTncTransport: discoverServices attempt $attempt failed: $e');
+          if (attempt == 3) rethrow;
+          await Future<void>.delayed(const Duration(milliseconds: 500));
+        }
+      }
+
+      // 4. Find the TNC GATT service.
+      final targetServiceGuid = Guid(_serviceUuid);
+      final service = services!.where((s) => s.serviceUuid == targetServiceGuid).firstOrNull;
+      if (service == null) {
+        throw Exception(
+          'BleTncTransport: service $_serviceUuid not found on ${_adapter.platformName}. '
+          'Is this a Mobilinkd-compatible TNC?',
+        );
+      }
+
+      // 5. Find TX (notify) and RX (write) characteristics.
+      final txGuid = Guid(_txCharUuid);
+      final rxGuid = Guid(_rxCharUuid);
+      _txChar = service.characteristics.where((c) => c.characteristicUuid == txGuid).firstOrNull;
+      _rxChar = service.characteristics.where((c) => c.characteristicUuid == rxGuid).firstOrNull;
+
+      if (_txChar == null || _rxChar == null) {
+        throw Exception(
+          'BleTncTransport: TX or RX characteristic not found. '
+          'TX found: ${_txChar != null}, RX found: ${_rxChar != null}',
+        );
+      }
+
+      // 6. Subscribe to TX characteristic notifications.
+      await _txChar!.setNotifyValue(true);
+      _notifySub = _txChar!.onValueReceived.listen(_onBleChunk);
+
+      // 7. Wire KissFramer output → frameStream.
+      _framesSub = _kissFramer.frames.listen(_framesController.add);
+
+      // 8. Monitor for unexpected disconnects.
+      _connStateSub = _adapter.connectionState.listen(_onBleConnectionState);
+
+      _setStatus(ConnectionStatus.connected);
+    } catch (e) {
+      debugPrint('BleTncTransport connect failed: $e');
+      _setStatus(ConnectionStatus.error);
+      // Best-effort cleanup before rethrowing.
+      await _cleanupSubscriptions();
+      try {
+        await _adapter.disconnect();
+      } catch (_) {}
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    if (_status == ConnectionStatus.disconnected) return;
+    _setStatus(ConnectionStatus.disconnected);
+    await _cleanupSubscriptions();
+    try {
+      await _txChar?.setNotifyValue(false);
+    } catch (_) {}
+    _txChar = null;
+    _rxChar = null;
+    try {
+      await _adapter.disconnect();
+    } catch (_) {}
+    _kissFramer.dispose();
+  }
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) async {
+    final rxChar = _rxChar;
+    if (rxChar == null || !isConnected) {
+      throw StateError('BleTncTransport: not connected');
+    }
+    final kissFrame = KissFramer.encode(ax25Frame);
+    // Split into MTU-sized chunks and write sequentially with response.
+    int offset = 0;
+    while (offset < kissFrame.length) {
+      final end = min(offset + _mtu, kissFrame.length);
+      final chunk = kissFrame.sublist(offset, end);
+      await rxChar.write(chunk, withoutResponse: false);
+      offset = end;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  void _onBleChunk(List<int> chunk) {
+    _kissFramer.addBytes(chunk);
+  }
+
+  void _onBleConnectionState(BluetoothConnectionState state) {
+    if (state == BluetoothConnectionState.disconnected &&
+        _status == ConnectionStatus.connected) {
+      debugPrint('BleTncTransport: unexpected disconnect from ${_adapter.platformName}');
+      _status = ConnectionStatus.error;
+      _stateController.add(ConnectionStatus.error);
+      _cleanupSubscriptions();
+    }
+  }
+
+  Future<void> _cleanupSubscriptions() async {
+    await _notifySub?.cancel();
+    _notifySub = null;
+    await _connStateSub?.cancel();
+    _connStateSub = null;
+    await _framesSub?.cancel();
+    _framesSub = null;
+  }
+
+  void _setStatus(ConnectionStatus status) {
+    _status = status;
+    _stateController.add(status);
+  }
+}

--- a/lib/core/transport/ble_tnc_transport_stub.dart
+++ b/lib/core/transport/ble_tnc_transport_stub.dart
@@ -1,0 +1,40 @@
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'kiss_tnc_transport.dart';
+
+/// Stub [BleTncTransport] for platforms where BLE is not available (web).
+class BleTncTransport implements KissTncTransport {
+  // ignore: avoid_unused_constructor_parameters
+  BleTncTransport(BluetoothDevice device, {dynamic adapter});
+
+  @override
+  Stream<Uint8List> get frameStream =>
+      throw UnsupportedError('BLE TNC not supported on this platform');
+
+  @override
+  Stream<ConnectionStatus> get connectionState =>
+      throw UnsupportedError('BLE TNC not supported on this platform');
+
+  @override
+  ConnectionStatus get currentStatus => ConnectionStatus.disconnected;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  Future<void> connect() =>
+      throw UnsupportedError('BLE TNC not supported on this platform');
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) =>
+      throw UnsupportedError('BLE TNC not supported on this platform');
+}

--- a/lib/core/transport/kiss_tnc_transport.dart
+++ b/lib/core/transport/kiss_tnc_transport.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'aprs_transport.dart' show ConnectionStatus;
+
+/// Low-level KISS TNC transport abstraction.
+///
+/// Emits raw AX.25 frame payloads (KISS header stripped) on [frameStream].
+/// Both [SerialKissTransport] and [BleTncTransport] implement this interface.
+///
+/// Parsing (AX.25 → APRS text) is the responsibility of the service layer,
+/// not the transport. This keeps the transport layer free of APRS semantics
+/// and testable at the raw byte level.
+abstract interface class KissTncTransport {
+  /// Stream of decoded KISS frames as raw AX.25 byte arrays.
+  ///
+  /// Each emission is a complete AX.25 frame payload (command byte stripped).
+  Stream<Uint8List> get frameStream;
+
+  /// Emits the current [ConnectionStatus] whenever it changes.
+  Stream<ConnectionStatus> get connectionState;
+
+  /// Returns the most-recently-set [ConnectionStatus] synchronously.
+  ConnectionStatus get currentStatus;
+
+  /// True when the transport is connected and ready to receive/send frames.
+  bool get isConnected;
+
+  /// Connect to the TNC. Throws on failure.
+  Future<void> connect();
+
+  /// Disconnect cleanly and release all resources.
+  Future<void> disconnect();
+
+  /// Send a raw AX.25 frame wrapped in a KISS frame.
+  ///
+  /// The transport is responsible for KISS-encoding [ax25Frame] before
+  /// transmitting. Throws if not connected.
+  Future<void> sendFrame(Uint8List ax25Frame);
+}

--- a/lib/core/transport/serial_kiss_transport_impl.dart
+++ b/lib/core/transport/serial_kiss_transport_impl.dart
@@ -6,25 +6,25 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_libserialport/flutter_libserialport.dart';
 
-import '../packet/aprs_parser.dart';
-import 'aprs_transport.dart';
+import 'aprs_transport.dart' show ConnectionStatus;
 import 'kiss_framer.dart';
+import 'kiss_tnc_transport.dart';
 import 'serial_port_adapter.dart';
 import 'serial_port_adapter_impl.dart';
 import 'tnc_config.dart';
 
 /// USB serial KISS TNC transport.
 ///
-/// Implements [AprsTransport] so that [StationService] can consume APRS
-/// packets from a hardware TNC over USB serial without any changes to the
-/// service layer. Internally performs:
-///   raw serial bytes → [KissFramer] → [AprsParser.parseFrame] → APRS line
+/// Implements [KissTncTransport], emitting raw AX.25 frame payloads on
+/// [frameStream]. APRS parsing is the responsibility of the caller (service
+/// layer). Internally performs:
+///   raw serial bytes → [KissFramer] → AX.25 bytes on [frameStream]
 ///
 /// Desktop only (Linux, macOS, Windows). Use the conditional import shim
 /// at `serial_kiss_transport.dart` rather than importing this file directly.
 ///
 /// Pass a custom [SerialPortAdapter] to inject a fake in tests.
-class SerialKissTransport implements AprsTransport {
+class SerialKissTransport implements KissTncTransport {
   SerialKissTransport(this._config, {SerialPortAdapter? adapter})
     : _adapter = adapter ?? DefaultSerialPortAdapter(_config.port);
 
@@ -35,20 +35,22 @@ class SerialKissTransport implements AprsTransport {
 
   final _kissFramer = KissFramer();
   StreamSubscription<Uint8List>? _frameSub;
-  final _aprsParser = AprsParser();
 
-  final _linesController = StreamController<String>.broadcast();
+  final _framesController = StreamController<Uint8List>.broadcast();
   final _stateController = StreamController<ConnectionStatus>.broadcast();
   ConnectionStatus _status = ConnectionStatus.disconnected;
 
   @override
-  Stream<String> get lines => _linesController.stream;
+  Stream<Uint8List> get frameStream => _framesController.stream;
 
   @override
   Stream<ConnectionStatus> get connectionState => _stateController.stream;
 
   @override
   ConnectionStatus get currentStatus => _status;
+
+  @override
+  bool get isConnected => _status == ConnectionStatus.connected;
 
   @override
   Future<void> connect() async {
@@ -66,8 +68,8 @@ class SerialKissTransport implements AprsTransport {
         hardwareFlowControl: _config.hardwareFlowControl,
       );
 
-      // Subscribe KISS frames → APRS line emission.
-      _frameSub = _kissFramer.frames.listen(_onFrame);
+      // Subscribe KISS frames → frameStream.
+      _frameSub = _kissFramer.frames.listen(_onAx25Frame);
 
       // Subscribe serial reader → KISS framer.
       _readerSub = _adapter.byteStream.listen(
@@ -101,19 +103,16 @@ class SerialKissTransport implements AprsTransport {
     _setStatus(ConnectionStatus.disconnected);
   }
 
-  /// No-op in v0.3. Transmit path is v0.5 beaconing.
   @override
-  void sendLine(String line) {}
+  Future<void> sendFrame(Uint8List ax25Frame) async {
+    _adapter.write(KissFramer.encode(ax25Frame));
+  }
 
   /// Returns the list of available serial port names on the host system.
   static List<String> availablePorts() => SerialPort.availablePorts;
 
-  void _onFrame(Uint8List frameBytes) {
-    final packet = _aprsParser.parseFrame(frameBytes);
-    // packet.rawLine is the reconstructed APRS-IS–format line.
-    // An empty rawLine means AX.25 decode failed; StationService silently
-    // ignores empty lines, so we can emit unconditionally.
-    _linesController.add(packet.rawLine);
+  void _onAx25Frame(Uint8List frameBytes) {
+    _framesController.add(frameBytes);
   }
 
   void _setStatus(ConnectionStatus status) {

--- a/lib/core/transport/serial_kiss_transport_stub.dart
+++ b/lib/core/transport/serial_kiss_transport_stub.dart
@@ -1,19 +1,21 @@
 library;
 
 import 'dart:async';
+import 'dart:typed_data';
 
-import 'aprs_transport.dart';
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'kiss_tnc_transport.dart';
 import 'serial_port_adapter.dart';
 import 'tnc_config.dart';
 
 /// Stub [SerialKissTransport] for platforms where flutter_libserialport
 /// is not available (web, and as a compile-time safety net for mobile).
-class SerialKissTransport implements AprsTransport {
+class SerialKissTransport implements KissTncTransport {
   // ignore: avoid_unused_constructor_parameters
   SerialKissTransport(TncConfig config, {SerialPortAdapter? adapter});
 
   @override
-  Stream<String> get lines =>
+  Stream<Uint8List> get frameStream =>
       throw UnsupportedError('Serial port not supported on this platform');
 
   @override
@@ -24,6 +26,9 @@ class SerialKissTransport implements AprsTransport {
   ConnectionStatus get currentStatus => ConnectionStatus.disconnected;
 
   @override
+  bool get isConnected => false;
+
+  @override
   Future<void> connect() =>
       throw UnsupportedError('Serial port not supported on this platform');
 
@@ -31,7 +36,8 @@ class SerialKissTransport implements AprsTransport {
   Future<void> disconnect() async {}
 
   @override
-  void sendLine(String line) {}
+  Future<void> sendFrame(Uint8List ax25Frame) =>
+      throw UnsupportedError('Serial port not supported on this platform');
 
   static List<String> availablePorts() => const [];
 }

--- a/lib/core/transport/serial_port_adapter.dart
+++ b/lib/core/transport/serial_port_adapter.dart
@@ -25,6 +25,9 @@ abstract interface class SerialPortAdapter {
   /// The stream ends (onDone) when the port is closed or disconnected.
   Stream<Uint8List> get byteStream;
 
+  /// Write raw bytes to the port.
+  void write(Uint8List data);
+
   /// Close the port and release resources.
   void close();
 }

--- a/lib/core/transport/serial_port_adapter_impl.dart
+++ b/lib/core/transport/serial_port_adapter_impl.dart
@@ -45,6 +45,9 @@ class DefaultSerialPortAdapter implements SerialPortAdapter {
   }
 
   @override
+  void write(Uint8List data) => _port.write(data);
+
+  @override
   void close() {
     _reader?.close();
     _reader = null;

--- a/lib/core/transport/transport_manager.dart
+++ b/lib/core/transport/transport_manager.dart
@@ -58,7 +58,10 @@ class TransportManager extends ChangeNotifier {
   ///
   /// Disconnects any currently active transport first.
   /// Pass [adapter] to inject a fake for tests.
-  Future<void> connectSerial(TncConfig config, {SerialPortAdapter? adapter}) async {
+  Future<void> connectSerial(
+    TncConfig config, {
+    SerialPortAdapter? adapter,
+  }) async {
     await disconnect();
     final transport = SerialKissTransport(config, adapter: adapter);
     _attach(transport, TransportType.serial);

--- a/lib/core/transport/transport_manager.dart
+++ b/lib/core/transport/transport_manager.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'ble_tnc_transport.dart';
+import 'kiss_tnc_transport.dart';
+import 'serial_kiss_transport.dart';
+import 'serial_port_adapter.dart';
+import 'tnc_config.dart';
+
+export 'aprs_transport.dart' show ConnectionStatus;
+
+/// Identifies which transport type is currently active.
+enum TransportType { none, serial, ble }
+
+/// Manages the lifecycle of the currently active [KissTncTransport].
+///
+/// Holds at most one active transport at a time. Switching transports
+/// disconnects the current one first. Exposes [frameStream] and
+/// [connectionState] as re-published streams so callers don't need to
+/// re-subscribe when the underlying transport changes.
+///
+/// Register as a [ChangeNotifier] (via [TncService]) so the UI can react
+/// to transport changes.
+class TransportManager extends ChangeNotifier {
+  KissTncTransport? _active;
+  TransportType _activeType = TransportType.none;
+
+  StreamSubscription<ConnectionStatus>? _stateSub;
+  StreamSubscription<Uint8List>? _frameSub;
+
+  final _stateController = StreamController<ConnectionStatus>.broadcast();
+  final _framesController = StreamController<Uint8List>.broadcast();
+
+  // ---------------------------------------------------------------------------
+  // Public read API
+  // ---------------------------------------------------------------------------
+
+  KissTncTransport? get activeTransport => _active;
+  TransportType get activeType => _activeType;
+  bool get isConnected => _active?.isConnected ?? false;
+  ConnectionStatus get currentStatus =>
+      _active?.currentStatus ?? ConnectionStatus.disconnected;
+
+  /// Stream of [ConnectionStatus] from whichever transport is active.
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  /// Stream of raw AX.25 frame payloads from whichever transport is active.
+  Stream<Uint8List> get frameStream => _framesController.stream;
+
+  // ---------------------------------------------------------------------------
+  // Connect / disconnect
+  // ---------------------------------------------------------------------------
+
+  /// Connect using USB serial with [config].
+  ///
+  /// Disconnects any currently active transport first.
+  /// Pass [adapter] to inject a fake for tests.
+  Future<void> connectSerial(TncConfig config, {SerialPortAdapter? adapter}) async {
+    await disconnect();
+    final transport = SerialKissTransport(config, adapter: adapter);
+    _attach(transport, TransportType.serial);
+    await transport.connect();
+  }
+
+  /// Connect to a BLE TNC device.
+  ///
+  /// Disconnects any currently active transport first.
+  Future<void> connectBle(BluetoothDevice device) async {
+    await disconnect();
+    final transport = BleTncTransport(device);
+    _attach(transport, TransportType.ble);
+    await transport.connect();
+  }
+
+  /// Disconnect the active transport and release resources.
+  Future<void> disconnect() async {
+    if (_active == null) return;
+    await _stateSub?.cancel();
+    _stateSub = null;
+    await _frameSub?.cancel();
+    _frameSub = null;
+    await _active!.disconnect();
+    _active = null;
+    _activeType = TransportType.none;
+    _stateController.add(ConnectionStatus.disconnected);
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  void _attach(KissTncTransport t, TransportType type) {
+    _active = t;
+    _activeType = type;
+    _stateSub = t.connectionState.listen((s) {
+      _stateController.add(s);
+      notifyListeners();
+    });
+    _frameSub = t.frameStream.listen(_framesController.add);
+  }
+
+  @override
+  void dispose() {
+    disconnect();
+    _stateController.close();
+    _framesController.close();
+    super.dispose();
+  }
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -8,7 +8,6 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/packet/station.dart';
-import '../core/transport/aprs_transport.dart';
 import '../services/station_service.dart';
 import '../services/tnc_service.dart';
 import '../ui/layout/responsive_layout.dart';

--- a/lib/screens/onboarding/onboarding_connect_page.dart
+++ b/lib/screens/onboarding/onboarding_connect_page.dart
@@ -62,13 +62,11 @@ class _OnboardingConnectPageState extends State<OnboardingConnectPage> {
               selectedIndex: _selectedOption,
               icon: Symbols.bluetooth,
               title: 'BLE TNC',
-              subtitle:
-                  (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+              subtitle: (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
                   ? 'Connect wirelessly to a Mobilinkd or compatible TNC.'
                   : 'Available on iOS and Android.',
               dimmed: kIsWeb || !(Platform.isAndroid || Platform.isIOS),
-              onTap:
-                  (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+              onTap: (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
                   ? () => setState(() => _selectedOption = 1)
                   : null,
             ),

--- a/lib/screens/onboarding/onboarding_connect_page.dart
+++ b/lib/screens/onboarding/onboarding_connect_page.dart
@@ -21,8 +21,7 @@ class OnboardingConnectPage extends StatefulWidget {
 }
 
 class _OnboardingConnectPageState extends State<OnboardingConnectPage> {
-  int _selectedOption =
-      0; // 0=APRS-IS only — BLE/USB coming in future milestones
+  int _selectedOption = 0; // 0=APRS-IS, 1=BLE TNC, 2=USB TNC
 
   @override
   Widget build(BuildContext context) {
@@ -63,9 +62,15 @@ class _OnboardingConnectPageState extends State<OnboardingConnectPage> {
               selectedIndex: _selectedOption,
               icon: Symbols.bluetooth,
               title: 'BLE TNC',
-              subtitle: 'Coming in v0.4',
-              dimmed: true,
-              onTap: null,
+              subtitle:
+                  (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+                  ? 'Connect wirelessly to a Mobilinkd or compatible TNC.'
+                  : 'Available on iOS and Android.',
+              dimmed: kIsWeb || !(Platform.isAndroid || Platform.isIOS),
+              onTap:
+                  (!kIsWeb && (Platform.isAndroid || Platform.isIOS))
+                  ? () => setState(() => _selectedOption = 1)
+                  : null,
             ),
             const SizedBox(height: 12),
             _OptionCard(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -521,8 +521,7 @@ class _TncSectionState extends State<_TncSection> {
       _selectedPort = null;
     }
 
-    final isBlePlatform =
-        !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+    final isBlePlatform = !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -530,8 +529,7 @@ class _TncSectionState extends State<_TncSection> {
         const _SectionHeader('TNC'),
 
         // ── BLE TNC card (mobile only) ──────────────────────────────────────
-        if (isBlePlatform)
-          _BleTncCard(tncService: tncService),
+        if (isBlePlatform) _BleTncCard(tncService: tncService),
 
         // ── USB serial TNC card ─────────────────────────────────────────────
         Card(
@@ -766,7 +764,8 @@ class _BleTncCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isBleConnected = tncService.currentStatus == ConnectionStatus.connected &&
+    final isBleConnected =
+        tncService.currentStatus == ConnectionStatus.connected &&
         tncService.activeTransportType == TransportType.ble;
 
     return Card(
@@ -839,9 +838,8 @@ class _BleTncCard extends StatelessWidget {
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      builder: (_) => MeridianBottomSheet(
-        child: BleScannerSheet(tncService: tncService),
-      ),
+      builder: (_) =>
+          MeridianBottomSheet(child: BleScannerSheet(tncService: tncService)),
     );
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -9,6 +9,8 @@ import 'package:provider/provider.dart';
 import '../core/transport/tnc_config.dart';
 import '../core/transport/tnc_preset.dart';
 import '../services/tnc_service.dart';
+import '../ui/widgets/ble_scanner_sheet.dart';
+import '../ui/widgets/meridian_bottom_sheet.dart';
 import '../theme/meridian_colors.dart';
 import '../theme/theme_controller.dart';
 
@@ -519,10 +521,19 @@ class _TncSectionState extends State<_TncSection> {
       _selectedPort = null;
     }
 
+    final isBlePlatform =
+        !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const _SectionHeader('TNC'),
+
+        // ── BLE TNC card (mobile only) ──────────────────────────────────────
+        if (isBlePlatform)
+          _BleTncCard(tncService: tncService),
+
+        // ── USB serial TNC card ─────────────────────────────────────────────
         Card(
           margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: Column(
@@ -531,7 +542,7 @@ class _TncSectionState extends State<_TncSection> {
               ListTile(
                 leading: const Icon(Symbols.settings_input_component),
                 title: Text(
-                  'TNC',
+                  isBlePlatform ? 'USB Serial TNC' : 'TNC',
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),
@@ -742,6 +753,95 @@ class _TncSectionState extends State<_TncSection> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// BLE TNC card shown in Settings → TNC on iOS and Android.
+class _BleTncCard extends StatelessWidget {
+  const _BleTncCard({required this.tncService});
+
+  final TncService tncService;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isBleConnected = tncService.currentStatus == ConnectionStatus.connected &&
+        tncService.activeTransportType == TransportType.ble;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Symbols.bluetooth),
+                const SizedBox(width: 12),
+                Text(
+                  'BLE TNC',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const Spacer(),
+                if (isBleConnected)
+                  Chip(
+                    label: const Text('Connected'),
+                    side: BorderSide.none,
+                    backgroundColor: theme.colorScheme.secondaryContainer,
+                  ),
+              ],
+            ),
+            if (isBleConnected) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Mobilinkd or compatible device',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: () => tncService.disconnect(),
+                  child: const Text('Disconnect BLE TNC'),
+                ),
+              ),
+            ] else ...[
+              const SizedBox(height: 8),
+              Text(
+                'Connect to a Mobilinkd or compatible KISS TNC via Bluetooth.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: () => _openBleScanner(context),
+                  icon: const Icon(Symbols.bluetooth_searching),
+                  label: const Text('Scan & Connect'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openBleScanner(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => MeridianBottomSheet(
+        child: BleScannerSheet(tncService: tncService),
+      ),
     );
   }
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -65,11 +65,8 @@ class StationService {
 
   Future<void> start() async {
     // Wire up the line stream once — persists across reconnects.
-    _transport.lines.listen(
-      _handleLine,
-      onError: (e) => debugPrint('Transport error: $e'),
-      onDone: () => debugPrint('Transport connection closed'),
-    );
+    // Errors are handled inside AprsIsTransport and do not propagate here.
+    _transport.lines.listen(_handleLine);
     await connectAprsIs();
   }
 
@@ -97,7 +94,7 @@ class StationService {
       _handleLine(raw, source: source);
 
   Future<void> stop() async {
-    await _transport.disconnect();
+    await _transport.dispose();
     await _stationController.close();
     await _packetController.close();
   }
@@ -126,17 +123,38 @@ class StationService {
     // If this is a position packet, also update the station map.
     if (packet is PositionPacket) {
       debugPrint('PARSED: ${packet.source} @ ${packet.lat}, ${packet.lon}');
-      final station = _stationFromPosition(packet);
+      final station = _mergeStation(_stationFromPosition(packet));
       _stations[station.callsign] = station;
       _stationController.add(Map.unmodifiable(_stations));
     } else if (packet is MicEPacket) {
       debugPrint('MIC-E: ${packet.source} @ ${packet.lat}, ${packet.lon}');
-      final station = _stationFromMicE(packet);
+      final station = _mergeStation(_stationFromMicE(packet));
       _stations[station.callsign] = station;
       _stationController.add(Map.unmodifiable(_stations));
     } else if (packet is UnknownPacket) {
       debugPrint('SKIP: ${packet.reason} -- $raw');
     }
+  }
+
+  /// Carry forward non-empty fields from the previous [Station] record for the
+  /// same callsign when the incoming station has empty values.
+  ///
+  /// Currently preserves: comment (never blank out a previously seen comment),
+  /// device (keep the last successfully identified device).
+  Station _mergeStation(Station incoming) {
+    final prev = _stations[incoming.callsign];
+    if (prev == null) return incoming;
+    return Station(
+      callsign: incoming.callsign,
+      lat: incoming.lat,
+      lon: incoming.lon,
+      rawPacket: incoming.rawPacket,
+      lastHeard: incoming.lastHeard,
+      symbolTable: incoming.symbolTable,
+      symbolCode: incoming.symbolCode,
+      comment: incoming.comment.isNotEmpty ? incoming.comment : prev.comment,
+      device: incoming.device ?? prev.device,
+    );
   }
 
   /// Convert a [PositionPacket] to a [Station] for the legacy station map.
@@ -150,6 +168,7 @@ class StationService {
       symbolTable: p.symbolTable,
       symbolCode: p.symbolCode,
       comment: p.comment,
+      device: p.device,
     );
   }
 
@@ -164,6 +183,7 @@ class StationService {
       symbolTable: p.symbolTable,
       symbolCode: p.symbolCode,
       comment: p.comment,
+      device: p.device,
     );
   }
 }

--- a/lib/services/tnc_service.dart
+++ b/lib/services/tnc_service.dart
@@ -11,7 +11,8 @@ import '../core/transport/tnc_config.dart';
 import '../core/transport/transport_manager.dart';
 import 'station_service.dart';
 
-export '../core/transport/transport_manager.dart' show TransportType, ConnectionStatus;
+export '../core/transport/transport_manager.dart'
+    show TransportType, ConnectionStatus;
 
 /// Manages the TNC connection lifecycle and bridges decoded packets to
 /// [StationService].

--- a/lib/services/tnc_service.dart
+++ b/lib/services/tnc_service.dart
@@ -1,18 +1,24 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../core/transport/aprs_transport.dart' show ConnectionStatus;
+import '../core/packet/aprs_packet.dart' show PacketSource;
+import '../core/packet/aprs_parser.dart';
 import '../core/transport/serial_kiss_transport.dart';
 import '../core/transport/tnc_config.dart';
+import '../core/transport/transport_manager.dart';
 import 'station_service.dart';
 
-/// Manages the USB serial TNC connection lifecycle.
+export '../core/transport/transport_manager.dart' show TransportType, ConnectionStatus;
+
+/// Manages the TNC connection lifecycle and bridges decoded packets to
+/// [StationService].
 ///
-/// Wraps [SerialKissTransport], exposes connection state and decoded APRS
-/// packets, and bridges received packets into [StationService] via
-/// [StationService.ingestLine].
+/// Owns a [TransportManager] that holds the currently active [KissTncTransport]
+/// (serial or BLE). Raw AX.25 frames from the transport are parsed here via
+/// [AprsParser.parseFrame] and forwarded to [StationService.ingestLine].
 ///
 /// Register as a [ChangeNotifierProvider] in main.dart. Call
 /// [loadPersistedConfig] once on startup.
@@ -20,12 +26,12 @@ class TncService extends ChangeNotifier {
   TncService(this._stationService);
 
   final StationService _stationService;
+  final _transportManager = TransportManager();
+  final _aprsParser = AprsParser();
 
-  SerialKissTransport? _transport;
-  StreamSubscription<String>? _linesSub;
+  StreamSubscription<Uint8List>? _frameSub;
   StreamSubscription<ConnectionStatus>? _stateSub;
 
-  ConnectionStatus _status = ConnectionStatus.disconnected;
   TncConfig? _activeConfig;
 
   /// Platform-guidance or error description. Set when status == error.
@@ -35,42 +41,51 @@ class TncService extends ChangeNotifier {
   // Public API
   // ---------------------------------------------------------------------------
 
-  ConnectionStatus get currentStatus => _status;
+  ConnectionStatus get currentStatus => _transportManager.currentStatus;
   TncConfig? get activeConfig => _activeConfig;
   String? get lastErrorMessage => _lastErrorMessage;
+  TransportType get activeTransportType => _transportManager.activeType;
 
-  /// Stream of [ConnectionStatus] changes.
+  /// Expose the transport manager for widgets that need direct access
+  /// (e.g. BLE scanner passing a device to connect).
+  TransportManager get transportManager => _transportManager;
+
+  /// Stream of [ConnectionStatus] changes (serial or BLE).
   Stream<ConnectionStatus> get connectionState => _stateController.stream;
   final _stateController = StreamController<ConnectionStatus>.broadcast();
 
-  /// Connect to the TNC described by [config].
+  /// Connect to the serial TNC described by [config].
   ///
-  /// Saves the config to SharedPreferences so it can be restored on the next
-  /// launch. On failure, transitions to [ConnectionStatus.error] and sets
-  /// [lastErrorMessage].
+  /// Saves the config to SharedPreferences. On failure, transitions to
+  /// [ConnectionStatus.error] and sets [lastErrorMessage].
   Future<void> connect(TncConfig config) async {
-    await disconnect();
+    await _cancelBridge();
     _activeConfig = config;
     await _saveConfig(config);
 
-    final transport = SerialKissTransport(config);
-    _transport = transport;
-
-    // Mirror transport state into our own stream.
-    _stateSub = transport.connectionState.listen((s) {
-      _status = s;
-      _stateController.add(s);
-      notifyListeners();
-    });
-
-    // Pipe decoded APRS lines into StationService.
-    _linesSub = transport.lines.listen(_stationService.ingestLine);
+    _attachBridge();
 
     try {
-      await transport.connect();
+      await _transportManager.connectSerial(config);
     } catch (e) {
-      _lastErrorMessage = _errorMessage(e.toString(), config.port);
-      _status = ConnectionStatus.error;
+      _lastErrorMessage = _serialErrorMessage(e.toString(), config.port);
+      _stateController.add(ConnectionStatus.error);
+      notifyListeners();
+    }
+  }
+
+  /// Connect to a BLE TNC device.
+  ///
+  /// On failure, transitions to [ConnectionStatus.error] and sets
+  /// [lastErrorMessage].
+  Future<void> connectBle(BluetoothDevice device) async {
+    await _cancelBridge();
+    _attachBridge();
+
+    try {
+      await _transportManager.connectBle(device);
+    } catch (e) {
+      _lastErrorMessage = _bleErrorMessage(e.toString(), device.platformName);
       _stateController.add(ConnectionStatus.error);
       notifyListeners();
     }
@@ -78,17 +93,8 @@ class TncService extends ChangeNotifier {
 
   /// Disconnect and release resources.
   Future<void> disconnect() async {
-    await _linesSub?.cancel();
-    _linesSub = null;
-    await _stateSub?.cancel();
-    _stateSub = null;
-    await _transport?.disconnect();
-    _transport = null;
-    if (_status != ConnectionStatus.disconnected) {
-      _status = ConnectionStatus.disconnected;
-      _stateController.add(ConnectionStatus.disconnected);
-      notifyListeners();
-    }
+    await _cancelBridge();
+    await _transportManager.disconnect();
   }
 
   /// Returns available serial port names. Empty on non-desktop platforms.
@@ -96,9 +102,7 @@ class TncService extends ChangeNotifier {
 
   /// Persist [config] as the active TNC configuration without connecting.
   ///
-  /// Use this to save settings changes from the Settings screen. The new
-  /// config becomes [activeConfig] and is persisted to SharedPreferences.
-  /// Does not affect an in-progress connection — [disconnect] first if needed.
+  /// Use this to save settings changes from the Settings screen.
   Future<void> updateConfig(TncConfig config) async {
     _activeConfig = config;
     await _saveConfig(config);
@@ -107,8 +111,7 @@ class TncService extends ChangeNotifier {
 
   /// Load the previously-persisted [TncConfig] from SharedPreferences.
   ///
-  /// Call once on app startup. Does not automatically connect — the user
-  /// must tap Connect in the UI.
+  /// Call once on app startup. Does not automatically connect.
   Future<void> loadPersistedConfig() async {
     final prefs = await SharedPreferences.getInstance();
     final map = {
@@ -121,13 +124,45 @@ class TncService extends ChangeNotifier {
 
   @override
   void dispose() {
-    disconnect();
+    _cancelBridge();
+    _transportManager.dispose();
     _stateController.close();
     super.dispose();
   }
 
   // ---------------------------------------------------------------------------
-  // Internal
+  // Internal — frame bridge
+  // ---------------------------------------------------------------------------
+
+  /// Subscribe to the transport manager's streams.
+  ///
+  /// Must be called before connecting (to capture state transitions from
+  /// `connecting` onward).
+  void _attachBridge() {
+    _stateSub = _transportManager.connectionState.listen((s) {
+      _stateController.add(s);
+      notifyListeners();
+    });
+    _frameSub = _transportManager.frameStream.listen(_onFrame);
+  }
+
+  Future<void> _cancelBridge() async {
+    await _frameSub?.cancel();
+    _frameSub = null;
+    await _stateSub?.cancel();
+    _stateSub = null;
+  }
+
+  void _onFrame(Uint8List frameBytes) {
+    final packet = _aprsParser.parseFrame(frameBytes);
+    // An empty rawLine means AX.25 decode failed; skip silently.
+    if (packet.rawLine.isNotEmpty) {
+      _stationService.ingestLine(packet.rawLine, source: PacketSource.tnc);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — persistence
   // ---------------------------------------------------------------------------
 
   Future<void> _saveConfig(TncConfig config) async {
@@ -140,8 +175,7 @@ class TncService extends ChangeNotifier {
     }
   }
 
-  String _errorMessage(String error, String port) {
-    // Provide platform-specific guidance for permission errors.
+  String _serialErrorMessage(String error, String port) {
     final lower = error.toLowerCase();
     if (lower.contains('permission') ||
         lower.contains('access denied') ||
@@ -164,5 +198,19 @@ class TncService extends ChangeNotifier {
       return 'Port $port not found. Is the TNC plugged in?';
     }
     return 'Could not connect to $port: $error';
+  }
+
+  String _bleErrorMessage(String error, String deviceName) {
+    final lower = error.toLowerCase();
+    if (lower.contains('permission') || lower.contains('unauthorized')) {
+      return 'Bluetooth permission is required to connect a TNC.';
+    }
+    if (lower.contains('timeout') || lower.contains('canceled')) {
+      return 'Could not connect to $deviceName. Try again.';
+    }
+    if (lower.contains('service') && lower.contains('not found')) {
+      return '$deviceName does not appear to be a compatible KISS TNC.';
+    }
+    return 'Could not connect to $deviceName: $error';
   }
 }

--- a/lib/ui/layout/desktop_scaffold.dart
+++ b/lib/ui/layout/desktop_scaffold.dart
@@ -6,7 +6,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../core/transport/aprs_transport.dart' show ConnectionStatus;
 import '../../screens/packet_log_screen.dart';
 import '../../screens/station_list_screen.dart';
 import '../../services/station_service.dart';

--- a/lib/ui/layout/mobile_scaffold.dart
+++ b/lib/ui/layout/mobile_scaffold.dart
@@ -113,8 +113,7 @@ class _MobileScaffoldState extends State<MobileScaffold> {
           ),
           if (!kIsWeb &&
               (widget.tncConnectionStatus != ConnectionStatus.disconnected ||
-                  widget.tncService.activeTransportType !=
-                      TransportType.none))
+                  widget.tncService.activeTransportType != TransportType.none))
             MeridianStatusPill(
               label: _tncPillLabel(widget.tncService.activeTransportType),
               status: widget.tncConnectionStatus,

--- a/lib/ui/layout/mobile_scaffold.dart
+++ b/lib/ui/layout/mobile_scaffold.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -7,7 +5,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../core/transport/aprs_transport.dart' show ConnectionStatus;
 import '../../screens/packet_log_screen.dart';
 import '../../screens/station_list_screen.dart';
 import '../../services/station_service.dart';
@@ -61,6 +58,12 @@ class MobileScaffold extends StatefulWidget {
 class _MobileScaffoldState extends State<MobileScaffold> {
   int _selectedIndex = 0;
 
+  static String _tncPillLabel(TransportType type) => switch (type) {
+    TransportType.ble => 'BLE TNC',
+    TransportType.serial => 'USB TNC',
+    TransportType.none => 'TNC',
+  };
+
   void _showConnectionSheet() {
     showModalBottomSheet(
       context: context,
@@ -109,9 +112,11 @@ class _MobileScaffoldState extends State<MobileScaffold> {
             onTap: _showConnectionSheet,
           ),
           if (!kIsWeb &&
-              (Platform.isLinux || Platform.isMacOS || Platform.isWindows))
+              (widget.tncConnectionStatus != ConnectionStatus.disconnected ||
+                  widget.tncService.activeTransportType !=
+                      TransportType.none))
             MeridianStatusPill(
-              label: 'TNC',
+              label: _tncPillLabel(widget.tncService.activeTransportType),
               status: widget.tncConnectionStatus,
               onTap: _showConnectionSheet,
             ),

--- a/lib/ui/layout/responsive_layout.dart
+++ b/lib/ui/layout/responsive_layout.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../core/transport/aprs_transport.dart';
 import '../../services/station_service.dart';
 import '../../services/tnc_service.dart';
 import 'desktop_scaffold.dart';

--- a/lib/ui/layout/tablet_scaffold.dart
+++ b/lib/ui/layout/tablet_scaffold.dart
@@ -6,7 +6,6 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../core/transport/aprs_transport.dart' show ConnectionStatus;
 import '../../screens/packet_log_screen.dart';
 import '../../screens/station_list_screen.dart';
 import '../../services/station_service.dart';

--- a/lib/ui/widgets/ble_scanner_sheet.dart
+++ b/lib/ui/widgets/ble_scanner_sheet.dart
@@ -57,7 +57,10 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
     // On desktop Linux/macOS/Windows BLE may be unavailable.
     final state = await FlutterBluePlus.adapterState.first;
     if (state == BluetoothAdapterState.off) {
-      setState(() => _bleError = 'Bluetooth is off. Enable it in Settings to connect a BLE TNC.');
+      setState(
+        () => _bleError =
+            'Bluetooth is off. Enable it in Settings to connect a BLE TNC.',
+      );
     } else if (state == BluetoothAdapterState.unavailable) {
       setState(() => _bleError = 'Bluetooth is not available on this device.');
     } else if (state == BluetoothAdapterState.unauthorized) {
@@ -77,9 +80,7 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
     _scanSub?.cancel();
 
     try {
-      await FlutterBluePlus.startScan(
-        timeout: const Duration(seconds: 15),
-      );
+      await FlutterBluePlus.startScan(timeout: const Duration(seconds: 15));
     } on FlutterBluePlusException catch (e) {
       setState(() {
         _bleError = _friendlyBleError(e.description ?? e.toString());
@@ -96,7 +97,9 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
             final advertisedUuids = r.advertisementData.serviceUuids
                 .map((g) => g.str.toLowerCase())
                 .toList();
-            if (!advertisedUuids.contains(kMobilinkdServiceUuid.toLowerCase())) {
+            if (!advertisedUuids.contains(
+              kMobilinkdServiceUuid.toLowerCase(),
+            )) {
               continue;
             }
           }
@@ -127,7 +130,8 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
       if (mounted) {
         setState(() {
           _connectingDeviceId = null;
-          _bleError = 'Could not connect to ${result.device.platformName.isNotEmpty ? result.device.platformName : "device"}. Try again.';
+          _bleError =
+              'Could not connect to ${result.device.platformName.isNotEmpty ? result.device.platformName : "device"}. Try again.';
         });
       }
     }
@@ -152,7 +156,12 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
   }
 
   bool get _isBlePlatform =>
-      !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS || Platform.isLinux || Platform.isWindows);
+      !kIsWeb &&
+      (Platform.isAndroid ||
+          Platform.isIOS ||
+          Platform.isMacOS ||
+          Platform.isLinux ||
+          Platform.isWindows);
 
   @override
   Widget build(BuildContext context) {
@@ -182,7 +191,10 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
           // Title row.
           Row(
             children: [
-              Icon(Symbols.bluetooth_searching, color: theme.colorScheme.primary),
+              Icon(
+                Symbols.bluetooth_searching,
+                color: theme.colorScheme.primary,
+              ),
               const SizedBox(width: 10),
               Text('BLE TNC', style: theme.textTheme.titleMedium),
             ],
@@ -239,10 +251,7 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
                 ],
                 const Spacer(),
                 // Filter toggle.
-                Text(
-                  'Mobilinkd only',
-                  style: theme.textTheme.labelSmall,
-                ),
+                Text('Mobilinkd only', style: theme.textTheme.labelSmall),
                 Switch(
                   value: _filterMobilinkd,
                   onChanged: (v) => setState(() {

--- a/lib/ui/widgets/ble_scanner_sheet.dart
+++ b/lib/ui/widgets/ble_scanner_sheet.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '../../core/transport/ble_constants.dart';
+import '../../services/tnc_service.dart';
+
+/// Bottom sheet for scanning and connecting to a BLE KISS TNC.
+///
+/// Scans for nearby BLE devices, optionally filtering to Mobilinkd-compatible
+/// devices (service UUID [kMobilinkdServiceUuid]). Tapping "Connect" on a
+/// device calls [TncService.connectBle] and closes the sheet on success.
+class BleScannerSheet extends StatefulWidget {
+  const BleScannerSheet({super.key, required this.tncService});
+
+  final TncService tncService;
+
+  @override
+  State<BleScannerSheet> createState() => _BleScannerSheetState();
+}
+
+class _BleScannerSheetState extends State<BleScannerSheet> {
+  bool _scanning = false;
+  bool _filterMobilinkd = true;
+  String? _bleError;
+  String? _connectingDeviceId;
+
+  // Track unique devices by remoteId (deduplicates scan updates).
+  final _deviceMap = <DeviceIdentifier, ScanResult>{};
+
+  StreamSubscription<List<ScanResult>>? _scanSub;
+  StreamSubscription<BluetoothAdapterState>? _adapterSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkAdapter();
+  }
+
+  @override
+  void dispose() {
+    _scanSub?.cancel();
+    _adapterSub?.cancel();
+    if (_scanning) FlutterBluePlus.stopScan();
+    super.dispose();
+  }
+
+  Future<void> _checkAdapter() async {
+    if (kIsWeb) {
+      setState(() => _bleError = 'BLE TNC is not available on web.');
+      return;
+    }
+    // On desktop Linux/macOS/Windows BLE may be unavailable.
+    final state = await FlutterBluePlus.adapterState.first;
+    if (state == BluetoothAdapterState.off) {
+      setState(() => _bleError = 'Bluetooth is off. Enable it in Settings to connect a BLE TNC.');
+    } else if (state == BluetoothAdapterState.unavailable) {
+      setState(() => _bleError = 'Bluetooth is not available on this device.');
+    } else if (state == BluetoothAdapterState.unauthorized) {
+      setState(
+        () => _bleError = 'Bluetooth permission is required to connect a TNC.',
+      );
+    }
+  }
+
+  Future<void> _startScan() async {
+    setState(() {
+      _scanning = true;
+      _deviceMap.clear();
+      _bleError = null;
+    });
+
+    _scanSub?.cancel();
+
+    try {
+      await FlutterBluePlus.startScan(
+        timeout: const Duration(seconds: 15),
+      );
+    } on FlutterBluePlusException catch (e) {
+      setState(() {
+        _bleError = _friendlyBleError(e.description ?? e.toString());
+        _scanning = false;
+      });
+      return;
+    }
+
+    _scanSub = FlutterBluePlus.onScanResults.listen((results) {
+      if (!mounted) return;
+      setState(() {
+        for (final r in results) {
+          if (_filterMobilinkd) {
+            final advertisedUuids = r.advertisementData.serviceUuids
+                .map((g) => g.str.toLowerCase())
+                .toList();
+            if (!advertisedUuids.contains(kMobilinkdServiceUuid.toLowerCase())) {
+              continue;
+            }
+          }
+          _deviceMap[r.device.remoteId] = r;
+        }
+      });
+    });
+
+    // FlutterBluePlus stops on timeout; listen for adapter state to detect early stop.
+    FlutterBluePlus.isScanning.listen((isScanning) {
+      if (!isScanning && mounted) {
+        setState(() => _scanning = false);
+      }
+    });
+  }
+
+  Future<void> _connect(ScanResult result) async {
+    await FlutterBluePlus.stopScan();
+    setState(() {
+      _connectingDeviceId = result.device.remoteId.str;
+      _bleError = null;
+    });
+
+    try {
+      await widget.tncService.connectBle(result.device);
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _connectingDeviceId = null;
+          _bleError = 'Could not connect to ${result.device.platformName.isNotEmpty ? result.device.platformName : "device"}. Try again.';
+        });
+      }
+    }
+  }
+
+  String _friendlyBleError(String raw) {
+    final lower = raw.toLowerCase();
+    if (lower.contains('permission') || lower.contains('unauthorized')) {
+      return 'Bluetooth permission is required to connect a TNC.';
+    }
+    if (lower.contains('off') || lower.contains('adapter')) {
+      return 'Bluetooth is off. Enable it in Settings to connect a BLE TNC.';
+    }
+    return raw;
+  }
+
+  IconData _rssiIcon(int rssi) {
+    if (rssi >= -60) return Symbols.signal_cellular_4_bar;
+    if (rssi >= -70) return Symbols.network_wifi_3_bar;
+    if (rssi >= -80) return Symbols.network_wifi_2_bar;
+    return Symbols.network_wifi_1_bar;
+  }
+
+  bool get _isBlePlatform =>
+      !kIsWeb && (Platform.isAndroid || Platform.isIOS || Platform.isMacOS || Platform.isLinux || Platform.isWindows);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final devices = _deviceMap.values.toList()
+      ..sort((a, b) => b.rssi.compareTo(a.rssi));
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Drag handle.
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+
+          // Title row.
+          Row(
+            children: [
+              Icon(Symbols.bluetooth_searching, color: theme.colorScheme.primary),
+              const SizedBox(width: 10),
+              Text('BLE TNC', style: theme.textTheme.titleMedium),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          // Error banner.
+          if (_bleError != null) ...[
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.errorContainer,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Symbols.error_outline,
+                    color: theme.colorScheme.onErrorContainer,
+                    size: 18,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      _bleError!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onErrorContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
+
+          // Controls row.
+          if (_isBlePlatform && _bleError == null) ...[
+            Row(
+              children: [
+                FilledButton.icon(
+                  onPressed: _scanning ? null : _startScan,
+                  icon: Icon(_scanning ? Symbols.stop : Symbols.search),
+                  label: Text(_scanning ? 'Scanning…' : 'Scan'),
+                ),
+                const SizedBox(width: 12),
+                if (_scanning) ...[
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 8),
+                ],
+                const Spacer(),
+                // Filter toggle.
+                Text(
+                  'Mobilinkd only',
+                  style: theme.textTheme.labelSmall,
+                ),
+                Switch(
+                  value: _filterMobilinkd,
+                  onChanged: (v) => setState(() {
+                    _filterMobilinkd = v;
+                    _deviceMap.clear();
+                  }),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            // Scanning indicator.
+            if (_scanning) const LinearProgressIndicator(),
+            const SizedBox(height: 8),
+          ],
+
+          // Device list.
+          if (devices.isNotEmpty)
+            ...devices.map((result) {
+              final name = result.device.platformName.isNotEmpty
+                  ? result.device.platformName
+                  : result.device.remoteId.str;
+              final isConnecting =
+                  _connectingDeviceId == result.device.remoteId.str;
+
+              return Card(
+                margin: const EdgeInsets.only(bottom: 8),
+                child: ListTile(
+                  leading: Icon(_rssiIcon(result.rssi)),
+                  title: Text(name),
+                  subtitle: Text(
+                    'RSSI: ${result.rssi} dBm',
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  trailing: isConnecting
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : FilledButton.tonal(
+                          onPressed: _connectingDeviceId != null
+                              ? null
+                              : () => _connect(result),
+                          child: const Text('Connect'),
+                        ),
+                ),
+              );
+            })
+          else if (!_scanning && _bleError == null)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: Center(
+                child: Column(
+                  children: [
+                    Icon(
+                      Symbols.bluetooth_disabled,
+                      size: 48,
+                      color: theme.colorScheme.outline,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'No TNC devices found.',
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Make sure your TNC is powered on and in range.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/connection_sheet.dart
+++ b/lib/ui/widgets/connection_sheet.dart
@@ -357,9 +357,11 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
   }
 
   Widget _buildBleTncCard(ThemeData theme, ConnectionStatus tncStatus) {
-    final isBleConnected = tncStatus == ConnectionStatus.connected &&
+    final isBleConnected =
+        tncStatus == ConnectionStatus.connected &&
         widget.tncService.activeTransportType == TransportType.ble;
-    final isBleConnecting = tncStatus == ConnectionStatus.connecting &&
+    final isBleConnecting =
+        tncStatus == ConnectionStatus.connecting &&
         widget.tncService.activeTransportType == TransportType.ble;
     final errorMessage = isBleConnected || isBleConnecting
         ? null
@@ -435,7 +437,6 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
       ),
     );
   }
-
 }
 
 class _TncUnavailableCard extends StatelessWidget {

--- a/lib/ui/widgets/connection_sheet.dart
+++ b/lib/ui/widgets/connection_sheet.dart
@@ -6,11 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../core/packet/aprs_packet.dart' show AprsPacket, PacketSource;
-import '../../core/transport/aprs_transport.dart' show ConnectionStatus;
 import '../../core/transport/tnc_config.dart';
 import '../../core/transport/tnc_preset.dart';
 import '../../services/station_service.dart';
 import '../../services/tnc_service.dart';
+import 'ble_scanner_sheet.dart';
+import 'meridian_bottom_sheet.dart';
 import 'meridian_status_pill.dart';
 
 /// Bottom sheet content for managing APRS-IS and TNC connection settings.
@@ -44,8 +45,11 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
   int _aprsIsCount = 0;
   int _tncCount = 0;
 
-  static bool get _isTncPlatform =>
+  static bool get _isSerialPlatform =>
       !kIsWeb && (Platform.isLinux || Platform.isMacOS || Platform.isWindows);
+
+  static bool get _isBlePlatform =>
+      !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
   @override
   void initState() {
@@ -106,7 +110,7 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
   }
 
   void _refreshPorts({String? initial}) {
-    final ports = _isTncPlatform ? widget.tncService.availablePorts() : [];
+    final ports = _isSerialPlatform ? widget.tncService.availablePorts() : [];
     _availablePorts = List<String>.from(ports);
     if (_availablePorts.isNotEmpty) {
       if (initial != null && _availablePorts.contains(initial)) {
@@ -156,10 +160,12 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
 
           // ── TNC section ──────────────────────────────────────────────────
           _SectionHeader('TNC'),
-          if (!_isTncPlatform)
-            _TncUnavailableCard()
+          if (_isSerialPlatform)
+            _buildTncCard(theme, tncStatus)
+          else if (_isBlePlatform)
+            _buildBleTncCard(theme, tncStatus)
           else
-            _buildTncCard(theme, tncStatus),
+            _TncUnavailableCard(),
         ],
       ),
     );
@@ -349,6 +355,87 @@ class _ConnectionSheetState extends State<ConnectionSheet> {
       ),
     );
   }
+
+  Widget _buildBleTncCard(ThemeData theme, ConnectionStatus tncStatus) {
+    final isBleConnected = tncStatus == ConnectionStatus.connected &&
+        widget.tncService.activeTransportType == TransportType.ble;
+    final isBleConnecting = tncStatus == ConnectionStatus.connecting &&
+        widget.tncService.activeTransportType == TransportType.ble;
+    final errorMessage = isBleConnected || isBleConnecting
+        ? null
+        : widget.tncService.lastErrorMessage;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Bluetooth TNC',
+                    style: theme.textTheme.titleSmall,
+                  ),
+                ),
+                if (isBleConnected || isBleConnecting)
+                  MeridianStatusPill(label: 'BLE TNC', status: tncStatus),
+              ],
+            ),
+            if (isBleConnected) ...[
+              const SizedBox(height: 4),
+              Text(
+                '$_tncCount packets received',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (errorMessage != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                errorMessage,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: isBleConnected
+                  ? OutlinedButton(
+                      onPressed: _onDisconnectTap,
+                      child: const Text('Disconnect BLE TNC'),
+                    )
+                  : FilledButton.icon(
+                      onPressed: isBleConnecting
+                          ? null
+                          : () => _openBleScanner(theme),
+                      icon: const Icon(Symbols.bluetooth_searching),
+                      label: Text(
+                        isBleConnecting ? 'Connecting…' : 'Scan & Connect',
+                      ),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openBleScanner(ThemeData theme) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => MeridianBottomSheet(
+        child: BleScannerSheet(tncService: widget.tncService),
+      ),
+    );
+  }
+
 }
 
 class _TncUnavailableCard extends StatelessWidget {

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -162,6 +162,7 @@ class PacketDetailSheet extends StatelessWidget {
           m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
         }
         m['Messaging'] = p.hasMessaging ? 'Yes' : 'No';
+        if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
         if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
 
@@ -208,6 +209,7 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol table'] = p.symbolTable;
         m['Symbol code'] = p.symbolCode;
         m['Alive'] = p.isAlive ? 'Yes' : 'No (killed)';
+        if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
       case ItemPacket():
@@ -218,6 +220,7 @@ class PacketDetailSheet extends StatelessWidget {
         m['Symbol table'] = p.symbolTable;
         m['Symbol code'] = p.symbolCode;
         m['Alive'] = p.isAlive ? 'Yes' : 'No (killed)';
+        if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
       case StatusPacket():
@@ -237,6 +240,7 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.altitude != null) {
           m['Altitude'] = '${p.altitude!.toStringAsFixed(0)} m';
         }
+        if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
       case UnknownPacket():

--- a/lib/ui/widgets/station_info_sheet.dart
+++ b/lib/ui/widgets/station_info_sheet.dart
@@ -100,6 +100,27 @@ class StationInfoSheet extends StatelessWidget {
               ),
             ],
 
+            // Device (conditional)
+            if (station.device != null) ...[
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Icon(
+                    Icons.memory,
+                    size: 14,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    station.device!,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+
             const SizedBox(height: 12),
 
             // Last heard

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,13 @@ import FlutterMacOS
 import Foundation
 
 import dynamic_color
+import flutter_blue_plus_darwin
 import flutter_libserialport
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FlutterBluePlusPlugin.register(with: registry.registrar(forPlugin: "FlutterBluePlusPlugin"))
   FlutterLibserialportPlugin.register(with: registry.registrar(forPlugin: "FlutterLibserialportPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  bluez:
+    dependency: transitive
+    description:
+      name: bluez
+      sha256: "61a7204381925896a374301498f2f5399e59827c6498ae1e924aaa598751b545"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   dylib:
     dependency: transitive
     description:
@@ -182,6 +198,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blue_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_blue_plus
+      sha256: "69a8c87c11fc792e8cf0f997d275484fbdb5143ac9f0ac4d424429700cb4e0ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.36.8"
+  flutter_blue_plus_android:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_android
+      sha256: "6f7fe7e69659c30af164a53730707edc16aa4d959e4c208f547b893d940f853d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.4"
+  flutter_blue_plus_darwin:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_darwin
+      sha256: "682982862c1d964f4d54a3fb5fccc9e59a066422b93b7e22079aeecd9c0d38f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
+  flutter_blue_plus_linux:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_linux
+      sha256: "56b0c45edd0a2eec8f85bd97a26ac3cd09447e10d0094fed55587bf0592e3347"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
+  flutter_blue_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_platform_interface
+      sha256: "84fbd180c50a40c92482f273a92069960805ce324e3673ad29c41d2faaa7c5c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  flutter_blue_plus_web:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_web
+      sha256: a1aceee753d171d24c0e0cdadb37895b5e9124862721f25f60bb758e20b72c99
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   flutter_libserialport:
     dependency: "direct main"
     description:
@@ -533,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -581,6 +653,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -850,6 +930,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_m3shapes: ^1.0.0
   animations: ^2.0.11
   material_symbols_icons: ^4.2906.0
+  flutter_blue_plus: ^1.33.0
 
 dev_dependencies:
   flutter_test:

--- a/test/core/ax25/ax25_parser_test.dart
+++ b/test/core/ax25/ax25_parser_test.dart
@@ -178,21 +178,21 @@ void main() {
     // M7: control/PID validation
     // -------------------------------------------------------------------------
 
-    test('non-UI control byte (0x13) returns Ax25Err with descriptive reason', () {
-      final raw = buildFrame(
-        dst: 'APRS',
-        src: 'W1AW',
-        control: 0x13,
-        pid: 0xF0,
-        info: [0x21],
-      );
-      final result = parser.parseFrame(raw);
-      expect(result, isA<Ax25Err>());
-      expect(
-        (result as Ax25Err).reason,
-        contains('Not a UI/APRS frame'),
-      );
-    });
+    test(
+      'non-UI control byte (0x13) returns Ax25Err with descriptive reason',
+      () {
+        final raw = buildFrame(
+          dst: 'APRS',
+          src: 'W1AW',
+          control: 0x13,
+          pid: 0xF0,
+          info: [0x21],
+        );
+        final result = parser.parseFrame(raw);
+        expect(result, isA<Ax25Err>());
+        expect((result as Ax25Err).reason, contains('Not a UI/APRS frame'));
+      },
+    );
 
     test('non-APRS PID (0xCF) returns Ax25Err with descriptive reason', () {
       final raw = buildFrame(
@@ -204,10 +204,7 @@ void main() {
       );
       final result = parser.parseFrame(raw);
       expect(result, isA<Ax25Err>());
-      expect(
-        (result as Ax25Err).reason,
-        contains('Not a UI/APRS frame'),
-      );
+      expect((result as Ax25Err).reason, contains('Not a UI/APRS frame'));
     });
   });
 }

--- a/test/core/ax25/ax25_parser_test.dart
+++ b/test/core/ax25/ax25_parser_test.dart
@@ -173,5 +173,41 @@ void main() {
       expect(frame.source.callsign, equals('W1AW'));
       expect(frame.source.callsign, isNot(contains(' ')));
     });
+
+    // -------------------------------------------------------------------------
+    // M7: control/PID validation
+    // -------------------------------------------------------------------------
+
+    test('non-UI control byte (0x13) returns Ax25Err with descriptive reason', () {
+      final raw = buildFrame(
+        dst: 'APRS',
+        src: 'W1AW',
+        control: 0x13,
+        pid: 0xF0,
+        info: [0x21],
+      );
+      final result = parser.parseFrame(raw);
+      expect(result, isA<Ax25Err>());
+      expect(
+        (result as Ax25Err).reason,
+        contains('Not a UI/APRS frame'),
+      );
+    });
+
+    test('non-APRS PID (0xCF) returns Ax25Err with descriptive reason', () {
+      final raw = buildFrame(
+        dst: 'APRS',
+        src: 'W1AW',
+        control: 0x03,
+        pid: 0xCF,
+        info: [0x21],
+      );
+      final result = parser.parseFrame(raw);
+      expect(result, isA<Ax25Err>());
+      expect(
+        (result as Ax25Err).reason,
+        contains('Not a UI/APRS frame'),
+      );
+    });
   });
 }

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -8,11 +8,7 @@ import 'package:test/test.dart';
 // AX.25 frame builder (mirrors the helper in ax25_parser_test.dart)
 // ---------------------------------------------------------------------------
 
-List<int> _encodeAddr(
-  String callsign,
-  int ssid, {
-  bool last = false,
-}) {
+List<int> _encodeAddr(String callsign, int ssid, {bool last = false}) {
   final bytes = List<int>.filled(7, 0);
   final padded = callsign.padRight(6);
   for (int i = 0; i < 6; i++) {
@@ -776,81 +772,94 @@ void main() {
     // Yaesu proprietary prefix: '"' + 2 data bytes + '}' (terminator).
     // Strip everything up to and including '}', then suffix _0 →
     // comment should be 'comment', device 'Yaesu FT3D series'.
-    test('strips Yaesu 0x22 prefix (}-terminated) and detects _0 device suffix', () {
-      // Build raw line: 9-byte info prefix + '"4G}' (Yaesu block) + 'comment_0'
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x224G}comment_0';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals('comment'));
-        expect(packet.device, equals('Yaesu FT3D series'));
-      }
-    });
+    test(
+      'strips Yaesu 0x22 prefix (}-terminated) and detects _0 device suffix',
+      () {
+        // Build raw line: 9-byte info prefix + '"4G}' (Yaesu block) + 'comment_0'
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x224G}comment_0';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('comment'));
+          expect(packet.device, equals('Yaesu FT3D series'));
+        }
+      },
+    );
 
     // Backtick 2-channel telemetry: flag + exactly 4 hex digits → strip 5 bytes.
     // Per APRS 1.0.1 ch.10: 2 channels × 2 hex digits = "a1b2" here.
-    test('strips backtick 2-channel telemetry (4 hex digits) and detects ] suffix', () {
-      // comment field: \x60 + "a1b2" (valid hex) + "comment]"
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2comment]';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals('comment'));
-        expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
-      }
-    });
+    test(
+      'strips backtick 2-channel telemetry (4 hex digits) and detects ] suffix',
+      () {
+        // comment field: \x60 + "a1b2" (valid hex) + "comment]"
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2comment]';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('comment'));
+          expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
+        }
+      },
+    );
 
     // Apostrophe 5-channel telemetry: flag + exactly 10 hex digits → strip 11 bytes.
     // Per APRS 1.0.1 ch.10: 5 channels × 2 hex digits = "a1b2c3d4e5" here.
     // Followed by ]" (Kenwood TM-D710 suffix).
-    test('strips apostrophe 5-channel telemetry (10 hex digits) and detects ]" suffix (TM-D710)', () {
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]\x22';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals('comment'));
-        expect(packet.device, equals('Kenwood TM-D710'));
-      }
-    });
+    test(
+      'strips apostrophe 5-channel telemetry (10 hex digits) and detects ]" suffix (TM-D710)',
+      () {
+        final rawLine =
+            'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]\x22';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('comment'));
+          expect(packet.device, equals('Kenwood TM-D710'));
+        }
+      },
+    );
 
     // Apostrophe 5-channel telemetry + ]= suffix (Kenwood TH-D72A).
-    test('strips apostrophe 5-channel telemetry (10 hex digits) and detects ]= suffix', () {
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]=';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals('comment'));
-        expect(packet.device, equals('Kenwood TH-D72A'));
-      }
-    });
+    test(
+      'strips apostrophe 5-channel telemetry (10 hex digits) and detects ]= suffix',
+      () {
+        final rawLine =
+            'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]=';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('comment'));
+          expect(packet.device, equals('Kenwood TH-D72A'));
+        }
+      },
+    );
 
     // Real-world Yaesu FT3D packet: "`"3x}_0"
     // Backtick followed by '"' (0x22) — not a hex digit → strip only 1 byte.
     // The altitude decoder then sees '"3x}' → 6 ft.  After altitude strip the
     // only remaining bytes are '_0' which the device resolver strips as
     // FT3D suffix → empty comment, device 'Yaesu FT3D series', altitude ≈ 6 ft.
-    test('backtick + Yaesu altitude block: `"3x}_0 yields empty comment and altitude', () {
-      // Exact comment bytes from: KM4TJO-7>S6TU8R,...:`h&Vl!b[/`"3x}_0
-      // We use the same format but with the known-good SX5E0A destination.
-      // Comment field (after 9-byte position block): \x60\x22\x33\x78\x7D\x5F\x30
-      // = backtick + '"' + '3' + 'x' + '}' + '_' + '0'
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60\x22\x33\x78\x7D\x5F\x30';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals(''));
-        expect(packet.device, equals('Yaesu FT3D series'));
-        // altitude = (0x22-33)*91^2 + (0x33-33)*91 + (0x78-33) - 10000
-        //          = (1)*8281 + (18)*91 + (87) - 10000
-        //          = 8281 + 1638 + 87 - 10000 = 6
-        expect(packet.altitude, closeTo(6.0, 1.0));
-      }
-    });
+    test(
+      'backtick + Yaesu altitude block: `"3x}_0 yields empty comment and altitude',
+      () {
+        // Exact comment bytes from: KM4TJO-7>S6TU8R,...:`h&Vl!b[/`"3x}_0
+        // We use the same format but with the known-good SX5E0A destination.
+        // Comment field (after 9-byte position block): \x60\x22\x33\x78\x7D\x5F\x30
+        // = backtick + '"' + '3' + 'x' + '}' + '_' + '0'
+        final rawLine =
+            'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60\x22\x33\x78\x7D\x5F\x30';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals(''));
+          expect(packet.device, equals('Yaesu FT3D series'));
+          // altitude = (0x22-33)*91^2 + (0x33-33)*91 + (0x78-33) - 10000
+          //          = (1)*8281 + (18)*91 + (87) - 10000
+          //          = 8281 + 1638 + 87 - 10000 = 6
+          expect(packet.altitude, closeTo(6.0, 1.0));
+        }
+      },
+    );
 
     // Real-world Yaesu FT3D with user text in the comment: the radio uses
     // backtick (symbol table = ` at byte 8) + backtick comment prefix (byte 9)
@@ -864,22 +873,24 @@ void main() {
     // "Er" are NOT hex digits, so backtick is a 1-byte device-type prefix.
     // Strip 1 byte → "Eric's FT3DR_0 " → trim → "Eric's FT3DR_0".
     // _\d$ matches → strip "_0" → "Eric's FT3DR"; device = Yaesu FT3D series.
-    test('backtick + non-hex text + _0 suffix + trailing space: full comment preserved', () {
-      final rawLine =
-          "N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60Eric's FT3DR_0 ";
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals("Eric's FT3DR"));
-        expect(packet.device, equals('Yaesu FT3D series'));
-      }
-    });
+    test(
+      'backtick + non-hex text + _0 suffix + trailing space: full comment preserved',
+      () {
+        final rawLine =
+            "N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60Eric's FT3DR_0 ";
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals("Eric's FT3DR"));
+          expect(packet.device, equals('Yaesu FT3D series'));
+        }
+      },
+    );
 
     // Actual 2-channel telemetry: backtick + 4 hex digits + remaining comment.
     // "a1b2" are valid hex → strip flag + 4 hex = 5 bytes.
     test('backtick + 4 hex digits = telemetry stripped, remainder kept', () {
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
       final packet = parser.parse(rawLine);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
@@ -889,8 +900,7 @@ void main() {
     });
 
     test('comment with no prefix and no suffix is unchanged', () {
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
       final packet = parser.parse(rawLine);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
@@ -926,10 +936,7 @@ void main() {
       );
       final packet = parser.parseFrame(frame);
       expect(packet, isA<MicEPacket>());
-      expect(
-        (packet as MicEPacket).lon,
-        inInclusiveRange(-180.0, 180.0),
-      );
+      expect((packet as MicEPacket).lon, inInclusiveRange(-180.0, 180.0));
     });
 
     test('parseFrame and parse produce consistent lat/lon for latin1 0xB7', () {
@@ -989,10 +996,7 @@ void main() {
       );
       final packet = parser.parseFrame(frame);
       expect(packet, isA<UnknownPacket>());
-      expect(
-        (packet as UnknownPacket).reason,
-        contains('Not a UI/APRS frame'),
-      );
+      expect((packet as UnknownPacket).reason, contains('Not a UI/APRS frame'));
     });
 
     test('non-APRS PID (0xCF) returns UnknownPacket', () {
@@ -1006,10 +1010,7 @@ void main() {
       );
       final packet = parser.parseFrame(frame);
       expect(packet, isA<UnknownPacket>());
-      expect(
-        (packet as UnknownPacket).reason,
-        contains('Not a UI/APRS frame'),
-      );
+      expect((packet as UnknownPacket).reason, contains('Not a UI/APRS frame'));
     });
   });
 
@@ -1141,17 +1142,19 @@ void main() {
     //   c1=0 → char 33='!', c2=90 → char 123='{', c3=90 → char 123='{', c4='}'
     //   Verify: (0)*8281 + (90)*91 + (90) - 10000 = 0+8190+90-10000 = -1720
     //   c1 is '!' (0x21), not '"' (0x22), so Yaesu stripper is not triggered.
-    test('base-91 altitude -1720 ft (below sea level) decoded from comment', () {
-      // info comment bytes: '!' '{' '{' '}' = 0x21 0x7B 0x7B 0x7D
-      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/!\x7B\x7B\x7D';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      expect((packet as MicEPacket).altitude, closeTo(-1720.0, 0.5));
-    });
+    test(
+      'base-91 altitude -1720 ft (below sea level) decoded from comment',
+      () {
+        // info comment bytes: '!' '{' '{' '}' = 0x21 0x7B 0x7B 0x7D
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/!\x7B\x7B\x7D';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        expect((packet as MicEPacket).altitude, closeTo(-1720.0, 0.5));
+      },
+    );
 
     test('comment with no altitude prefix leaves altitude null', () {
-      final rawLine =
-          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
       final packet = parser.parse(rawLine);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).altitude, isNull);

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1,6 +1,44 @@
+import 'dart:typed_data';
+
 import 'package:meridian_aprs/core/packet/aprs_packet.dart';
 import 'package:meridian_aprs/core/packet/aprs_parser.dart';
 import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// AX.25 frame builder (mirrors the helper in ax25_parser_test.dart)
+// ---------------------------------------------------------------------------
+
+List<int> _encodeAddr(
+  String callsign,
+  int ssid, {
+  bool last = false,
+}) {
+  final bytes = List<int>.filled(7, 0);
+  final padded = callsign.padRight(6);
+  for (int i = 0; i < 6; i++) {
+    bytes[i] = padded.codeUnitAt(i) << 1;
+  }
+  bytes[6] = ((ssid & 0x0F) << 1) | (last ? 0x01 : 0x00);
+  return bytes;
+}
+
+Uint8List _buildAprsFrame({
+  required String dst,
+  int dstSsid = 0,
+  required String src,
+  int srcSsid = 0,
+  int control = 0x03,
+  int pid = 0xF0,
+  required List<int> info,
+}) {
+  final bytes = <int>[];
+  bytes.addAll(_encodeAddr(dst, dstSsid, last: false));
+  bytes.addAll(_encodeAddr(src, srcSsid, last: true));
+  bytes.add(control);
+  bytes.add(pid);
+  bytes.addAll(info);
+  return Uint8List.fromList(bytes);
+}
 
 void main() {
   late AprsParser parser;
@@ -697,6 +735,443 @@ void main() {
       expect(p.source, equals('WB4APR-14'));
       expect(p.destination, equals('APWW10'));
       expect(p.path, contains('TCPIP*'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Device resolution — PositionPacket
+  // ---------------------------------------------------------------------------
+
+  group('device resolution — PositionPacket', () {
+    test('destination APDR15 → device is APRSdroid', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APDR15,WIDE1-1:!4903.50N/07201.75W-Test',
+      );
+      expect(p.device, equals('APRSdroid'));
+    });
+
+    test('destination APDW2 → device is Dire Wolf', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APDW2,WIDE1-1:!4903.50N/07201.75W-Test',
+      );
+      expect(p.device, equals('Dire Wolf'));
+    });
+
+    test('unknown destination → device is null', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APXXX:!4903.50N/07201.75W-Test',
+      );
+      expect(p.device, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Device resolution and comment cleaning — MicEPacket
+  // ---------------------------------------------------------------------------
+
+  group('device resolution and comment cleaning — MicEPacket', () {
+    // Baseline Mic-E info: "`i<N Ol>/" (9 bytes), destination SX5E0A decodes
+    // to a valid position. We append comment bytes after the 9-byte fixed block.
+
+    // Yaesu proprietary prefix: '"' + 2 data bytes + '}' (terminator).
+    // Strip everything up to and including '}', then suffix _0 →
+    // comment should be 'comment', device 'Yaesu FT3D series'.
+    test('strips Yaesu 0x22 prefix (}-terminated) and detects _0 device suffix', () {
+      // Build raw line: 9-byte info prefix + '"4G}' (Yaesu block) + 'comment_0'
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x224G}comment_0';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('comment'));
+        expect(packet.device, equals('Yaesu FT3D series'));
+      }
+    });
+
+    // Backtick 2-channel telemetry: flag + exactly 4 hex digits → strip 5 bytes.
+    // Per APRS 1.0.1 ch.10: 2 channels × 2 hex digits = "a1b2" here.
+    test('strips backtick 2-channel telemetry (4 hex digits) and detects ] suffix', () {
+      // comment field: \x60 + "a1b2" (valid hex) + "comment]"
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2comment]';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('comment'));
+        expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
+      }
+    });
+
+    // Apostrophe 5-channel telemetry: flag + exactly 10 hex digits → strip 11 bytes.
+    // Per APRS 1.0.1 ch.10: 5 channels × 2 hex digits = "a1b2c3d4e5" here.
+    // Followed by ]" (Kenwood TM-D710 suffix).
+    test('strips apostrophe 5-channel telemetry (10 hex digits) and detects ]" suffix (TM-D710)', () {
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]\x22';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('comment'));
+        expect(packet.device, equals('Kenwood TM-D710'));
+      }
+    });
+
+    // Apostrophe 5-channel telemetry + ]= suffix (Kenwood TH-D72A).
+    test('strips apostrophe 5-channel telemetry (10 hex digits) and detects ]= suffix', () {
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]=';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('comment'));
+        expect(packet.device, equals('Kenwood TH-D72A'));
+      }
+    });
+
+    // Real-world Yaesu FT3D packet: "`"3x}_0"
+    // Backtick followed by '"' (0x22) — not a hex digit → strip only 1 byte.
+    // The altitude decoder then sees '"3x}' → 6 ft.  After altitude strip the
+    // only remaining bytes are '_0' which the device resolver strips as
+    // FT3D suffix → empty comment, device 'Yaesu FT3D series', altitude ≈ 6 ft.
+    test('backtick + Yaesu altitude block: `"3x}_0 yields empty comment and altitude', () {
+      // Exact comment bytes from: KM4TJO-7>S6TU8R,...:`h&Vl!b[/`"3x}_0
+      // We use the same format but with the known-good SX5E0A destination.
+      // Comment field (after 9-byte position block): \x60\x22\x33\x78\x7D\x5F\x30
+      // = backtick + '"' + '3' + 'x' + '}' + '_' + '0'
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60\x22\x33\x78\x7D\x5F\x30';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals(''));
+        expect(packet.device, equals('Yaesu FT3D series'));
+        // altitude = (0x22-33)*91^2 + (0x33-33)*91 + (0x78-33) - 10000
+        //          = (1)*8281 + (18)*91 + (87) - 10000
+        //          = 8281 + 1638 + 87 - 10000 = 6
+        expect(packet.altitude, closeTo(6.0, 1.0));
+      }
+    });
+
+    // Real-world Yaesu FT3D with user text in the comment: the radio uses
+    // backtick (symbol table = ` at byte 8) + backtick comment prefix (byte 9)
+    // + user text + `_0` device suffix + trailing space.
+    // The 3-byte telemetry strip eats `\x60` + first 2 chars of user text.
+    // The trailing space must be trimmed BEFORE suffix detection so `_\d$`
+    // can match `_0`, giving stripped comment = remaining text without `_0`.
+    // Real-world Yaesu FT3D with user text: radio prepends a backtick before
+    // the user text and appends `_0` + trailing space.
+    // Comment bytes: \x60 + "Eric's FT3DR_0 " (trailing space after suffix).
+    // "Er" are NOT hex digits, so backtick is a 1-byte device-type prefix.
+    // Strip 1 byte → "Eric's FT3DR_0 " → trim → "Eric's FT3DR_0".
+    // _\d$ matches → strip "_0" → "Eric's FT3DR"; device = Yaesu FT3D series.
+    test('backtick + non-hex text + _0 suffix + trailing space: full comment preserved', () {
+      final rawLine =
+          "N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60Eric's FT3DR_0 ";
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals("Eric's FT3DR"));
+        expect(packet.device, equals('Yaesu FT3D series'));
+      }
+    });
+
+    // Actual 2-channel telemetry: backtick + 4 hex digits + remaining comment.
+    // "a1b2" are valid hex → strip flag + 4 hex = 5 bytes.
+    test('backtick + 4 hex digits = telemetry stripped, remainder kept', () {
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('rest'));
+        expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
+      }
+    });
+
+    test('comment with no prefix and no suffix is unchanged', () {
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('plain comment'));
+        expect(packet.device, isNull);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // B4: parseFrame latin1 decode
+  // ---------------------------------------------------------------------------
+
+  group('parseFrame — latin1 decode', () {
+    // Build a Mic-E AX.25 frame with info[1] = 0xB7 (183 decimal).
+    // utf8.decode(allowMalformed:true) would corrupt 0xB7 to U+FFFD (65533),
+    // causing b1 = 65533 - 28 = 65505 — a hopelessly invalid longitude.
+    // latin1.decode preserves it as 183, giving b1 = 183 - 28 = 155,
+    // lonDeg = 155 → after wrap correction a valid result.
+    //
+    // Destination SX5E0A: S=P+3 stdBit, X=P+8 stdBit, 5=digit, E=North,
+    // 0=no offset, A=West. This is the same destination used in other tests.
+    // Info bytes: [0x60, 0xB7, 0x4C, 0x50, 0x20, 0x4C, 0x6C, 0x3E, 0x2F]
+    // (backtick DTI, 0xB7 lon byte, then remaining Mic-E bytes)
+
+    test('parseFrame with latin1 byte 0xB7 produces MicEPacket', () {
+      final infoBytes = [0x60, 0xB7, 0x4C, 0x50, 0x20, 0x4C, 0x6C, 0x3E, 0x2F];
+      final frame = _buildAprsFrame(
+        dst: 'SX5E0A',
+        src: 'N0CALL',
+        srcSsid: 9,
+        info: infoBytes,
+      );
+      final packet = parser.parseFrame(frame);
+      expect(packet, isA<MicEPacket>());
+      expect(
+        (packet as MicEPacket).lon,
+        inInclusiveRange(-180.0, 180.0),
+      );
+    });
+
+    test('parseFrame and parse produce consistent lat/lon for latin1 0xB7', () {
+      // APRS-IS string with same destination/info using latin1 char 0xB7.
+      const rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60\xB7LPN Ol>/';
+      final fromString = parser.parse(rawLine);
+      expect(fromString, isA<MicEPacket>());
+
+      final infoBytes = [0x60, 0xB7, 0x4C, 0x50, 0x20, 0x4C, 0x6C, 0x3E, 0x2F];
+      final frame = _buildAprsFrame(
+        dst: 'SX5E0A',
+        src: 'N0CALL',
+        srcSsid: 9,
+        info: infoBytes,
+      );
+      final fromFrame = parser.parseFrame(frame);
+      expect(fromFrame, isA<MicEPacket>());
+
+      final p1 = fromString as MicEPacket;
+      final p2 = fromFrame as MicEPacket;
+      expect(p1.lat, closeTo(p2.lat, 1e-6));
+      expect(p1.lon, closeTo(p2.lon, 1e-6));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // B5: Item minimum name length (3-char minimum)
+  // ---------------------------------------------------------------------------
+
+  group('ItemPacket — minimum name length', () {
+    test('2-char item name (delimiter at index 2) is rejected', () {
+      final packet = parser.parse('W1ABC>APRS:)AB!4903.50N/07201.75W-');
+      expect(packet, isA<UnknownPacket>());
+    });
+
+    test('3-char item name is accepted', () {
+      final p = expectPacketType<ItemPacket>(
+        'W1ABC>APRS:)ABC!4903.50N/07201.75W-',
+      );
+      expect(p.itemName, equals('ABC'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // M7: AX.25 control/PID validation
+  // ---------------------------------------------------------------------------
+
+  group('AX.25 control/PID validation (via parseFrame)', () {
+    test('non-UI control byte (0x13) returns UnknownPacket', () {
+      final infoBytes = [0x21, 0x41]; // minimal info
+      final frame = _buildAprsFrame(
+        dst: 'APRS',
+        src: 'W1AW',
+        control: 0x13,
+        pid: 0xF0,
+        info: infoBytes,
+      );
+      final packet = parser.parseFrame(frame);
+      expect(packet, isA<UnknownPacket>());
+      expect(
+        (packet as UnknownPacket).reason,
+        contains('Not a UI/APRS frame'),
+      );
+    });
+
+    test('non-APRS PID (0xCF) returns UnknownPacket', () {
+      final infoBytes = [0x21, 0x41];
+      final frame = _buildAprsFrame(
+        dst: 'APRS',
+        src: 'W1AW',
+        control: 0x03,
+        pid: 0xCF,
+        info: infoBytes,
+      );
+      final packet = parser.parseFrame(frame);
+      expect(packet, isA<UnknownPacket>());
+      expect(
+        (packet as UnknownPacket).reason,
+        contains('Not a UI/APRS frame'),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // M2: Compressed speed — pow formula (sByte=0 → speed=0.0, not -1.0)
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket compressed — speed formula', () {
+    // cByte=3 → course=12; sByte=0 → speed = pow(1.08,0)-1 = 0.0
+    // T byte: comprType=1 (course/speed) → bits 5-4 of (T-33) = 0b0001_0000 = 16
+    //   T = 33+16 = 49 = '1'
+    // c byte: cByte+33 = 36 = '$'
+    // s byte: sByte+33 = 33 = '!'
+    // Packet uses existing compressed pos base '/5L!!<*e7>' with csT='$!1'
+    test('sByte=0 produces speed=0.0 not -1.0', () {
+      final p = expectPacketType<PositionPacket>(
+        r'N0CALL>APRS:=/5L!!<*e7>$!1Comment',
+      );
+      expect(p.speed, equals(0.0));
+      expect(p.course, equals(12));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // M6: Compressed position — space c byte leaves course/speed null
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket compressed — space c byte', () {
+    // First csT char is 0x20 (space): no course/speed data.
+    // Using the same base '/5L!!<*e7>' with csT=' AB' (space + two data bytes).
+    test('space c byte produces null course and speed', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:=/5L!!<*e7> ABComment',
+      );
+      expect(p.course, isNull);
+      expect(p.speed, isNull);
+      expect(p.comment, equals('Comment'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // M8: Uncompressed position — course/speed stripped from comment
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket uncompressed — course/speed stripped from comment', () {
+    test('course/speed prefix stripped from comment', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W>059/030My comment',
+      );
+      expect(p.comment, equals('My comment'));
+    });
+
+    test('000/000 course/speed leaves comment unchanged', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W>000/000My comment',
+      );
+      expect(p.comment, equals('000/000My comment'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // B1: Mic-E Standard vs Custom message type
+  // ---------------------------------------------------------------------------
+
+  group('MicEPacket — Standard vs Custom message bits', () {
+    // Destination ABJE0A:
+    //   'A'(0x41=A+0) i=0 → custBits |= 0b100 (4)
+    //   'B'(0x42=A+1) i=1 → custBits |= 0b010 (2)
+    //   'J'(0x4A=A+9) i=2 → custBits |= 0b001 (1)
+    //   'E'(A+4) i=3 → isNorth, '0' i=4 → no offset, 'A'(A+0) i=5 → isWest
+    //   custBits = 0b111 = 7, stdBits = 0 → _micECustomMessages[7] = 'Custom-6'
+    test('Mic-E Custom message bits (A-J) decode to Custom-6', () {
+      final rawLine = 'N0CALL-9>ABJE0A,WIDE1-1:\x60i<N Ol>/';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Custom-6'));
+    });
+
+    // Destination ASRE0A:
+    //   'A'(0x41) i=0 → custBits |= 0b100
+    //   'S'(0x53=P+3) i=1 → stdBits |= 0b010
+    //   'R'(0x52=P+2) i=2 → stdBits |= 0b001
+    //   custBits=0b100≠0, stdBits=0b011≠0 → mixed → 'Unknown'
+    test('Mic-E mixed Standard+Custom bits decode to Unknown', () {
+      final rawLine = 'N0CALL-9>ASRE0A,WIDE1-1:\x60i<N Ol>/';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Unknown'));
+    });
+
+    // Regression: P-Y only → stdBits → standard table (Off Duty, In Service)
+    test('regression: Off Duty still decodes correctly', () {
+      final packet = parser.parse('N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Off Duty'));
+    });
+
+    test('regression: In Service still decodes correctly', () {
+      final packet = parser.parse('N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('In Service'));
+    });
+
+    // All digits → stdBits=0, custBits=0 → Emergency
+    test('regression: Emergency (all digits) still decodes correctly', () {
+      final packet = parser.parse('N0CALL-9>385E0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Emergency'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // B2: Mic-E base-91 altitude from comment
+  // ---------------------------------------------------------------------------
+
+  group('MicEPacket — base-91 altitude', () {
+    // 10000 ft: altFeet+10000=20000
+    //   c1=2 → char 35='#', c2=37 → char 70='F', c3=71 → char 104='h', c4='}'
+    //   Verify: (2)*8281 + (37)*91 + (71) - 10000 = 16562+3367+71-10000 = 10000
+    //   c1 is '#' (0x23), not '"' (0x22), so the Yaesu stripper is not triggered.
+    test('base-91 altitude 10000 ft decoded from comment', () {
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x23Fh}';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).altitude, closeTo(10000.0, 0.5));
+    });
+
+    // -1720 ft: altFeet+10000=8280
+    //   c1=0 → char 33='!', c2=90 → char 123='{', c3=90 → char 123='{', c4='}'
+    //   Verify: (0)*8281 + (90)*91 + (90) - 10000 = 0+8190+90-10000 = -1720
+    //   c1 is '!' (0x21), not '"' (0x22), so Yaesu stripper is not triggered.
+    test('base-91 altitude -1720 ft (below sea level) decoded from comment', () {
+      // info comment bytes: '!' '{' '{' '}' = 0x21 0x7B 0x7B 0x7D
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/!\x7B\x7B\x7D';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).altitude, closeTo(-1720.0, 0.5));
+    });
+
+    test('comment with no altitude prefix leaves altitude null', () {
+      final rawLine =
+          'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).altitude, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // B3: Compressed position GGA altitude
+  // ---------------------------------------------------------------------------
+
+  group('PositionPacket compressed — GGA altitude', () {
+    // altitude ≈ 1000 ft: pow(1.002, x) = 1000 → x ≈ 3453
+    //   3453 = 37*91 + 86 → cByte=37 → char 70='F', sByte=86 → char 119='w'
+    //   T byte: comprType=2 → bits 5-4 of (T-33) = 0b10 = 0x20 → T=65='A'
+    test('GGA altitude ~1000 ft decoded from compressed position', () {
+      final p = expectPacketType<PositionPacket>(
+        r'N0CALL>APRS:=/5L!!<*e7>FwAMy comment',
+      );
+      expect(p.altitude, isNotNull);
+      expect(p.altitude!, closeTo(1000.0, 50.0));
     });
   });
 }

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -501,6 +501,75 @@ void main() {
       );
       expect(packet, anyOf(isA<MicEPacket>(), isA<UnknownPacket>()));
     });
+
+    // -------------------------------------------------------------------------
+    // P-Y encoding (custom message) — Bug 2 regression tests
+    // -------------------------------------------------------------------------
+    //
+    // Packet: N0CALL-9>SX5E0A,WIDE1-1:`i<N Ol>/
+    // Destination SX5E0A encodes:
+    //   'S' (0x53) = P+3 → digit=3, msgBit=true  (custom, A-bit set)
+    //   'X' (0x58) = P+8 → digit=8, msgBit=true  (custom, B-bit set)
+    //   '5'        → digit=5, msgBit=false         (C-bit clear)
+    //   'E' (0x45) = A+4 → digit=4, msgBit=true   (North)
+    //   '0'        → digit=0, msgBit=false          (no lon offset)
+    //   'A' (0x41) = A+0 → digit=0, msgBit=true   (West)
+    // messageBits = 0b110 = 6 → En Route (custom)
+    // lat = 38°54.00' N = 38.9000 N
+    // lon: info[1]='i'(105-28=77), info[2]='<'(60-28=32), info[3]='N'(78-28=50)
+    //      → 77°32.50' W = -77.5417
+    test('P-Y destination decodes lat, lon, hemisphere, and message type', () {
+      // All printable ASCII; info field is exactly 9 bytes.
+      final packet = parser.parse('N0CALL-9>SX5E0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      final p = packet as MicEPacket;
+      expect(p.lat, closeTo(38.9, 0.001));
+      expect(p.lon, closeTo(-77.5417, 0.001));
+      expect(p.lat, isPositive, reason: 'should be North (positive)');
+      expect(p.lon, isNegative, reason: 'should be West (negative)');
+      expect(p.micEMessage, equals('En Route'));
+    });
+
+    // -------------------------------------------------------------------------
+    // _micEMessages table ordering — Bug 3 regression tests
+    // -------------------------------------------------------------------------
+    //
+    // These use the same constructible packet above but we only need a packet
+    // that decodes to a specific messageBits value.  We use a helper that
+    // calls _parseMicE indirectly through parse().
+    //
+    // messageBits=7 (0b111) → Off Duty
+    //   All three bits set: positions 0,1,2 must all be letters.
+    //   'S'(P+3),  'X'(P+8),  'T'(P+4)  → digits 3,8,4 / bits 1,1,1
+    //   Position 3 North: 'E'(A+4), Position 4 no offset: '0', Position 5 West: 'A'
+    //   Destination: SXT E0A → SXTE0A  (6 chars)
+    //   lat = 38°84.00' — latMin=84 is out of range; that is fine, the parser
+    //   does no range validation on lat.  We only check micEMessage here.
+    test('messageBits=7 decodes to Off Duty', () {
+      final packet = parser.parse('N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Off Duty'));
+    });
+
+    // messageBits=0 (0b000) → Emergency
+    //   All three bits clear: positions 0,1,2 must all be plain digits.
+    //   '3', '8', '5' → bits 0,0,0
+    //   North: 'E', no offset: '0', West: 'A'  → Destination: 385E0A
+    test('messageBits=0 decodes to Emergency', () {
+      final packet = parser.parse('N0CALL-9>385E0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('Emergency'));
+    });
+
+    // messageBits=5 (0b101) → In Service
+    //   Bits: A=1, B=0, C=1 → pos0=letter, pos1=digit, pos2=letter
+    //   'S'(P+3), '8', 'T'(P+4) → bits 1,0,1 = 0b101 = 5
+    //   Destination: S8TE0A
+    test('messageBits=5 decodes to In Service', () {
+      final packet = parser.parse('N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/');
+      expect(packet, isA<MicEPacket>());
+      expect((packet as MicEPacket).micEMessage, equals('In Service'));
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/core/packet/device_resolver_test.dart
+++ b/test/core/packet/device_resolver_test.dart
@@ -4,17 +4,11 @@ import 'package:test/test.dart';
 void main() {
   group('DeviceResolver.resolve — tocall', () {
     test('APDR16 → APRSdroid', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APDR16'),
-        equals('APRSdroid'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APDR16'), equals('APRSdroid'));
     });
 
     test('APDW1.6 → Dire Wolf', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APDW1.6'),
-        equals('Dire Wolf'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APDW1.6'), equals('Dire Wolf'));
     });
 
     test('APK004 → Kenwood TH-D7A', () {
@@ -25,31 +19,19 @@ void main() {
     });
 
     test('APWW10 → UI-View32', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APWW10'),
-        equals('UI-View32'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APWW10'), equals('UI-View32'));
     });
 
     test('unknown tocall returns null', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APXXX'),
-        isNull,
-      );
+      expect(DeviceResolver.resolve(tocall: 'APXXX'), isNull);
     });
 
     test('case-insensitive match on lowercase tocall', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'apdr12'),
-        equals('APRSdroid'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'apdr12'), equals('APRSdroid'));
     });
 
     test('tocall with SSID stripped before match', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APDW-7'),
-        equals('Dire Wolf'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APDW-7'), equals('Dire Wolf'));
     });
 
     test('APFII prefix → iPhone app (APRS.fi)', () {
@@ -60,17 +42,11 @@ void main() {
     });
 
     test('APAGW prefix → AGWTracker', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APAGW0'),
-        equals('AGWTracker'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APAGW0'), equals('AGWTracker'));
     });
 
     test('APRS (generic) matches', () {
-      expect(
-        DeviceResolver.resolve(tocall: 'APRS'),
-        equals('APRS (generic)'),
-      );
+      expect(DeviceResolver.resolve(tocall: 'APRS'), equals('APRS (generic)'));
     });
   });
 
@@ -125,10 +101,7 @@ void main() {
     });
 
     test('generic > suffix with 2-char identifier → returned as device', () {
-      expect(
-        DeviceResolver.resolve(micECommentSuffix: 'hi>AB'),
-        equals('AB'),
-      );
+      expect(DeviceResolver.resolve(micECommentSuffix: 'hi>AB'), equals('AB'));
     });
 
     test('no known pattern → null', () {
@@ -139,10 +112,7 @@ void main() {
     });
 
     test('empty suffix → null', () {
-      expect(
-        DeviceResolver.resolve(micECommentSuffix: ''),
-        isNull,
-      );
+      expect(DeviceResolver.resolve(micECommentSuffix: ''), isNull);
     });
 
     test('generic > suffix that is too long (>10 chars) → null', () {
@@ -153,10 +123,7 @@ void main() {
     });
 
     test('generic > suffix that is 1 char → null (too short)', () {
-      expect(
-        DeviceResolver.resolve(micECommentSuffix: 'comment>X'),
-        isNull,
-      );
+      expect(DeviceResolver.resolve(micECommentSuffix: 'comment>X'), isNull);
     });
   });
 

--- a/test/core/packet/device_resolver_test.dart
+++ b/test/core/packet/device_resolver_test.dart
@@ -1,0 +1,172 @@
+import 'package:meridian_aprs/core/packet/device_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DeviceResolver.resolve — tocall', () {
+    test('APDR16 → APRSdroid', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APDR16'),
+        equals('APRSdroid'),
+      );
+    });
+
+    test('APDW1.6 → Dire Wolf', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APDW1.6'),
+        equals('Dire Wolf'),
+      );
+    });
+
+    test('APK004 → Kenwood TH-D7A', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APK004'),
+        equals('Kenwood TH-D7A'),
+      );
+    });
+
+    test('APWW10 → UI-View32', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APWW10'),
+        equals('UI-View32'),
+      );
+    });
+
+    test('unknown tocall returns null', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APXXX'),
+        isNull,
+      );
+    });
+
+    test('case-insensitive match on lowercase tocall', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'apdr12'),
+        equals('APRSdroid'),
+      );
+    });
+
+    test('tocall with SSID stripped before match', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APDW-7'),
+        equals('Dire Wolf'),
+      );
+    });
+
+    test('APFII prefix → iPhone app (APRS.fi)', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APFII24'),
+        equals('iPhone app (APRS.fi)'),
+      );
+    });
+
+    test('APAGW prefix → AGWTracker', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APAGW0'),
+        equals('AGWTracker'),
+      );
+    });
+
+    test('APRS (generic) matches', () {
+      expect(
+        DeviceResolver.resolve(tocall: 'APRS'),
+        equals('APRS (generic)'),
+      );
+    });
+  });
+
+  group('DeviceResolver.resolve — Mic-E suffix', () {
+    test('suffix ] → Kenwood (TH-D7x/TM-D7x)', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'some comment]'),
+        equals('Kenwood (TH-D7x/TM-D7x)'),
+      );
+    });
+
+    test('suffix ]= → Kenwood TH-D72A', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'some comment]='),
+        equals('Kenwood TH-D72A'),
+      );
+    });
+
+    test('suffix ^ → Yaesu VX-8', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment^'),
+        equals('Yaesu VX-8'),
+      );
+    });
+
+    test('suffix ~ → Yaesu FT2D', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment~'),
+        equals('Yaesu FT2D'),
+      );
+    });
+
+    test('suffix _0 → Yaesu FT3D series', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment_0'),
+        equals('Yaesu FT3D series'),
+      );
+    });
+
+    test('suffix _9 → Yaesu FT3D series', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment_9'),
+        equals('Yaesu FT3D series'),
+      );
+    });
+
+    test('generic >FT3DR suffix → FT3DR', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment>FT3DR'),
+        equals('FT3DR'),
+      );
+    });
+
+    test('generic > suffix with 2-char identifier → returned as device', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'hi>AB'),
+        equals('AB'),
+      );
+    });
+
+    test('no known pattern → null', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'just a plain comment'),
+        isNull,
+      );
+    });
+
+    test('empty suffix → null', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: ''),
+        isNull,
+      );
+    });
+
+    test('generic > suffix that is too long (>10 chars) → null', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment>TOOLONGDEVICENAME'),
+        isNull,
+      );
+    });
+
+    test('generic > suffix that is 1 char → null (too short)', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'comment>X'),
+        isNull,
+      );
+    });
+  });
+
+  group('DeviceResolver.resolve — null inputs', () {
+    test('both null → null', () {
+      expect(DeviceResolver.resolve(), isNull);
+    });
+
+    test('empty tocall → null', () {
+      expect(DeviceResolver.resolve(tocall: ''), isNull);
+    });
+  });
+}

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -70,7 +70,10 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   int get mtu => fakeMtu;
 
   @override
-  Future<void> connect({int? mtu, Duration timeout = const Duration(seconds: 15)}) async {
+  Future<void> connect({
+    int? mtu,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
     connectCallCount++;
     if (connectThrows) throw Exception('FakeBleDeviceAdapter: connect failed');
   }
@@ -90,7 +93,8 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   @override
   Future<List<BluetoothService>> discoverServices() async {
     discoverCallCount++;
-    if (discoverThrows) throw Exception('FakeBleDeviceAdapter: discoverServices failed');
+    if (discoverThrows)
+      throw Exception('FakeBleDeviceAdapter: discoverServices failed');
     return services;
   }
 
@@ -139,19 +143,22 @@ void main() {
     });
 
     // 2 -----------------------------------------------------------------------
-    test('connect() emits connecting status then transitions to error when no matching service', () async {
-      // fakeAdapter.services is empty → service UUID not found → error.
-      final capturedStates = <ConnectionStatus>[];
-      final sub = transport.connectionState.listen(capturedStates.add);
+    test(
+      'connect() emits connecting status then transitions to error when no matching service',
+      () async {
+        // fakeAdapter.services is empty → service UUID not found → error.
+        final capturedStates = <ConnectionStatus>[];
+        final sub = transport.connectionState.listen(capturedStates.add);
 
-      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
 
-      await sub.cancel();
+        await sub.cancel();
 
-      expect(capturedStates, containsAll([ConnectionStatus.connecting]));
-      // After the exception the status must be error.
-      expect(transport.currentStatus, ConnectionStatus.error);
-    });
+        expect(capturedStates, containsAll([ConnectionStatus.connecting]));
+        // After the exception the status must be error.
+        expect(transport.currentStatus, ConnectionStatus.error);
+      },
+    );
 
     // 3 -----------------------------------------------------------------------
     test('connect() calls device connect and discoverServices', () async {
@@ -162,32 +169,38 @@ void main() {
     });
 
     // 4 -----------------------------------------------------------------------
-    test('connect() transitions to error when adapter.connect() throws', () async {
-      fakeAdapter.connectThrows = true;
+    test(
+      'connect() transitions to error when adapter.connect() throws',
+      () async {
+        fakeAdapter.connectThrows = true;
 
-      final capturedStates = <ConnectionStatus>[];
-      final sub = transport.connectionState.listen(capturedStates.add);
+        final capturedStates = <ConnectionStatus>[];
+        final sub = transport.connectionState.listen(capturedStates.add);
 
-      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
 
-      await sub.cancel();
+        await sub.cancel();
 
-      expect(transport.currentStatus, ConnectionStatus.error);
-      // disconnect() should have been called during cleanup.
-      expect(fakeAdapter.disconnectCallCount, 1);
-    });
+        expect(transport.currentStatus, ConnectionStatus.error);
+        // disconnect() should have been called during cleanup.
+        expect(fakeAdapter.disconnectCallCount, 1);
+      },
+    );
 
     // 5 -----------------------------------------------------------------------
-    test('connect() retries discoverServices up to 3 times when it throws', () async {
-      fakeAdapter.discoverThrows = true;
+    test(
+      'connect() retries discoverServices up to 3 times when it throws',
+      () async {
+        fakeAdapter.discoverThrows = true;
 
-      // connect() → adapter.connect succeeds → discoverServices throws × 3 → rethrows.
-      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        // connect() → adapter.connect succeeds → discoverServices throws × 3 → rethrows.
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
 
-      // The implementation retries up to 3× before rethrowing.
-      expect(fakeAdapter.discoverCallCount, 3);
-      expect(transport.currentStatus, ConnectionStatus.error);
-    });
+        // The implementation retries up to 3× before rethrowing.
+        expect(fakeAdapter.discoverCallCount, 3);
+        expect(transport.currentStatus, ConnectionStatus.error);
+      },
+    );
 
     // 6 -----------------------------------------------------------------------
     test('disconnect() on disconnected transport is a no-op', () async {
@@ -222,10 +235,7 @@ void main() {
     // 8 -----------------------------------------------------------------------
     test('sendFrame throws StateError when not connected', () async {
       final ax25 = Uint8List.fromList([0x01, 0x02, 0x03]);
-      expect(
-        () async => transport.sendFrame(ax25),
-        throwsA(isA<StateError>()),
-      );
+      expect(() async => transport.sendFrame(ax25), throwsA(isA<StateError>()));
     });
 
     // 9 -----------------------------------------------------------------------
@@ -245,7 +255,11 @@ void main() {
       });
 
       test('reassembles a frame delivered in two BLE chunks', () async {
-        final kissBytes = _buildKissFrame('W1AW', 'APRS', '!4903.50N/07201.75W-BLE');
+        final kissBytes = _buildKissFrame(
+          'W1AW',
+          'APRS',
+          '!4903.50N/07201.75W-BLE',
+        );
         // Split the frame into two chunks as BLE might deliver them.
         final mid = kissBytes.length ~/ 2;
         final chunk1 = kissBytes.sublist(0, mid);
@@ -266,7 +280,11 @@ void main() {
       });
 
       test('reassembles a frame delivered one byte at a time', () async {
-        final kissBytes = _buildKissFrame('KD9TST', 'APRS', '>Testing BLE chunks');
+        final kissBytes = _buildKissFrame(
+          'KD9TST',
+          'APRS',
+          '>Testing BLE chunks',
+        );
         final frames = <Uint8List>[];
         final sub = framer.frames.listen(frames.add);
 
@@ -337,7 +355,9 @@ void main() {
         }
 
         // All chunks together must reconstruct the original KISS frame.
-        final reassembled = Uint8List.fromList(chunks.expand((c) => c).toList());
+        final reassembled = Uint8List.fromList(
+          chunks.expand((c) => c).toList(),
+        );
         expect(reassembled, equals(kissFrame));
         // No chunk exceeds MTU.
         for (final chunk in chunks) {

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -93,8 +93,9 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   @override
   Future<List<BluetoothService>> discoverServices() async {
     discoverCallCount++;
-    if (discoverThrows)
+    if (discoverThrows) {
       throw Exception('FakeBleDeviceAdapter: discoverServices failed');
+    }
     return services;
   }
 

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/transport/aprs_transport.dart';
+import 'package:meridian_aprs/core/transport/ble_tnc_transport_impl.dart';
+import 'package:meridian_aprs/core/transport/kiss_framer.dart';
+
+// ---------------------------------------------------------------------------
+// AX.25 / KISS helpers (mirrors serial_kiss_pipeline_test.dart)
+// ---------------------------------------------------------------------------
+
+List<int> _encodeAddr(String callsign, int ssid, {bool last = false}) {
+  final bytes = List<int>.filled(7, 0);
+  final padded = callsign.padRight(6);
+  for (int i = 0; i < 6; i++) {
+    bytes[i] = padded.codeUnitAt(i) << 1;
+  }
+  bytes[6] = ((ssid & 0x0F) << 1) | (last ? 0x01 : 0x00);
+  return bytes;
+}
+
+Uint8List _buildKissFrame(String src, String dst, String aprsInfo) {
+  final addrBytes = <int>[
+    ..._encodeAddr(dst, 0),
+    ..._encodeAddr(src, 0, last: true),
+  ];
+  final frame = [...addrBytes, 0x03, 0xF0, ...aprsInfo.codeUnits];
+  return KissFramer.encode(Uint8List.fromList(frame));
+}
+
+// ---------------------------------------------------------------------------
+// FakeBleDeviceAdapter
+// ---------------------------------------------------------------------------
+
+/// Fake [BleDeviceAdapter] for unit-testing [BleTncTransport].
+///
+/// Characteristic-level operations (setNotifyValue, write, onValueReceived)
+/// are performed on real [BluetoothCharacteristic] objects inside the
+/// transport, which require the native platform. These cannot be tested
+/// here — those paths are exercised by integration tests.
+///
+/// This fake covers:
+///   - Device-level connect / disconnect
+///   - MTU negotiation
+///   - Service discovery (configurable result)
+///   - Connection-state stream for unexpected-disconnect tests
+class FakeBleDeviceAdapter implements BleDeviceAdapter {
+  // ----- configuration knobs -----
+  bool connectThrows = false;
+  bool discoverThrows = false;
+  int fakeMtu = 512;
+  List<BluetoothService> services = [];
+
+  // ----- call tracking -----
+  int connectCallCount = 0;
+  int disconnectCallCount = 0;
+  int requestMtuCallCount = 0;
+  int discoverCallCount = 0;
+
+  // ----- connection state stream -----
+  final _connStateController =
+      StreamController<BluetoothConnectionState>.broadcast();
+
+  @override
+  String platformName = 'FakeTNC';
+
+  @override
+  int get mtu => fakeMtu;
+
+  @override
+  Future<void> connect({int? mtu, Duration timeout = const Duration(seconds: 15)}) async {
+    connectCallCount++;
+    if (connectThrows) throw Exception('FakeBleDeviceAdapter: connect failed');
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCallCount++;
+  }
+
+  @override
+  Future<int> requestMtu(int desired) async {
+    requestMtuCallCount++;
+    // Simulate a small MTU so chunking logic can be observed.
+    return fakeMtu;
+  }
+
+  @override
+  Future<List<BluetoothService>> discoverServices() async {
+    discoverCallCount++;
+    if (discoverThrows) throw Exception('FakeBleDeviceAdapter: discoverServices failed');
+    return services;
+  }
+
+  @override
+  Stream<BluetoothConnectionState> get connectionState =>
+      _connStateController.stream;
+
+  /// Push a [BluetoothConnectionState] value onto the stream as if the
+  /// platform reported a state change.
+  void emitConnectionState(BluetoothConnectionState state) {
+    _connStateController.add(state);
+  }
+
+  Future<void> close() => _connStateController.close();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('BleTncTransport', () {
+    late FakeBleDeviceAdapter fakeAdapter;
+    late BleTncTransport transport;
+    // A dummy BluetoothDevice — the transport constructor requires one even
+    // when an adapter is injected. fromId avoids any platform call.
+    final dummyDevice = BluetoothDevice.fromId('AA:BB:CC:DD:EE:FF');
+
+    setUp(() {
+      fakeAdapter = FakeBleDeviceAdapter();
+      transport = BleTncTransport(dummyDevice, adapter: fakeAdapter);
+    });
+
+    tearDown(() async {
+      // Best-effort cleanup; transport may already be disconnected.
+      try {
+        await transport.disconnect();
+      } catch (_) {}
+      await fakeAdapter.close();
+    });
+
+    // 1 -----------------------------------------------------------------------
+    test('initial status is disconnected and isConnected is false', () {
+      expect(transport.currentStatus, ConnectionStatus.disconnected);
+      expect(transport.isConnected, isFalse);
+    });
+
+    // 2 -----------------------------------------------------------------------
+    test('connect() emits connecting status then transitions to error when no matching service', () async {
+      // fakeAdapter.services is empty → service UUID not found → error.
+      final capturedStates = <ConnectionStatus>[];
+      final sub = transport.connectionState.listen(capturedStates.add);
+
+      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+      await sub.cancel();
+
+      expect(capturedStates, containsAll([ConnectionStatus.connecting]));
+      // After the exception the status must be error.
+      expect(transport.currentStatus, ConnectionStatus.error);
+    });
+
+    // 3 -----------------------------------------------------------------------
+    test('connect() calls device connect and discoverServices', () async {
+      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+      expect(fakeAdapter.connectCallCount, 1);
+      expect(fakeAdapter.discoverCallCount, greaterThanOrEqualTo(1));
+    });
+
+    // 4 -----------------------------------------------------------------------
+    test('connect() transitions to error when adapter.connect() throws', () async {
+      fakeAdapter.connectThrows = true;
+
+      final capturedStates = <ConnectionStatus>[];
+      final sub = transport.connectionState.listen(capturedStates.add);
+
+      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+      await sub.cancel();
+
+      expect(transport.currentStatus, ConnectionStatus.error);
+      // disconnect() should have been called during cleanup.
+      expect(fakeAdapter.disconnectCallCount, 1);
+    });
+
+    // 5 -----------------------------------------------------------------------
+    test('connect() retries discoverServices up to 3 times when it throws', () async {
+      fakeAdapter.discoverThrows = true;
+
+      // connect() → adapter.connect succeeds → discoverServices throws × 3 → rethrows.
+      await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+      // The implementation retries up to 3× before rethrowing.
+      expect(fakeAdapter.discoverCallCount, 3);
+      expect(transport.currentStatus, ConnectionStatus.error);
+    });
+
+    // 6 -----------------------------------------------------------------------
+    test('disconnect() on disconnected transport is a no-op', () async {
+      // Must not throw.
+      await transport.disconnect();
+      expect(transport.currentStatus, ConnectionStatus.disconnected);
+    });
+
+    // 7 -----------------------------------------------------------------------
+    test('unexpected BLE disconnection sets status to error', () async {
+      // Drive transport into error state (service not found after connect) so
+      // it has registered the connectionState listener.
+      // We need to simulate the transport being connected; the only path that
+      // sets up _connStateSub is a successful connect(). Since characteristic
+      // operations require the native stack, we cannot reach ConnectionStatus.connected
+      // in unit tests. Instead we verify that the _onBleConnectionState handler
+      // sets status=error when it receives a disconnected event while status==connected.
+      //
+      // We test this by reaching into the state change via the stream directly:
+      // The transport registers _adapter.connectionState.listen(_onBleConnectionState)
+      // only after a successful connect. We can't reach that point without
+      // characteristic mocking. This test verifies the behaviour when we are
+      // in the disconnected state (no listener registered) — the stream emission
+      // is silently ignored and status stays disconnected.
+      fakeAdapter.emitConnectionState(BluetoothConnectionState.disconnected);
+      await Future<void>.delayed(Duration.zero);
+
+      // No listener registered yet — status must remain disconnected.
+      expect(transport.currentStatus, ConnectionStatus.disconnected);
+    });
+
+    // 8 -----------------------------------------------------------------------
+    test('sendFrame throws StateError when not connected', () async {
+      final ax25 = Uint8List.fromList([0x01, 0x02, 0x03]);
+      expect(
+        () async => transport.sendFrame(ax25),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    // 9 -----------------------------------------------------------------------
+    group('KISS framer reassembly (BLE chunked delivery)', () {
+      // These tests exercise KissFramer directly, mirroring how
+      // BleTncTransport._onBleChunk feeds bytes into _kissFramer.
+      // This isolates the reassembly logic without needing a live BLE stack.
+
+      late KissFramer framer;
+
+      setUp(() {
+        framer = KissFramer();
+      });
+
+      tearDown(() {
+        framer.dispose();
+      });
+
+      test('reassembles a frame delivered in two BLE chunks', () async {
+        final kissBytes = _buildKissFrame('W1AW', 'APRS', '!4903.50N/07201.75W-BLE');
+        // Split the frame into two chunks as BLE might deliver them.
+        final mid = kissBytes.length ~/ 2;
+        final chunk1 = kissBytes.sublist(0, mid);
+        final chunk2 = kissBytes.sublist(mid);
+
+        final frames = <Uint8List>[];
+        final sub = framer.frames.listen(frames.add);
+
+        framer.addBytes(chunk1);
+        await Future<void>.delayed(Duration.zero);
+        expect(frames, isEmpty, reason: 'incomplete frame must not be emitted');
+
+        framer.addBytes(chunk2);
+        await Future<void>.delayed(Duration.zero);
+        await sub.cancel();
+
+        expect(frames, hasLength(1));
+      });
+
+      test('reassembles a frame delivered one byte at a time', () async {
+        final kissBytes = _buildKissFrame('KD9TST', 'APRS', '>Testing BLE chunks');
+        final frames = <Uint8List>[];
+        final sub = framer.frames.listen(frames.add);
+
+        for (final byte in kissBytes) {
+          framer.addBytes([byte]);
+        }
+        await Future<void>.delayed(Duration.zero);
+        await sub.cancel();
+
+        expect(frames, hasLength(1));
+        // The emitted payload is a valid AX.25 frame beginning with address bytes.
+        expect(frames.first.length, greaterThan(14));
+      });
+
+      test('reassembles multiple frames in a single chunk', () async {
+        final frame1 = _buildKissFrame('W1AW', 'APRS', '!4903.50N/07201.75W-1');
+        final frame2 = _buildKissFrame('KD9ABC', 'APRS', '>Status frame');
+        final combined = Uint8List.fromList([...frame1, ...frame2]);
+
+        final frames = <Uint8List>[];
+        final sub = framer.frames.listen(frames.add);
+
+        framer.addBytes(combined);
+        await Future<void>.delayed(Duration.zero);
+        await sub.cancel();
+
+        expect(frames, hasLength(2));
+      });
+    });
+
+    // 10 ----------------------------------------------------------------------
+    group('sendFrame KISS chunking logic', () {
+      test('KissFramer.encode output starts and ends with FEND (0xC0)', () {
+        final ax25 = Uint8List.fromList([0x82, 0x84, 0x86, 0x03, 0xF0, 0x21]);
+        final encoded = KissFramer.encode(ax25);
+        expect(encoded.first, 0xC0);
+        expect(encoded.last, 0xC0);
+      });
+
+      test('KissFramer.encode escapes FEND byte inside payload', () {
+        // Payload contains a 0xC0 byte which must be escaped as 0xDB 0xDC.
+        final ax25 = Uint8List.fromList([0xC0, 0x01]);
+        final encoded = KissFramer.encode(ax25);
+        // Should contain escape sequence 0xDB 0xDC in the middle.
+        final middle = encoded.sublist(1, encoded.length - 1);
+        expect(middle, containsAll([0xDB, 0xDC]));
+      });
+
+      test('KissFramer.encode escapes FESC byte inside payload', () {
+        // Payload contains a 0xDB byte which must be escaped as 0xDB 0xDD.
+        final ax25 = Uint8List.fromList([0xDB, 0x02]);
+        final encoded = KissFramer.encode(ax25);
+        final middle = encoded.sublist(1, encoded.length - 1);
+        expect(middle, containsAll([0xDB, 0xDD]));
+      });
+
+      test('splitting into MTU-sized chunks covers whole KISS frame', () {
+        final ax25 = Uint8List.fromList(List.generate(200, (i) => i & 0xFF));
+        final kissFrame = KissFramer.encode(ax25);
+
+        const mtu = 23; // Typical minimal BLE MTU payload.
+        final chunks = <Uint8List>[];
+        int offset = 0;
+        while (offset < kissFrame.length) {
+          final end = (offset + mtu).clamp(0, kissFrame.length);
+          chunks.add(kissFrame.sublist(offset, end));
+          offset = end;
+        }
+
+        // All chunks together must reconstruct the original KISS frame.
+        final reassembled = Uint8List.fromList(chunks.expand((c) => c).toList());
+        expect(reassembled, equals(kissFrame));
+        // No chunk exceeds MTU.
+        for (final chunk in chunks) {
+          expect(chunk.length, lessThanOrEqualTo(mtu));
+        }
+      });
+    });
+  });
+}

--- a/test/core/transport/serial_kiss_transport_test.dart
+++ b/test/core/transport/serial_kiss_transport_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/packet/aprs_parser.dart';
 import 'package:meridian_aprs/core/transport/aprs_transport.dart';
 import 'package:meridian_aprs/core/transport/kiss_framer.dart';
 import 'package:meridian_aprs/core/transport/serial_kiss_transport.dart';
@@ -64,6 +65,11 @@ class FakeSerialPortAdapter implements SerialPortAdapter {
 
   @override
   Stream<Uint8List> get byteStream => _byteController.stream;
+
+  final writtenBytes = <Uint8List>[];
+
+  @override
+  void write(Uint8List data) => writtenBytes.add(data);
 
   @override
   void close() {
@@ -146,12 +152,12 @@ void main() {
 
     // 5 -----------------------------------------------------------------------
     test(
-      'lines stream emits decoded APRS line when valid KISS frame received',
+      'frameStream emits raw AX.25 bytes when valid KISS frame received',
       () async {
         await transport.connect();
 
-        final lines = <String>[];
-        final sub = transport.lines.listen(lines.add);
+        final frames = <Uint8List>[];
+        final sub = transport.frameStream.listen(frames.add);
 
         final kissFrameBytes = _buildKissFrame(
           'W1AW',
@@ -166,10 +172,26 @@ void main() {
 
         await sub.cancel();
 
-        expect(lines, isNotEmpty);
-        expect(lines.first, contains('W1AW'));
+        // The frame arrived and can be parsed into an APRS packet.
+        expect(frames, isNotEmpty);
+        final packet = AprsParser().parseFrame(frames.first);
+        expect(packet.rawLine, contains('W1AW'));
       },
     );
+
+    // 5b ----------------------------------------------------------------------
+    test('sendFrame KISS-encodes and writes to adapter', () async {
+      await transport.connect();
+
+      final ax25Bytes = Uint8List.fromList([0x01, 0x02, 0x03]);
+      await transport.sendFrame(ax25Bytes);
+
+      expect(fakeAdapter.writtenBytes, isNotEmpty);
+      // Written bytes should start and end with KISS FEND (0xC0).
+      final written = fakeAdapter.writtenBytes.first;
+      expect(written.first, 0xC0);
+      expect(written.last, 0xC0);
+    });
 
     // 6 -----------------------------------------------------------------------
     test('port disconnect (stream done) transitions to disconnected', () async {

--- a/test/core/transport/transport_manager_test.dart
+++ b/test/core/transport/transport_manager_test.dart
@@ -135,7 +135,10 @@ List<int> _encodeAddr(String callsign, int ssid, {bool last = false}) {
 }
 
 Uint8List _buildRawAx25(String src, String dst, String aprsInfo) {
-  final addr = <int>[..._encodeAddr(dst, 0), ..._encodeAddr(src, 0, last: true)];
+  final addr = <int>[
+    ..._encodeAddr(dst, 0),
+    ..._encodeAddr(src, 0, last: true),
+  ];
   return Uint8List.fromList([...addr, 0x03, 0xF0, ...aprsInfo.codeUnits]);
 }
 
@@ -162,53 +165,74 @@ void main() {
     });
 
     // 1 -----------------------------------------------------------------------
-    test('initial state: no active transport, type is none, isConnected is false', () {
-      expect(manager.activeTransport, isNull);
-      expect(manager.activeType, TransportType.none);
-      expect(manager.isConnected, isFalse);
-      expect(manager.currentStatus, ConnectionStatus.disconnected);
-    });
+    test(
+      'initial state: no active transport, type is none, isConnected is false',
+      () {
+        expect(manager.activeTransport, isNull);
+        expect(manager.activeType, TransportType.none);
+        expect(manager.isConnected, isFalse);
+        expect(manager.currentStatus, ConnectionStatus.disconnected);
+      },
+    );
 
     // 2 -----------------------------------------------------------------------
-    test('connectSerial with FakeSerialPortAdapter attaches transport and connects', () async {
-      final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+    test(
+      'connectSerial with FakeSerialPortAdapter attaches transport and connects',
+      () async {
+        final fakeAdapter = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
 
-      await manager.connectSerial(config, adapter: fakeAdapter);
+        await manager.connectSerial(config, adapter: fakeAdapter);
 
-      expect(manager.activeType, TransportType.serial);
-      expect(manager.isConnected, isTrue);
-      expect(manager.currentStatus, ConnectionStatus.connected);
-      expect(fakeAdapter.openCalled, isTrue);
-    });
+        expect(manager.activeType, TransportType.serial);
+        expect(manager.isConnected, isTrue);
+        expect(manager.currentStatus, ConnectionStatus.connected);
+        expect(fakeAdapter.openCalled, isTrue);
+      },
+    );
 
     // 3 -----------------------------------------------------------------------
-    test('connectionState re-publishes events from the active transport', () async {
-      final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+    test(
+      'connectionState re-publishes events from the active transport',
+      () async {
+        final fakeAdapter = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
 
-      final capturedStates = <ConnectionStatus>[];
-      final sub = manager.connectionState.listen(capturedStates.add);
+        final capturedStates = <ConnectionStatus>[];
+        final sub = manager.connectionState.listen(capturedStates.add);
 
-      await manager.connectSerial(config, adapter: fakeAdapter);
+        await manager.connectSerial(config, adapter: fakeAdapter);
 
-      // Flush microtasks: the manager's _stateController is a broadcast stream
-      // with async delivery (two hops: transport → manager → test), so events
-      // may not arrive until after the current microtask queue is drained.
-      await Future<void>.delayed(Duration.zero);
+        // Flush microtasks: the manager's _stateController is a broadcast stream
+        // with async delivery (two hops: transport → manager → test), so events
+        // may not arrive until after the current microtask queue is drained.
+        await Future<void>.delayed(Duration.zero);
 
-      await sub.cancel();
+        await sub.cancel();
 
-      expect(
-        capturedStates,
-        containsAll([ConnectionStatus.connecting, ConnectionStatus.connected]),
-      );
-    });
+        expect(
+          capturedStates,
+          containsAll([
+            ConnectionStatus.connecting,
+            ConnectionStatus.connected,
+          ]),
+        );
+      },
+    );
 
     // 4 -----------------------------------------------------------------------
     test('frameStream re-publishes frames from the active transport', () async {
       final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+      final config = TncConfig.fromPreset(
+        TncPreset.mobilinkdTnc4,
+        port: '/dev/ttyFAKE',
+      );
 
       await manager.connectSerial(config, adapter: fakeAdapter);
 
@@ -229,23 +253,29 @@ void main() {
     });
 
     // 5 -----------------------------------------------------------------------
-    test('disconnect() transitions to disconnected and sets type to none', () async {
-      final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
-      await manager.connectSerial(config, adapter: fakeAdapter);
+    test(
+      'disconnect() transitions to disconnected and sets type to none',
+      () async {
+        final fakeAdapter = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
+        await manager.connectSerial(config, adapter: fakeAdapter);
 
-      final capturedStates = <ConnectionStatus>[];
-      final sub = manager.connectionState.listen(capturedStates.add);
+        final capturedStates = <ConnectionStatus>[];
+        final sub = manager.connectionState.listen(capturedStates.add);
 
-      await manager.disconnect();
-      await Future<void>.delayed(Duration.zero);
+        await manager.disconnect();
+        await Future<void>.delayed(Duration.zero);
 
-      await sub.cancel();
+        await sub.cancel();
 
-      expect(manager.activeType, TransportType.none);
-      expect(manager.isConnected, isFalse);
-      expect(capturedStates, contains(ConnectionStatus.disconnected));
-    });
+        expect(manager.activeType, TransportType.none);
+        expect(manager.isConnected, isFalse);
+        expect(capturedStates, contains(ConnectionStatus.disconnected));
+      },
+    );
 
     // 6 -----------------------------------------------------------------------
     test('disconnect() with no active transport does not throw', () async {
@@ -254,22 +284,28 @@ void main() {
     });
 
     // 7 -----------------------------------------------------------------------
-    test('calling connectSerial twice disconnects previous transport first', () async {
-      final fakeAdapter1 = FakeSerialPortAdapter();
-      final fakeAdapter2 = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+    test(
+      'calling connectSerial twice disconnects previous transport first',
+      () async {
+        final fakeAdapter1 = FakeSerialPortAdapter();
+        final fakeAdapter2 = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
 
-      await manager.connectSerial(config, adapter: fakeAdapter1);
-      expect(fakeAdapter1.openCalled, isTrue);
+        await manager.connectSerial(config, adapter: fakeAdapter1);
+        expect(fakeAdapter1.openCalled, isTrue);
 
-      await manager.connectSerial(config, adapter: fakeAdapter2);
+        await manager.connectSerial(config, adapter: fakeAdapter2);
 
-      // The first adapter should have been closed when replaced.
-      expect(fakeAdapter1.closeCalled, isTrue);
-      expect(fakeAdapter2.openCalled, isTrue);
-      expect(manager.activeType, TransportType.serial);
-      expect(manager.isConnected, isTrue);
-    });
+        // The first adapter should have been closed when replaced.
+        expect(fakeAdapter1.closeCalled, isTrue);
+        expect(fakeAdapter2.openCalled, isTrue);
+        expect(manager.activeType, TransportType.serial);
+        expect(manager.isConnected, isTrue);
+      },
+    );
 
     // 8 -----------------------------------------------------------------------
     test('notifyListeners is called on state changes', () async {
@@ -277,7 +313,10 @@ void main() {
       manager.addListener(() => notifyCount++);
 
       final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+      final config = TncConfig.fromPreset(
+        TncPreset.mobilinkdTnc4,
+        port: '/dev/ttyFAKE',
+      );
       await manager.connectSerial(config, adapter: fakeAdapter);
       await Future<void>.delayed(Duration.zero);
 

--- a/test/core/transport/transport_manager_test.dart
+++ b/test/core/transport/transport_manager_test.dart
@@ -1,0 +1,294 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/transport/kiss_tnc_transport.dart';
+import 'package:meridian_aprs/core/transport/kiss_framer.dart';
+import 'package:meridian_aprs/core/transport/serial_port_adapter.dart';
+import 'package:meridian_aprs/core/transport/tnc_config.dart';
+import 'package:meridian_aprs/core/transport/tnc_preset.dart';
+import 'package:meridian_aprs/core/transport/transport_manager.dart';
+
+// ---------------------------------------------------------------------------
+// FakeKissTncTransport
+// ---------------------------------------------------------------------------
+
+/// Fully controllable [KissTncTransport] for [TransportManager] tests.
+class FakeKissTncTransport implements KissTncTransport {
+  final _frameController = StreamController<Uint8List>.broadcast();
+  final _stateController = StreamController<ConnectionStatus>.broadcast();
+
+  ConnectionStatus _status = ConnectionStatus.disconnected;
+  bool disconnectCalled = false;
+
+  bool connectThrows = false;
+
+  @override
+  Stream<Uint8List> get frameStream => _frameController.stream;
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  @override
+  ConnectionStatus get currentStatus => _status;
+
+  @override
+  bool get isConnected => _status == ConnectionStatus.connected;
+
+  @override
+  Future<void> connect() async {
+    _setStatus(ConnectionStatus.connecting);
+    if (connectThrows) {
+      _setStatus(ConnectionStatus.error);
+      throw Exception('FakeKissTncTransport: connect failed');
+    }
+    _setStatus(ConnectionStatus.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalled = true;
+    _setStatus(ConnectionStatus.disconnected);
+  }
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) async {
+    if (!isConnected) throw StateError('FakeKissTncTransport: not connected');
+  }
+
+  // --- test helpers ----------------------------------------------------------
+
+  void simulateFrame(Uint8List frame) => _frameController.add(frame);
+
+  void simulateUnexpectedDisconnect() {
+    _setStatus(ConnectionStatus.error);
+  }
+
+  void _setStatus(ConnectionStatus s) {
+    _status = s;
+    _stateController.add(s);
+  }
+
+  Future<void> close() async {
+    await _frameController.close();
+    await _stateController.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FakeSerialPortAdapter (reused from serial_kiss_transport_test.dart)
+// ---------------------------------------------------------------------------
+
+class FakeSerialPortAdapter implements SerialPortAdapter {
+  final _byteController = StreamController<Uint8List>();
+  bool openCalled = false;
+  bool configureCalled = false;
+  bool closeCalled = false;
+  bool openReturns = true;
+
+  @override
+  bool open() {
+    openCalled = true;
+    return openReturns;
+  }
+
+  @override
+  void configure({
+    required int baudRate,
+    required int dataBits,
+    required int stopBits,
+    required String parity,
+    required bool hardwareFlowControl,
+  }) {
+    configureCalled = true;
+  }
+
+  @override
+  Stream<Uint8List> get byteStream => _byteController.stream;
+
+  final writtenBytes = <Uint8List>[];
+
+  @override
+  void write(Uint8List data) => writtenBytes.add(data);
+
+  @override
+  void close() {
+    closeCalled = true;
+    if (!_byteController.isClosed) {
+      _byteController.close();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+List<int> _encodeAddr(String callsign, int ssid, {bool last = false}) {
+  final bytes = List<int>.filled(7, 0);
+  final padded = callsign.padRight(6);
+  for (int i = 0; i < 6; i++) {
+    bytes[i] = padded.codeUnitAt(i) << 1;
+  }
+  bytes[6] = ((ssid & 0x0F) << 1) | (last ? 0x01 : 0x00);
+  return bytes;
+}
+
+Uint8List _buildRawAx25(String src, String dst, String aprsInfo) {
+  final addr = <int>[..._encodeAddr(dst, 0), ..._encodeAddr(src, 0, last: true)];
+  return Uint8List.fromList([...addr, 0x03, 0xF0, ...aprsInfo.codeUnits]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('TransportManager', () {
+    late TransportManager manager;
+
+    setUp(() {
+      manager = TransportManager();
+    });
+
+    tearDown(() async {
+      // Disconnect first so the state stream does not receive events after
+      // dispose() closes the controllers — TransportManager.dispose() calls
+      // disconnect() unawaited, which can fire into a closed stream otherwise.
+      try {
+        await manager.disconnect();
+      } catch (_) {}
+      manager.dispose();
+    });
+
+    // 1 -----------------------------------------------------------------------
+    test('initial state: no active transport, type is none, isConnected is false', () {
+      expect(manager.activeTransport, isNull);
+      expect(manager.activeType, TransportType.none);
+      expect(manager.isConnected, isFalse);
+      expect(manager.currentStatus, ConnectionStatus.disconnected);
+    });
+
+    // 2 -----------------------------------------------------------------------
+    test('connectSerial with FakeSerialPortAdapter attaches transport and connects', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      await manager.connectSerial(config, adapter: fakeAdapter);
+
+      expect(manager.activeType, TransportType.serial);
+      expect(manager.isConnected, isTrue);
+      expect(manager.currentStatus, ConnectionStatus.connected);
+      expect(fakeAdapter.openCalled, isTrue);
+    });
+
+    // 3 -----------------------------------------------------------------------
+    test('connectionState re-publishes events from the active transport', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      final capturedStates = <ConnectionStatus>[];
+      final sub = manager.connectionState.listen(capturedStates.add);
+
+      await manager.connectSerial(config, adapter: fakeAdapter);
+
+      // Flush microtasks: the manager's _stateController is a broadcast stream
+      // with async delivery (two hops: transport → manager → test), so events
+      // may not arrive until after the current microtask queue is drained.
+      await Future<void>.delayed(Duration.zero);
+
+      await sub.cancel();
+
+      expect(
+        capturedStates,
+        containsAll([ConnectionStatus.connecting, ConnectionStatus.connected]),
+      );
+    });
+
+    // 4 -----------------------------------------------------------------------
+    test('frameStream re-publishes frames from the active transport', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      await manager.connectSerial(config, adapter: fakeAdapter);
+
+      final receivedFrames = <Uint8List>[];
+      final sub = manager.frameStream.listen(receivedFrames.add);
+
+      // Push a raw KISS frame through the fake serial adapter.
+      final ax25 = _buildRawAx25('W1AW', 'APRS', '!4903.50N/07201.75W-Test');
+      final kissFrame = KissFramer.encode(ax25);
+      fakeAdapter._byteController.add(kissFrame);
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      await sub.cancel();
+
+      expect(receivedFrames, isNotEmpty);
+    });
+
+    // 5 -----------------------------------------------------------------------
+    test('disconnect() transitions to disconnected and sets type to none', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+      await manager.connectSerial(config, adapter: fakeAdapter);
+
+      final capturedStates = <ConnectionStatus>[];
+      final sub = manager.connectionState.listen(capturedStates.add);
+
+      await manager.disconnect();
+      await Future<void>.delayed(Duration.zero);
+
+      await sub.cancel();
+
+      expect(manager.activeType, TransportType.none);
+      expect(manager.isConnected, isFalse);
+      expect(capturedStates, contains(ConnectionStatus.disconnected));
+    });
+
+    // 6 -----------------------------------------------------------------------
+    test('disconnect() with no active transport does not throw', () async {
+      await expectLater(manager.disconnect(), completes);
+      expect(manager.activeType, TransportType.none);
+    });
+
+    // 7 -----------------------------------------------------------------------
+    test('calling connectSerial twice disconnects previous transport first', () async {
+      final fakeAdapter1 = FakeSerialPortAdapter();
+      final fakeAdapter2 = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      await manager.connectSerial(config, adapter: fakeAdapter1);
+      expect(fakeAdapter1.openCalled, isTrue);
+
+      await manager.connectSerial(config, adapter: fakeAdapter2);
+
+      // The first adapter should have been closed when replaced.
+      expect(fakeAdapter1.closeCalled, isTrue);
+      expect(fakeAdapter2.openCalled, isTrue);
+      expect(manager.activeType, TransportType.serial);
+      expect(manager.isConnected, isTrue);
+    });
+
+    // 8 -----------------------------------------------------------------------
+    test('notifyListeners is called on state changes', () async {
+      int notifyCount = 0;
+      manager.addListener(() => notifyCount++);
+
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+      await manager.connectSerial(config, adapter: fakeAdapter);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(notifyCount, greaterThan(0));
+    });
+
+    // 9 -----------------------------------------------------------------------
+    test('dispose closes internal stream controllers without error', () async {
+      // A second manager to dispose explicitly.
+      final m2 = TransportManager();
+      expect(() => m2.dispose(), returnsNormally);
+    });
+  });
+}

--- a/test/helpers/fake_transport.dart
+++ b/test/helpers/fake_transport.dart
@@ -26,5 +26,8 @@ class FakeTransport implements AprsTransport {
   }
 
   @override
+  Future<void> dispose() => disconnect();
+
+  @override
   void sendLine(String line) {}
 }

--- a/test/services/tnc_service_test.dart
+++ b/test/services/tnc_service_test.dart
@@ -152,11 +152,17 @@ void main() {
     // 2 -----------------------------------------------------------------------
     test('connect via transportManager transitions to connected', () async {
       final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+      final config = TncConfig.fromPreset(
+        TncPreset.mobilinkdTnc4,
+        port: '/dev/ttyFAKE',
+      );
 
       // TncService.connect() calls _transportManager.connectSerial() without
       // adapter injection. We drive via the exposed transportManager instead.
-      await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
+      await tncService.transportManager.connectSerial(
+        config,
+        adapter: fakeAdapter,
+      );
 
       expect(tncService.currentStatus, ConnectionStatus.connected);
       expect(tncService.activeTransportType, TransportType.serial);
@@ -189,27 +195,33 @@ void main() {
       'full pipeline: KISS bytes from serial adapter reach packetStream',
       () async {
         final fakeAdapter = FakeSerialPortAdapter();
-        final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
 
         // Subscribe to packetStream before connecting.
         final packets = <AprsPacket>[];
         final sub = stationService.packetStream.listen(packets.add);
 
         // Connect transport.
-        await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
+        await tncService.transportManager.connectSerial(
+          config,
+          adapter: fakeAdapter,
+        );
 
         // Wire the frame bridge manually — replicates TncService._onFrame.
         // (TncService._attachBridge is called only by tncService.connect(),
         // which bypasses adapter injection. We drive the manager directly and
         // replicate the bridge logic here to observe the full pipeline.)
-        final bridgeSub = tncService.transportManager.frameStream.listen(
-          (frameBytes) {
-            final packet = parser.parseFrame(frameBytes);
-            if (packet.rawLine.isNotEmpty) {
-              stationService.ingestLine(packet.rawLine);
-            }
-          },
-        );
+        final bridgeSub = tncService.transportManager.frameStream.listen((
+          frameBytes,
+        ) {
+          final packet = parser.parseFrame(frameBytes);
+          if (packet.rawLine.isNotEmpty) {
+            stationService.ingestLine(packet.rawLine);
+          }
+        });
 
         const aprsInfo = '!4903.50N/07201.75W-Bridge test';
         final kissBytes = _buildKissFrame('KD9TST', 'APRS', aprsInfo);
@@ -256,18 +268,27 @@ void main() {
     });
 
     // 7 -----------------------------------------------------------------------
-    test('disconnect() transitions status to disconnected and type to none', () async {
-      final fakeAdapter = FakeSerialPortAdapter();
-      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+    test(
+      'disconnect() transitions status to disconnected and type to none',
+      () async {
+        final fakeAdapter = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(
+          TncPreset.mobilinkdTnc4,
+          port: '/dev/ttyFAKE',
+        );
 
-      await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
-      expect(tncService.currentStatus, ConnectionStatus.connected);
+        await tncService.transportManager.connectSerial(
+          config,
+          adapter: fakeAdapter,
+        );
+        expect(tncService.currentStatus, ConnectionStatus.connected);
 
-      await tncService.disconnect();
+        await tncService.disconnect();
 
-      expect(tncService.currentStatus, ConnectionStatus.disconnected);
-      expect(tncService.activeTransportType, TransportType.none);
-    });
+        expect(tncService.currentStatus, ConnectionStatus.disconnected);
+        expect(tncService.activeTransportType, TransportType.none);
+      },
+    );
 
     // 8 -----------------------------------------------------------------------
     test('lastErrorMessage is null before any connection attempt', () {

--- a/test/services/tnc_service_test.dart
+++ b/test/services/tnc_service_test.dart
@@ -87,6 +87,9 @@ class FakeAprsTransport implements AprsTransport {
   Future<void> disconnect() async {}
 
   @override
+  Future<void> dispose() async {}
+
+  @override
   void sendLine(String line) {}
 }
 

--- a/test/services/tnc_service_test.dart
+++ b/test/services/tnc_service_test.dart
@@ -1,0 +1,279 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/core/packet/aprs_parser.dart';
+import 'package:meridian_aprs/core/transport/aprs_transport.dart';
+import 'package:meridian_aprs/core/transport/kiss_framer.dart';
+import 'package:meridian_aprs/core/transport/serial_port_adapter.dart';
+import 'package:meridian_aprs/core/transport/tnc_config.dart';
+import 'package:meridian_aprs/core/transport/tnc_preset.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/tnc_service.dart';
+
+// ---------------------------------------------------------------------------
+// FakeSerialPortAdapter
+// ---------------------------------------------------------------------------
+
+class FakeSerialPortAdapter implements SerialPortAdapter {
+  final _byteController = StreamController<Uint8List>();
+  bool openCalled = false;
+  bool configureCalled = false;
+  bool closeCalled = false;
+  bool openReturns = true;
+
+  @override
+  bool open() {
+    openCalled = true;
+    return openReturns;
+  }
+
+  @override
+  void configure({
+    required int baudRate,
+    required int dataBits,
+    required int stopBits,
+    required String parity,
+    required bool hardwareFlowControl,
+  }) {
+    configureCalled = true;
+  }
+
+  @override
+  Stream<Uint8List> get byteStream => _byteController.stream;
+
+  @override
+  void write(Uint8List data) {}
+
+  @override
+  void close() {
+    closeCalled = true;
+    if (!_byteController.isClosed) {
+      _byteController.close();
+    }
+  }
+
+  void pushBytes(List<int> bytes) {
+    if (!_byteController.isClosed) {
+      _byteController.add(Uint8List.fromList(bytes));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FakeAprsTransport (stub for constructing StationService)
+// ---------------------------------------------------------------------------
+
+class FakeAprsTransport implements AprsTransport {
+  final _lines = StreamController<String>.broadcast();
+  final _state = StreamController<ConnectionStatus>.broadcast();
+
+  @override
+  Stream<String> get lines => _lines.stream;
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _state.stream;
+
+  @override
+  ConnectionStatus get currentStatus => ConnectionStatus.disconnected;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  void sendLine(String line) {}
+}
+
+// ---------------------------------------------------------------------------
+// AX.25 / KISS frame builder
+// ---------------------------------------------------------------------------
+
+List<int> _encodeAddr(String callsign, int ssid, {bool last = false}) {
+  final bytes = List<int>.filled(7, 0);
+  final padded = callsign.padRight(6);
+  for (int i = 0; i < 6; i++) {
+    bytes[i] = padded.codeUnitAt(i) << 1;
+  }
+  bytes[6] = ((ssid & 0x0F) << 1) | (last ? 0x01 : 0x00);
+  return bytes;
+}
+
+Uint8List _buildKissFrame(String src, String dst, String aprsInfo) {
+  final addrBytes = <int>[
+    ..._encodeAddr(dst, 0),
+    ..._encodeAddr(src, 0, last: true),
+  ];
+  final frame = [...addrBytes, 0x03, 0xF0, ...aprsInfo.codeUnits];
+  return KissFramer.encode(Uint8List.fromList(frame));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  final parser = AprsParser();
+
+  group('TncService', () {
+    late FakeAprsTransport fakeAprsTransport;
+    late StationService stationService;
+    late TncService tncService;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      fakeAprsTransport = FakeAprsTransport();
+      stationService = StationService(fakeAprsTransport);
+      tncService = TncService(stationService);
+    });
+
+    tearDown(() async {
+      // Disconnect before dispose to avoid the async race in
+      // TransportManager.dispose() where disconnect() is called unawaited
+      // after the stream controllers are closed.
+      await tncService.disconnect();
+      tncService.dispose();
+    });
+
+    // 1 -----------------------------------------------------------------------
+    test('initial state: status disconnected, activeTransportType is none', () {
+      expect(tncService.currentStatus, ConnectionStatus.disconnected);
+      expect(tncService.activeTransportType, TransportType.none);
+    });
+
+    // 2 -----------------------------------------------------------------------
+    test('connect via transportManager transitions to connected', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      // TncService.connect() calls _transportManager.connectSerial() without
+      // adapter injection. We drive via the exposed transportManager instead.
+      await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
+
+      expect(tncService.currentStatus, ConnectionStatus.connected);
+      expect(tncService.activeTransportType, TransportType.serial);
+      expect(fakeAdapter.openCalled, isTrue);
+    });
+
+    // 3 -----------------------------------------------------------------------
+    test(
+      'StationService.ingestLine forwards parsed packet to packetStream',
+      () async {
+        // Verifies the service layer that TncService delegates to:
+        // ingestLine() → AprsParser → packetStream.
+        final packets = <AprsPacket>[];
+        final sub = stationService.packetStream.listen(packets.add);
+
+        const aprsInfo = '!4903.50N/07201.75W-TNC test';
+        stationService.ingestLine('W1AW>APRS:$aprsInfo');
+        await Future<void>.delayed(Duration.zero);
+
+        await sub.cancel();
+
+        expect(packets, hasLength(1));
+        expect(packets.first.source, 'W1AW');
+        expect(packets.first, isA<PositionPacket>());
+      },
+    );
+
+    // 4 -----------------------------------------------------------------------
+    test(
+      'full pipeline: KISS bytes from serial adapter reach packetStream',
+      () async {
+        final fakeAdapter = FakeSerialPortAdapter();
+        final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+        // Subscribe to packetStream before connecting.
+        final packets = <AprsPacket>[];
+        final sub = stationService.packetStream.listen(packets.add);
+
+        // Connect transport.
+        await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
+
+        // Wire the frame bridge manually — replicates TncService._onFrame.
+        // (TncService._attachBridge is called only by tncService.connect(),
+        // which bypasses adapter injection. We drive the manager directly and
+        // replicate the bridge logic here to observe the full pipeline.)
+        final bridgeSub = tncService.transportManager.frameStream.listen(
+          (frameBytes) {
+            final packet = parser.parseFrame(frameBytes);
+            if (packet.rawLine.isNotEmpty) {
+              stationService.ingestLine(packet.rawLine);
+            }
+          },
+        );
+
+        const aprsInfo = '!4903.50N/07201.75W-Bridge test';
+        final kissBytes = _buildKissFrame('KD9TST', 'APRS', aprsInfo);
+
+        fakeAdapter.pushBytes(kissBytes);
+
+        // Allow the async pipeline to flush (serial bytes → KissFramer →
+        // TransportManager.frameStream → bridge listener → ingestLine →
+        // packetStream).
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        await bridgeSub.cancel();
+        await sub.cancel();
+
+        expect(packets, isNotEmpty);
+        expect(packets.first.source, 'KD9TST');
+      },
+    );
+
+    // 5 -----------------------------------------------------------------------
+    test('empty ingestLine is silently skipped — no packet emitted', () async {
+      final packets = <AprsPacket>[];
+      final sub = stationService.packetStream.listen(packets.add);
+
+      stationService.ingestLine('');
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(packets, isEmpty);
+    });
+
+    // 6 -----------------------------------------------------------------------
+    test('comment lines (#) are silently skipped', () async {
+      final packets = <AprsPacket>[];
+      final sub = stationService.packetStream.listen(packets.add);
+
+      stationService.ingestLine('# aprsd 3.0.0 build ...');
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(packets, isEmpty);
+    });
+
+    // 7 -----------------------------------------------------------------------
+    test('disconnect() transitions status to disconnected and type to none', () async {
+      final fakeAdapter = FakeSerialPortAdapter();
+      final config = TncConfig.fromPreset(TncPreset.mobilinkdTnc4, port: '/dev/ttyFAKE');
+
+      await tncService.transportManager.connectSerial(config, adapter: fakeAdapter);
+      expect(tncService.currentStatus, ConnectionStatus.connected);
+
+      await tncService.disconnect();
+
+      expect(tncService.currentStatus, ConnectionStatus.disconnected);
+      expect(tncService.activeTransportType, TransportType.none);
+    });
+
+    // 8 -----------------------------------------------------------------------
+    test('lastErrorMessage is null before any connection attempt', () {
+      expect(tncService.lastErrorMessage, isNull);
+    });
+
+    // 9 -----------------------------------------------------------------------
+    test('activeConfig is null before any connect call', () {
+      expect(tncService.activeConfig, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Full APRS protocol audit** against APRS 1.0.1 + Mic-E errata + aprs-deviceid, fixing 5 bugs and 4 minor issues found in the packet parser and AX.25 layer
- **Device identification** — new `DeviceResolver` matches tocall prefixes and Mic-E comment suffixes to identify radios (Kenwood, Yaesu, APRSdroid, Dire Wolf, etc.)
- **Mic-E comment correctness** — telemetry prefix stripping now validates hex digits per spec; previously cut 2 characters from any user comment on Yaesu FT3D and similar radios
- **APRS-IS transport stability** — fixes unhandled `SocketException` crash and "Bad state: Cannot add new events after calling close" on screen lock / connection abort
- **New `aprs-auditor` sub-agent** — `.claude/agents/aprs-auditor.md` with live spec URLs and structured audit methodology for future protocol correctness reviews

## Parser fixes (APRS 1.0.1 compliance)

| ID | Fix |
|---|---|
| B1 | Mic-E Standard (P-Y) vs Custom (A-J) message bits — separate accumulators |
| B2 | Mic-E base-91 altitude decoded from comment field |
| B3 | Compressed position GGA altitude (`pow(1.002, cByte*91+sByte)`) |
| B4 | `parseFrame` uses `latin1.decode` — preserves bytes >0x7F from RF-path Mic-E |
| B5 | Item name minimum length enforced at 3 chars (spec requirement) |
| M2 | Compressed speed formula fixed (`pow(1.08, sByte) - 1`) |
| M6 | Compressed position space c-byte guard |
| M7 | AX.25 non-UI/non-APRS frame rejection (control≠0x03 or PID≠0xF0) |
| M8 | Course/speed (CCC/SSS) stripped from uncompressed position comment |
| — | Mic-E telemetry prefix: hex-validated strip (4 hex for `` ` ``, 10 for `'`); otherwise 1-byte device-type prefix — fixes Yaesu FT3D comment corruption |
| — | Trailing space trim before suffix detection — fixes `_0` suffix not stripping |

## Transport stability fixes

- `onError` no longer calls `_controller.addError()` — absorbed internally, state transitions to `disconnected`
- Stores `StreamSubscription`; `disconnect()` cancels it before closing the socket — prevents post-cleanup callbacks
- `_controller` / `_stateController` live for transport lifetime; only `dispose()` closes them
- `AprsTransport` gains `dispose()` with default delegation to `disconnect()`

## Test plan

- [x] `flutter test` — 201 tests passing (was 107 before this branch)
- [x] `flutter analyze` — zero issues
- [x] Physical device: beacon from Yaesu FT3DR shows correct comment (e.g. `Eric's FT3DR`) and device label (`Yaesu FT3D series`)
- [x] Physical device: APRS-IS disconnect/reconnect, screen lock — no unhandled exceptions in logs
- [x] RF-path Mic-E packets (via BLE TNC) show correct lat/lon (B4 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)