### PR TITLE
docs: update roadmap through v1.0 with new milestones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,14 +45,22 @@ See `docs/ARCHITECTURE.md` for full detail.
 
 | Milestone | Focus |
 |---|---|
-| v0.1 — Foundation | Flutter scaffold, map rendering, APRS-IS connection, basic station display |
-| v0.2 — Packets | AX.25/APRS parser, packet log view, message decoding |
-| v0.3 — TNC | KISS over USB serial, desktop platforms first |
-| v0.4 — BLE | KISS over BLE, mobile platforms |
-| v0.5 — Beaconing | Transmit path, position beaconing, message sending |
-| v1.0 — Polish | UI refinement, settings, documentation, onboarding |
+| ~~v0.1~~ | ~~Foundation — Flutter scaffold, map, APRS-IS, station display~~ ✓ |
+| ~~v0.2~~ | ~~Packets — AX.25/APRS parser, packet log, message decoding~~ ✓ |
+| ~~v0.3~~ | ~~TNC — KISS over USB serial, desktop platforms first~~ ✓ |
+| ~~v0.4~~ | ~~BLE — KISS over BLE, mobile platforms~~ ✓ |
+| ~~v0.5~~ | ~~Beaconing — Transmit path, position beaconing, message sending~~ ✓ |
+| ~~v0.6~~ | ~~Connection UI + Map Polish~~ ✓ |
+| **v0.7** | Android Background Beaconing (foreground service + persistent notification) |
+| **v0.8** | Cross-platform parity pass (iOS Cupertino audit, OSM tile swap) |
+| **v0.9** | iOS Background Beaconing (background location + Live Activity) |
+| **v0.10** | Map filters + station profiles + track history + cluster markers + object/item display + altitude in position packets |
+| **v0.11** | Background notifications + in-app banner system |
+| **v0.12** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
+| **v0.13** | Battery & performance optimization pass |
+| **v1.0** | Final polish + store submission |
 
-**Current status: v0.7 planning. v0.6 Connection UI & Map Polish complete — `ConnectionScreen` first-class nav destination on all three scaffold tiers; `ConnectionNavIcon` (reactive Selector2 nav icon); `_ConnectionStatusChip` in desktop AppBar; callsign search (Nominatim + `showSearch`); center-on-location (GPS on mobile/tablet, address picker fallback on desktop); `BeaconFAB` and location button loading spinners; TX transport selector reflects effective transport; TNC settings consolidated to Connection screen; `connection_sheet.dart` removed. 274 tests passing. ADRs 001–024 in `docs/DECISIONS.md`.**
+**Current status: v0.7 active. v0.6 Connection UI & Map Polish complete — `ConnectionScreen` first-class nav destination on all three scaffold tiers; `ConnectionNavIcon` (reactive Selector2 nav icon); `_ConnectionStatusChip` in desktop AppBar; callsign search (Nominatim + `showSearch`); center-on-location (GPS on mobile/tablet, address picker fallback on desktop); `BeaconFAB` and location button loading spinners; TX transport selector reflects effective transport; TNC settings consolidated to Connection screen; `connection_sheet.dart` removed. 274 tests passing. ADRs 001–024 in `docs/DECISIONS.md`.**
 
 **Conventions added in v0.5:**
 - `TODO(tocall)` — marks `APZMDN` destination; register with WB4APR before v1.0 release

--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -8,7 +8,6 @@ Ideas and enhancements beyond the current milestone scope. Not committed to any 
 
 - **Group / bulletin messages** — APRS bulletin (`BLN`) and announcement (`BLN0`–`BLN9`) support; display in a separate Bulletins tab
 - **Message search / archive** — local SQLite persistence of message history; search by callsign or keyword
-- **Background notifications** — platform push notification (or persistent service on Android) for incoming messages while the app is in the background
 - **Threaded replies** — link messages to a conversation with reply quoting, like a basic chat
 
 ---
@@ -16,7 +15,6 @@ Ideas and enhancements beyond the current milestone scope. Not committed to any 
 ## Beaconing
 
 - **SmartBeaconing map overlay** — show the beacon path on the map with breadcrumb dots, fading with age
-- **Altitude in position packets** — include altitude in the position comment when available from GPS
 - **Compressed position encoding** — APRS compressed format for shorter packets on RF
 - **Object / item TX** — create and transmit APRS objects and items (weather stations, repeaters, nets)
 
@@ -24,19 +22,14 @@ Ideas and enhancements beyond the current milestone scope. Not committed to any 
 
 ## Connection & Transport
 
-- **Passcode secure storage** — migrate APRS-IS passcode from SharedPreferences to platform keychain / keystore
 - **TCP KISS TNC** — TCP KISS transport (e.g., Direwolf running on a network host)
 - **Soundcard TNC** — integrate a pure-Dart or platform-native AFSK modem for RF TX/RX without dedicated hardware
-- **APRS-IS server filter configuration** — user-configurable `#filter` parameter (range, callsign, type)
 - **Multi-server support** — failover between APRS-IS tier-2 servers
 
 ---
 
 ## Map & Stations
 
-- **Cluster markers** — group overlapping stations into a count badge at low zoom levels
-- **Track history** — show station movement track (breadcrumbs) on map for a configurable duration
-- **Object / item display** — render APRS objects and items with their own symbols and info sheets
 - **Weather overlays** — display weather station data (WX) on map with colour-coded temperature / wind
 - **Offline tiles** — cache map tiles for offline use (MBTiles or similar)
 
@@ -47,5 +40,4 @@ Ideas and enhancements beyond the current milestone scope. Not committed to any 
 - **iPad multi-window** — support split-screen and Slide Over on iPad
 - **macOS menu bar** — native menu bar integration for connection management
 - **Keyboard shortcuts** — compose, send, beacon actions via keyboard on desktop
-- **Accessibility** — screen reader labels, sufficient contrast ratios, dynamic type support
 - **Localisation** — i18n framework; initial target: EN, DE, JA

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,16 +2,23 @@
 
 ## Summary
 
-| Milestone | Focus | Status |
-|---|---|---|
-| v0.1 — Foundation | Flutter scaffold, map, APRS-IS, station display with symbols | ✅ Complete |
-| v0.2 — Packets | AX.25/APRS parser, packet log, message decoding | ✅ Complete |
-| UI Foundation | Theme system, adaptive scaffold, core widgets, onboarding | ✅ Complete |
-| v0.3 — TNC | KISS over USB serial, desktop first | ✅ Complete |
-| v0.4 — BLE | KISS over BLE, mobile platforms | ✅ Complete |
-| v0.5 — Beaconing | Transmit path, position beaconing, message sending | ✅ Complete |
-| v0.6 — Connection UI & Map Polish | Connection screen, map improvements | ✅ Complete |
-| v1.0 — Polish | UI refinement, settings, documentation, onboarding | ⬜ Planned |
+| Milestone | Goal |
+|---|---|
+| ~~v0.1 — Foundation~~ | ~~Flutter scaffold, map, APRS-IS, station display with symbols~~ ✓ |
+| ~~v0.2 — Packets~~ | ~~AX.25/APRS parser, packet log, message decoding~~ ✓ |
+| ~~UI Foundation~~ | ~~Theme system, adaptive scaffold, core widgets, onboarding~~ ✓ |
+| ~~v0.3 — TNC~~ | ~~KISS over USB serial, desktop first~~ ✓ |
+| ~~v0.4 — BLE~~ | ~~KISS over BLE, mobile platforms~~ ✓ |
+| ~~v0.5 — Beaconing~~ | ~~Transmit path, position beaconing, message sending~~ ✓ |
+| ~~v0.6~~ | ~~Connection UI + Map Polish~~ ✓ |
+| **v0.7** | Android Background Beaconing (foreground service + persistent notification) |
+| **v0.8** | Cross-platform parity pass (iOS Cupertino audit, OSM tile swap) |
+| **v0.9** | iOS Background Beaconing (background location + Live Activity) |
+| **v0.10** | Map filters + station profiles + track history + cluster markers + object/item display + altitude in position packets |
+| **v0.11** | Background notifications + in-app banner system |
+| **v0.12** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
+| **v0.13** | Battery & performance optimization pass |
+| **v1.0** | Final polish + store submission |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add v0.7–v0.13 milestone sequence to `docs/ROADMAP.md` summary table; completed milestones shown with strikethrough
- Remove 8 items from `docs/FUTURE_FEATURES.md` that are now committed to specific milestones (background notifications → v0.11, altitude → v0.10, passcode secure storage → v0.12, APRS-IS filter config → v0.12, cluster markers → v0.10, track history → v0.10, object/item display → v0.10, accessibility → v1.0)
- Update `CLAUDE.md` milestone table and current status to reflect v0.7 as the active milestone

## Test plan

- [ ] Verify `docs/ROADMAP.md` summary table lists v0.7–v1.0 with correct goals
- [ ] Verify removed items no longer appear in `docs/FUTURE_FEATURES.md`
- [ ] Verify `CLAUDE.md` shows "v0.7 active" in current status

🤖 Generated with [Claude Code](https://claude.com/claude-code)