### PR TITLE
feat: v0.8 — cross-platform parity pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+STADIA_MAPS_API_KEY=your_stadia_maps_api_key_here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: flutter analyze
 
       - name: Run tests
-        run: flutter test
+        run: flutter test --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
 
       - name: Build (Linux debug)
-        run: flutter build linux --debug
+        run: flutter build linux --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ app.*.map.json
 
 # Claude Code agent memory (local only)
 .claude/agent-memory/
+
+# Ignore env files
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | ~~v0.5~~ | ~~Beaconing — Transmit path, position beaconing, message sending~~ ✓ |
 | ~~v0.6~~ | ~~Connection UI + Map Polish~~ ✓ |
 | ~~v0.7~~ | ~~Android Background Beaconing (foreground service + persistent notification)~~ ✓ |
-| **v0.8** | Cross-platform parity pass (iOS Cupertino audit, OSM tile swap) |
+| **v0.8** | Cross-platform parity pass (iOS Cupertino audit, Stadia Maps tile swap) |
 | **v0.9** | iOS Background Beaconing (background location + Live Activity) |
 | **v0.10** | Map filters + station profiles + track history + cluster markers + object/item display + altitude in position packets |
 | **v0.11** | Background notifications + in-app banner system |
@@ -62,7 +62,7 @@ See `docs/ARCHITECTURE.md` for full detail.
 | **v0.13** | Battery & performance optimization pass |
 | **v1.0** | Final polish + store submission |
 
-**Current status: v0.7 complete (pending physical Android device validation). Android foreground service keepalive via `flutter_foreground_task` — `BackgroundServiceManager` ChangeNotifier drives notification content + `BackgroundServiceState`; `MeridianConnectionTask` minimal background-isolate heartbeat; `ConnectionScreen` background service card (Android-only toggle + status); `ConnectionNavIcon` badge dot; `ACCESS_BACKGROUND_LOCATION` permission flow. 289 tests passing. ADRs 001–026 in `docs/DECISIONS.md`. v0.8 next (cross-platform parity: iOS Cupertino audit, OSM tile swap).**
+**Current status: v0.8 in progress. Stadia Maps tile provider in place (`MeridianTileProvider` abstraction, `StadiaTileProvider`, `AppConfig.stadiaMapsApiKey` via `--dart-define`); CartoDB tile artifacts removed; OSM attribution layer added. iOS Cupertino pass: `buildPlatformRoute` helper created; all `TODO(ios)` CupertinoPageRoute sites resolved; Cupertino widget pass applied to settings/modals. Physical iPhone 16 Pro validation pending. ADRs 001–028 in `docs/DECISIONS.md`.**
 
 **Conventions added in v0.5:**
 - `TODO(tocall)` — marks `APZMDN` destination; register with WB4APR before v1.0 release
@@ -132,6 +132,20 @@ Keep these files current as the project evolves:
 - Pure Dart for all packet core logic (no FFI in `lib/core/`)
 - Follow existing Flutter/Dart conventions in the codebase
 - Run `flutter analyze` and `flutter test` before considering any task done
+
+---
+
+## Local Development
+
+### Map Tiles
+Stadia Maps is used for tile serving. An API key is required.
+
+Run the app with:
+```
+flutter run --dart-define=STADIA_MAPS_API_KEY=your_key_here
+```
+
+For CI/CD, set `STADIA_MAPS_API_KEY` as a GitHub Actions secret. The key is never committed to source — see `.env.example` for the template.
 
 ---
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.java.home=/usr/lib/jvm/java-21-openjdk
 android.useAndroidX=true

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -389,3 +389,44 @@ A new `BackgroundServiceManager` ChangeNotifier on the main isolate manages the 
 **Rationale:** Google Play policy (as of August 2020) requires an explicit rationale dialog before requesting background location. Bundling this into `BeaconingService` would couple a UI concern (dialog display) to a service-layer class. Placing it at the call site (`requestStartService`) keeps the service layer free of BuildContext dependencies while ensuring the rationale is shown at the right moment — when the user explicitly enables background service, not on app launch.
 
 **Consequences:** Background location is only requested when the user enables the background service with non-manual beaconing configured — compliant with Google Play's "least privilege" policy. Users who only use manual beacon mode or APRS-IS receive-only are never prompted for background location.
+
+---
+
+## ADR-027: Tile provider — Stadia Maps (v0.8)
+
+**Status:** Accepted
+**Date:** 2026-04-04
+
+**Decision:** Replace public OSM/CartoDB tile URLs with Stadia Maps (`alidade_smooth` for light mode, `alidade_smooth_dark` for dark mode). Tile URLs are routed through a `MeridianTileProvider` abstraction (`lib/map/`) so the provider can be swapped with minimal changes in future milestones (e.g., `flutter_map_tile_caching` for offline support). The API key is injected at build time via `--dart-define=STADIA_MAPS_API_KEY` and is never committed to source.
+
+**Key sub-decisions:**
+- `MeridianTileProvider` abstract class with a single `tileUrl(Brightness)` method — keeps the tile-URL computation out of the widget tree.
+- `StadiaTileProvider` is a const-constructible implementation; the instance lives on `_MapScreenState` as a final field.
+- Brightness is resolved from `ThemeController.themeMode` in `MapScreen.build()` and passed down — consistent with the existing pattern for other theme-aware decisions.
+- CartoDB-specific `_usesSubdomains` + brightness-boost `ColorFilter.matrix` removed from `MeridianMap` — these were workarounds for CartoDB's near-black dark tiles, which Stadia does not require.
+- `RichAttributionWidget` added to `FlutterMap.children` — Stadia Maps requires attribution for OSM, OpenMapTiles, and Stadia itself.
+- `AppConfig.stadiaMapsApiKey` uses `String.fromEnvironment` with `defaultValue: ''` — the app will run without tiles (blank map) if the key is not provided, rather than crashing.
+
+**Rationale:** Public OSM tile servers are rate-limited and prohibited for production app use per OpenStreetMap ToS. Stadia Maps free tier explicitly covers non-commercial open-source projects. The `alidade_smooth` / `alidade_smooth_dark` styles are visually neutral, low-noise, and appropriate for overlaying APRS station data. Stadia is privacy-focused (no user tracking) and GDPR/CCPA compliant.
+
+**Consequences:** Developers must pass `--dart-define=STADIA_MAPS_API_KEY=<key>` to run the app locally (documented in CLAUDE.md and `.env.example`). CI uses a `STADIA_MAPS_API_KEY` GitHub Actions secret. The `MeridianTileProvider` abstraction is the designated extension point for future offline caching — do not bypass it.
+
+---
+
+## ADR-028: iOS platform routing pattern (v0.8)
+
+**Status:** Accepted
+**Date:** 2026-04-04
+
+**Decision:** Introduce `buildPlatformRoute<T>(WidgetBuilder)` in `lib/ui/utils/platform_route.dart`. On iOS (`!kIsWeb && Platform.isIOS`) it returns a `CupertinoPageRoute`; on all other platforms it returns a `MaterialPageRoute`. All imperative push navigations use this helper. All `TODO(ios): CupertinoPageRoute` markers are removed when the site is updated.
+
+**Key sub-decisions:**
+- Single free function (not a class, not an extension) — simplest possible API for a one-argument call site.
+- Generic `<T>` preserves the push return type used by `LocationPickerScreen` (returns `LatLng?`).
+- The three `TODO(ios): replace with Cupertino search UI` markers in scaffold files are deferred — they require a redesign of the `SearchDelegate` surface, not just a route swap.
+- The `MaterialBanner` in `MapScreen` (`TODO(ios): use Cupertino-styled banner`) is deferred — no direct Cupertino equivalent exists; requires a custom overlay in a future pass.
+
+**Rationale:** `MaterialPageRoute` on iOS produces left-to-right slide transitions instead of the native right-edge swipe-to-go-back behavior of `CupertinoPageRoute`. Without this fix, the iOS swipe-back gesture does not trigger pop on any screen that was pushed via `MaterialPageRoute`, which is immediately noticeable and jarring for iOS users.
+
+**Consequences:** All future push navigations in the app must use `buildPlatformRoute` rather than `MaterialPageRoute` directly. The three deferred `TODO(ios)` markers remain until their respective UIs are redesigned.
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -185,6 +185,35 @@ Goal: Keep transport connections and beaconing alive when Meridian is background
 
 ---
 
+## v0.8 — Cross-Platform Parity
+
+Goal: Replace public OSM tile URLs with Stadia Maps and complete the first real iOS Cupertino audit on physical hardware.
+
+### Workstream A — Stadia Maps Tile Swap
+- [x] `lib/map/meridian_tile_provider.dart` — abstract `MeridianTileProvider` interface
+- [x] `lib/map/stadia_tile_provider.dart` — concrete `StadiaTileProvider` (`alidade_smooth` / `alidade_smooth_dark`)
+- [x] `lib/config/app_config.dart` — `AppConfig.stadiaMapsApiKey` via `String.fromEnvironment`
+- [x] `lib/screens/map_screen.dart` — wired to `StadiaTileProvider`; brightness resolved in `build()`
+- [x] `lib/ui/layout/meridian_map.dart` — CartoDB subdomain + brightness-boost artifacts removed; `RichAttributionWidget` added for OSM/Stadia attribution
+- [x] `.env.example` — developer key template (`.env` gitignored)
+- [x] `CLAUDE.md` — Local Development section added
+- [x] `.github/workflows/ci.yml` — `--dart-define=STADIA_MAPS_API_KEY` added to test + build steps
+- [x] ADR-027 (tile provider decision)
+- [ ] Physical device validation: light/dark tiles on Android, iOS, desktop
+
+### Workstream B — iOS Cupertino Audit
+- [x] `lib/ui/utils/platform_route.dart` — `buildPlatformRoute<T>()` helper (CupertinoPageRoute on iOS, MaterialPageRoute elsewhere)
+- [x] All `TODO(ios): CupertinoPageRoute` sites resolved: `messages_screen.dart`, `settings_screen.dart` (×2), `compose_message_sheet.dart`, `station_info_sheet.dart`
+- [x] `SwitchListTile` → `SwitchListTile.adaptive` (connection screen ×2, settings notifications stub)
+- [x] `CircularProgressIndicator` → `CircularProgressIndicator.adaptive` across all scaffold/widget spinners (BLE scanner, mobile/tablet/desktop scaffold, connection screen, location picker, map connecting banner)
+- [x] ADR-028 (iOS platform routing pattern)
+- [ ] Discovery pass on iPhone 16 Pro — document punch list
+- [ ] Settings → Appearance validation on iOS
+- [ ] Safe area + Dynamic Island verification on iPhone 16 Pro
+- [ ] Full re-test on iPhone 16 Pro
+
+---
+
 ## v1.0 — Polish
 
 Goal: Release-quality app with full onboarding and documentation.

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,49 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_blue_plus_darwin (0.0.2):
+    - Flutter
+    - FlutterMacOS
+  - flutter_foreground_task (0.0.1):
+    - Flutter
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
+  - permission_handler_apple (9.3.0):
+    - Flutter
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_blue_plus_darwin (from `.symlinks/plugins/flutter_blue_plus_darwin/darwin`)
+  - flutter_foreground_task (from `.symlinks/plugins/flutter_foreground_task/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_blue_plus_darwin:
+    :path: ".symlinks/plugins/flutter_blue_plus_darwin/darwin"
+  flutter_foreground_task:
+    :path: ".symlinks/plugins/flutter_foreground_task/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_blue_plus_darwin: 20a08bfeaa0f7804d524858d3d8744bcc1b6dbc3
+  flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+
+PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,11 +10,13 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		53A1CA2899F4486A14131868 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E30B6E6F8A704C371C66E9B /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		BD180BF7F0962A5CEA50FDC4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1127D2CA4DC8DCC636DE91D8 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,15 +43,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1127D2CA4DC8DCC636DE91D8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		138680F040280DA92FFDAB63 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		3226C8DE7F469E3392A4FB8E /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		402CA0A1B86F0E55764CCA36 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7E30B6E6F8A704C371C66E9B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7EED2898EFFCCCE7623EA23D /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -57,13 +65,24 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A33149AABA5A4E15A5993529 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		F9E3A1E64250EF17591068AD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		6B6C64809A3B0A5B46BC8970 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BD180BF7F0962A5CEA50FDC4 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53A1CA2899F4486A14131868 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,6 +95,29 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		3D327757C632B1E439B4CBE7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F9E3A1E64250EF17591068AD /* Pods-Runner.debug.xcconfig */,
+				138680F040280DA92FFDAB63 /* Pods-Runner.release.xcconfig */,
+				402CA0A1B86F0E55764CCA36 /* Pods-Runner.profile.xcconfig */,
+				3226C8DE7F469E3392A4FB8E /* Pods-RunnerTests.debug.xcconfig */,
+				7EED2898EFFCCCE7623EA23D /* Pods-RunnerTests.release.xcconfig */,
+				A33149AABA5A4E15A5993529 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		8DE0A9A2BC05A0EADEC8AE52 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7E30B6E6F8A704C371C66E9B /* Pods_Runner.framework */,
+				1127D2CA4DC8DCC636DE91D8 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -96,6 +138,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				3D327757C632B1E439B4CBE7 /* Pods */,
+				8DE0A9A2BC05A0EADEC8AE52 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -131,8 +175,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				6E0326884875BEA11091CB8D /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				6B6C64809A3B0A5B46BC8970 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -148,12 +194,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				4F5AB27DFAC61CD1A96B3ABB /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				E00E8232958F413BBE9BCB6E /* [CP] Embed Pods Frameworks */,
+				09180F51C32BDFEA5845C523 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -225,6 +274,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		09180F51C32BDFEA5845C523 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -241,6 +307,50 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		4F5AB27DFAC61CD1A96B3ABB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6E0326884875BEA11091CB8D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -255,6 +365,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E00E8232958F413BBE9BCB6E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -366,6 +493,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = GN5GG8HB72;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -382,6 +510,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3226C8DE7F469E3392A4FB8E /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -399,6 +528,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EED2898EFFCCCE7623EA23D /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -414,6 +544,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A33149AABA5A4E15A5993529 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -545,6 +676,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = GN5GG8HB72;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -567,6 +699,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = GN5GG8HB72;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,6 +66,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.pravera.flutter_foreground_task.refresh</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Meridian APRS connects to the Flutter debug service on the local network during development.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Meridian APRS uses your location to transmit position beacons on the APRS network.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,10 @@
+/// Compile-time app configuration.
+///
+/// Values are injected via `--dart-define` at build time. See the
+/// "Local Development" section in CLAUDE.md for setup instructions.
+class AppConfig {
+  static const stadiaMapsApiKey = String.fromEnvironment(
+    'STADIA_MAPS_API_KEY',
+    defaultValue: '',
+  );
+}

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -18,8 +18,8 @@ class AprsIsTransport implements AprsTransport {
     this.port = 14580,
     required String loginLine,
     String? filterLine,
-  })  : _loginLine = loginLine,
-        _filterLine = filterLine;
+  }) : _loginLine = loginLine,
+       _filterLine = filterLine;
 
   /// Updates the login and filter lines used on the next [connect] call.
   /// Safe to call while disconnected; has no effect on an active connection.

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -10,15 +10,23 @@ import 'aprs_transport.dart';
 class AprsIsTransport implements AprsTransport {
   final String host;
   final int port;
-  final String loginLine;
-  final String? filterLine;
+  String _loginLine;
+  String? _filterLine;
 
   AprsIsTransport({
     this.host = 'rotate.aprs2.net',
     this.port = 14580,
-    required this.loginLine,
-    this.filterLine,
-  });
+    required String loginLine,
+    String? filterLine,
+  })  : _loginLine = loginLine,
+        _filterLine = filterLine;
+
+  /// Updates the login and filter lines used on the next [connect] call.
+  /// Safe to call while disconnected; has no effect on an active connection.
+  void updateCredentials({required String loginLine, String? filterLine}) {
+    _loginLine = loginLine;
+    _filterLine = filterLine;
+  }
 
   Socket? _socket;
   StreamSubscription? _socketSubscription;
@@ -65,8 +73,8 @@ class AprsIsTransport implements AprsTransport {
       // already handles state updates; ignoring .done prevents the same error
       // from also reaching the zone as an unhandled exception.
       _socket!.done.ignore();
-      _socket!.write(loginLine);
-      if (filterLine != null) _socket!.write(filterLine);
+      _socket!.write(_loginLine);
+      if (_filterLine != null) _socket!.write(_filterLine);
       _emitState(ConnectionStatus.connected);
 
       _socketSubscription = _socket!

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,20 @@
 import 'dart:io' show Platform;
 
+import 'package:http_cache_file_store/http_cache_file_store.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'config/app_config.dart';
 import 'core/packet/aprs_packet.dart' show PacketSource;
 import 'core/transport/aprs_is_transport.dart';
+import 'map/stadia_tile_provider.dart';
 import 'screens/map_screen.dart';
 import 'screens/onboarding/onboarding_screen.dart';
 import 'services/background_service_manager.dart';
@@ -90,6 +94,14 @@ Future<void> main() async {
   final messageService = MessageService(stationSettings, txService, service);
   await messageService.loadHistory();
 
+  // Tile cache: persist tiles to disk for 30 days so repeated sessions don't
+  // re-fetch the same tiles and burn through Stadia Maps API credits.
+  final cacheDir = await getTemporaryDirectory();
+  final tileProvider = StadiaTileProvider(
+    apiKey: AppConfig.stadiaMapsApiKey,
+    cacheStore: FileCacheStore('${cacheDir.path}/meridian_tiles'),
+  );
+
   final bgServiceManager = BackgroundServiceManager(
     tnc: tncService,
     station: service,
@@ -122,6 +134,7 @@ Future<void> main() async {
         mapZoom: mapZoom,
         service: service,
         tncService: tncService,
+        tileProvider: tileProvider,
       ),
     ),
   );
@@ -138,6 +151,7 @@ class MeridianApp extends StatelessWidget {
     this.mapZoom = 9.0,
     required this.service,
     required this.tncService,
+    required this.tileProvider,
   });
 
   final bool onboardingComplete;
@@ -148,6 +162,7 @@ class MeridianApp extends StatelessWidget {
   final double mapZoom;
   final StationService service;
   final TncService tncService;
+  final StadiaTileProvider tileProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -157,8 +172,14 @@ class MeridianApp extends StatelessWidget {
       final brightness = _resolveIosBrightness(controller.themeMode);
       return CupertinoApp(
         title: 'Meridian APRS',
-        theme: buildIosTheme(brightness: brightness),
+        theme: buildIosTheme(
+          brightness: brightness,
+          primaryColor: controller.seedColor,
+        ),
         debugShowCheckedModeBanner: false,
+        // CupertinoApp does not provide ScaffoldMessenger; add one so that
+        // Material SnackBars work on all routes under this navigator.
+        builder: (context, child) => ScaffoldMessenger(child: child!),
         localizationsDelegates: const [
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
@@ -169,6 +190,7 @@ class MeridianApp extends StatelessWidget {
             ? MapScreen(
                 service: service,
                 tncService: tncService,
+                tileProvider: tileProvider,
                 callsign: userCallsign,
                 ssid: userSsid,
                 initialLat: mapLat,
@@ -198,6 +220,7 @@ class MeridianApp extends StatelessWidget {
             ? MapScreen(
                 service: service,
                 tncService: tncService,
+                tileProvider: tileProvider,
                 callsign: userCallsign,
                 ssid: userSsid,
                 initialLat: mapLat,
@@ -227,6 +250,7 @@ class MeridianApp extends StatelessWidget {
               ? MapScreen(
                   service: service,
                   tncService: tncService,
+                  tileProvider: tileProvider,
                   callsign: userCallsign,
                   ssid: userSsid,
                   initialLat: mapLat,

--- a/lib/map/meridian_tile_provider.dart
+++ b/lib/map/meridian_tile_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+/// Abstraction over tile URL construction and network delivery.
+///
+/// [tileUrl] returns the URL template for a given brightness.
+/// [buildTileProvider] returns the flutter_map [TileProvider] to use —
+/// implementations must return the **same cached instance** on repeated calls
+/// to avoid creating new Dio/HTTP connections on every widget rebuild.
+/// [dispose] releases any underlying HTTP client resources.
+abstract class MeridianTileProvider {
+  String tileUrl(Brightness brightness);
+  TileProvider buildTileProvider();
+  void dispose() {}
+}

--- a/lib/map/stadia_tile_provider.dart
+++ b/lib/map/stadia_tile_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_cache/flutter_map_cache.dart';
+import 'package:http_cache_core/http_cache_core.dart';
+
+import 'meridian_tile_provider.dart';
+
+/// Stadia Maps tile provider with disk caching.
+///
+/// Serves `alidade_smooth` tiles in light mode and `alidade_smooth_dark` in
+/// dark mode. An API key is required and must be passed at build time via
+/// `--dart-define=STADIA_MAPS_API_KEY=<key>`.
+///
+/// Pass a [CacheStore] (e.g. [FileCacheStore]) to persist tiles across
+/// sessions and avoid redundant requests to the Stadia Maps API.
+class StadiaTileProvider implements MeridianTileProvider {
+  final String apiKey;
+  final CacheStore _cacheStore;
+
+  StadiaTileProvider({required this.apiKey, required CacheStore cacheStore})
+      : _cacheStore = cacheStore;
+
+  // Lazily created and reused across builds to avoid creating a new Dio
+  // HTTP client (and its keep-alive timers) on every widget rebuild.
+  CachedTileProvider? _provider;
+
+  @override
+  String tileUrl(Brightness brightness) {
+    final style = brightness == Brightness.dark
+        ? 'alidade_smooth_dark'
+        : 'alidade_smooth';
+    return 'https://tiles.stadiamaps.com/tiles/$style/{z}/{x}/{y}.png?api_key=$apiKey';
+  }
+
+  @override
+  TileProvider buildTileProvider() => _provider ??= CachedTileProvider(
+        store: _cacheStore,
+        // Serve from cache when offline; refresh after 30 days.
+        maxStale: const Duration(days: 30),
+        hitCacheOnNetworkFailure: true,
+      );
+
+  @override
+  void dispose() {
+    _provider?.dio.close(force: true);
+    _provider = null;
+  }
+}

--- a/lib/map/stadia_tile_provider.dart
+++ b/lib/map/stadia_tile_provider.dart
@@ -18,7 +18,7 @@ class StadiaTileProvider implements MeridianTileProvider {
   final CacheStore _cacheStore;
 
   StadiaTileProvider({required this.apiKey, required CacheStore cacheStore})
-      : _cacheStore = cacheStore;
+    : _cacheStore = cacheStore;
 
   // Lazily created and reused across builds to avoid creating a new Dio
   // HTTP client (and its keep-alive timers) on every widget rebuild.
@@ -34,11 +34,11 @@ class StadiaTileProvider implements MeridianTileProvider {
 
   @override
   TileProvider buildTileProvider() => _provider ??= CachedTileProvider(
-        store: _cacheStore,
-        // Serve from cache when offline; refresh after 30 days.
-        maxStale: const Duration(days: 30),
-        hitCacheOnNetworkFailure: true,
-      );
+    store: _cacheStore,
+    // Serve from cache when offline; refresh after 30 days.
+    maxStale: const Duration(days: 30),
+    hitCacheOnNetworkFailure: true,
+  );
 
   @override
   void dispose() {

--- a/lib/screens/connection_screen.dart
+++ b/lib/screens/connection_screen.dart
@@ -205,10 +205,12 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
                       ),
                       child: Row(
                         children: [
-                          const SizedBox(
+                          SizedBox(
                             width: 16,
                             height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+                            child: CircularProgressIndicator.adaptive(
+                              strokeWidth: 2,
+                            ),
                           ),
                           const SizedBox(width: 12),
                           const Expanded(
@@ -690,7 +692,7 @@ class _AprsActiveCard extends StatelessWidget {
               ),
             ),
             Consumer<TxService>(
-              builder: (_, txSvc, _) => SwitchListTile(
+              builder: (_, txSvc, _) => SwitchListTile.adaptive(
                 dense: true,
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Beacon'),
@@ -785,7 +787,7 @@ class _TncActiveCard extends StatelessWidget {
               ),
             ),
             Consumer<TxService>(
-              builder: (_, txSvc, _) => SwitchListTile(
+              builder: (_, txSvc, _) => SwitchListTile.adaptive(
                 dense: true,
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Beacon'),

--- a/lib/screens/location_picker_screen.dart
+++ b/lib/screens/location_picker_screen.dart
@@ -185,12 +185,14 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
               controller: _searchCtrl,
               hintText: 'Search address (requires internet)…',
               leading: _searching
-                  ? const Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 12),
+                  ? Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
                       child: SizedBox(
                         width: 20,
                         height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
                       ),
                     )
                   : const Icon(Symbols.search),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -7,7 +7,10 @@ import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+
+import '../config/app_config.dart';
 import '../core/packet/station.dart';
+import '../map/meridian_tile_provider.dart';
 import '../services/station_service.dart';
 import '../services/tnc_service.dart';
 import '../services/tx_service.dart';
@@ -15,20 +18,23 @@ import '../ui/layout/responsive_layout.dart';
 import '../theme/meridian_colors.dart';
 import '../theme/theme_controller.dart';
 import '../ui/widgets/aprs_symbol_widget.dart';
+import '../ui/utils/platform_route.dart';
 import '../ui/widgets/station_info_sheet.dart';
 import 'settings_screen.dart';
 
 /// Root screen that owns the [StationService] lifecycle and builds the
 /// adaptive layout.
 ///
-/// Map tile URL is theme-aware: light mode uses OSM standard tiles, dark mode
-/// uses CartoDB dark tiles. The theme is read from [ThemeController] and the
-/// system brightness is used to resolve [ThemeMode.system].
+/// Map tile URL is theme-aware: light mode uses Stadia `alidade_smooth` tiles,
+/// dark mode uses `alidade_smooth_dark`. The theme is read from
+/// [ThemeController] and the system brightness is used to resolve
+/// [ThemeMode.system].
 class MapScreen extends StatefulWidget {
   const MapScreen({
     super.key,
     required this.service,
     required this.tncService,
+    this.tileProvider,
     this.callsign = 'NOCALL',
     this.ssid = 0,
     this.initialLat = 39.0,
@@ -38,6 +44,10 @@ class MapScreen extends StatefulWidget {
 
   final StationService service;
   final TncService tncService;
+
+  /// Tile provider with disk cache. When null (e.g. from the onboarding path),
+  /// a memory-only fallback is used for the session.
+  final MeridianTileProvider? tileProvider;
   final String callsign;
 
   /// SSID suffix (0 = no suffix, 1–15 appended as `-N`).
@@ -53,6 +63,7 @@ class MapScreen extends StatefulWidget {
 
 class _MapScreenState extends State<MapScreen> {
   late final StationService _service;
+  late final MeridianTileProvider _tileProvider;
   final _mapController = MapController();
   List<Marker> _markers = [];
   Timer? _filterDebounce;
@@ -63,15 +74,11 @@ class _MapScreenState extends State<MapScreen> {
   StreamSubscription<TxEvent>? _txEventSub;
   bool _northUpLocked = true;
 
-  // Tile URL constants.
-  static const _lightTileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
-  static const _darkTileUrl =
-      'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png';
-
   @override
   void initState() {
     super.initState();
     _service = widget.service;
+    _tileProvider = widget.tileProvider ?? _UncachedTileProvider();
     _connectionStatus = _service.currentConnectionStatus;
     _service.stationUpdates.listen(_onStationsUpdated);
     // Seed markers from persisted stations already loaded before runApp.
@@ -108,6 +115,7 @@ class _MapScreenState extends State<MapScreen> {
     _markerDebounce?.cancel();
     _txEventSub?.cancel();
     _service.stop();
+    _tileProvider.dispose();
     super.dispose();
   }
 
@@ -225,17 +233,6 @@ class _MapScreenState extends State<MapScreen> {
     ),
   );
 
-  /// Resolve the tile URL based on the current theme mode and system brightness.
-  String _tileUrl(BuildContext context) {
-    final themeController = context.watch<ThemeController>();
-    final brightness = switch (themeController.themeMode) {
-      ThemeMode.light => Brightness.light,
-      ThemeMode.dark => Brightness.dark,
-      ThemeMode.system => MediaQuery.of(context).platformBrightness,
-    };
-    return brightness == Brightness.dark ? _darkTileUrl : _lightTileUrl;
-  }
-
   void _toggleNorthUp() {
     HapticFeedback.lightImpact();
     setState(() => _northUpLocked = !_northUpLocked);
@@ -243,10 +240,7 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   void _navigateToSettings() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const SettingsScreen()),
-    );
+    Navigator.push(context, buildPlatformRoute((_) => const SettingsScreen()));
   }
 
   @override
@@ -257,13 +251,20 @@ class _MapScreenState extends State<MapScreen> {
     // ensures the map always reflects live state regardless of stream ordering.
     final aprsStatus = context.watch<StationService>().currentConnectionStatus;
     final tncStatus = context.watch<TncService>().currentStatus;
+    final themeController = context.watch<ThemeController>();
+    final brightness = switch (themeController.themeMode) {
+      ThemeMode.light => Brightness.light,
+      ThemeMode.dark => Brightness.dark,
+      ThemeMode.system => MediaQuery.of(context).platformBrightness,
+    };
 
     return ResponsiveLayout(
       service: _service,
       tncService: widget.tncService,
       mapController: _mapController,
       markers: _markers,
-      tileUrl: _tileUrl(context),
+      tileUrl: _tileProvider.tileUrl(brightness),
+      meridianTileProvider: _tileProvider,
       onNavigateToSettings: _navigateToSettings,
       connectionStatus: aprsStatus,
       tncConnectionStatus: tncStatus,
@@ -273,4 +274,24 @@ class _MapScreenState extends State<MapScreen> {
       onToggleNorthUp: _toggleNorthUp,
     );
   }
+}
+
+/// Fallback tile provider used when no cached provider is supplied
+/// (e.g. the onboarding path or tests). Uses flutter_map's built-in
+/// NetworkTileProvider — no Dio client, no lingering timers.
+class _UncachedTileProvider implements MeridianTileProvider {
+  @override
+  String tileUrl(Brightness brightness) {
+    final style = brightness == Brightness.dark
+        ? 'alidade_smooth_dark'
+        : 'alidade_smooth';
+    return 'https://tiles.stadiamaps.com/tiles/$style/{z}/{x}/{y}.png'
+        '?api_key=${AppConfig.stadiaMapsApiKey}';
+  }
+
+  @override
+  TileProvider buildTileProvider() => NetworkTileProvider();
+
+  @override
+  void dispose() {}
 }

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -7,7 +7,6 @@ import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-
 import '../config/app_config.dart';
 import '../core/packet/station.dart';
 import '../map/meridian_tile_provider.dart';

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -392,8 +392,9 @@ class _ComposeBarState extends State<_ComposeBar> {
             ),
             const SizedBox(width: 8),
             IconButton.filled(
-              icon: const Icon(Symbols.send),
+              icon: const Icon(Icons.send_rounded),
               tooltip: 'Send',
+              style: IconButton.styleFrom(foregroundColor: Colors.white),
               onPressed: canSend ? widget.onSend : null,
             ),
           ],

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -12,6 +12,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../services/message_service.dart';
+import '../ui/utils/platform_route.dart';
 import '../ui/widgets/compose_message_sheet.dart';
 import 'message_thread_screen.dart';
 
@@ -60,9 +61,8 @@ class MessagesScreen extends StatelessWidget {
                     service.markRead(conv.peerCallsign);
                     Navigator.push(
                       context,
-                      MaterialPageRoute(
-                        // TODO(ios): CupertinoPageRoute
-                        builder: (_) => MessageThreadScreen(
+                      buildPlatformRoute(
+                        (_) => MessageThreadScreen(
                           peerCallsign: conv.peerCallsign,
                         ),
                       ),

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,9 +1,10 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../../core/transport/aprs_is_transport.dart';
 import '../../services/station_service.dart';
+import '../../services/station_settings_service.dart';
 import '../../services/tnc_service.dart';
 import '../map_screen.dart';
 import 'onboarding_callsign_page.dart';
@@ -45,6 +46,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Future<void> _markCompleteAndNavigate() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(OnboardingScreen._prefKey, true);
+
+    final effectiveCallsign = _callsign.isNotEmpty ? _callsign : 'NOCALL';
+    final ssidSuffix = _ssid > 0 ? '-$_ssid' : '';
+    final effectivePasscode = _passcode.isEmpty ? '-1' : _passcode;
+    final mapLat = prefs.getDouble('map_last_lat') ?? 39.0;
+    final mapLon = prefs.getDouble('map_last_lon') ?? -77.0;
+
     if (_callsign.isNotEmpty) {
       await prefs.setString('user_callsign', _callsign);
     }
@@ -55,42 +63,49 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     // yet implemented; transport selection will be wired here when they land.
     await prefs.setInt('connection_method', _connectionMethod);
 
-    final effectiveCallsign = _callsign.isNotEmpty ? _callsign : 'NOCALL';
-    final ssidSuffix = _ssid > 0 ? '-$_ssid' : '';
-    final effectivePasscode = _passcode.isEmpty ? '-1' : _passcode;
-    final mapLat = prefs.getDouble('map_last_lat') ?? 39.0;
-    final mapLon = prefs.getDouble('map_last_lon') ?? -77.0;
+    if (!mounted) return;
 
-    final transport = AprsIsTransport(
+    // Update the Provider tree's services with the entered identity so that
+    // Settings, BeaconingService, and MessageService all reflect the correct
+    // callsign without requiring an app restart.
+    final stationSettings = context.read<StationSettingsService>();
+    await stationSettings.setCallsign(effectiveCallsign);
+    await stationSettings.setSsid(_ssid);
+
+    // Update the APRS-IS transport login line so that the first connection
+    // uses the entered callsign and passcode rather than the NOCALL default
+    // that was set before onboarding completed.
+    if (!mounted) return;
+    context.read<StationService>().updateAprsIsCredentials(
       loginLine:
           'user $effectiveCallsign$ssidSuffix pass $effectivePasscode vers meridian-aprs $_kVersion\r\n',
       filterLine:
           '#filter r/${mapLat.toStringAsFixed(1)}/${mapLon.toStringAsFixed(1)}/100\r\n',
     );
-    final service = StationService(transport);
-    final tncService = TncService(service);
 
-    if (mounted) {
-      Navigator.pushReplacement(
-        context,
-        PageRouteBuilder<void>(
-          transitionDuration: const Duration(milliseconds: 300),
-          pageBuilder: (context, animation, secondaryAnimation) =>
-              FadeThroughTransition(
-                animation: animation,
-                secondaryAnimation: secondaryAnimation,
-                child: MapScreen(
-                  service: service,
-                  tncService: tncService,
-                  callsign: effectiveCallsign,
-                  ssid: _ssid,
-                  initialLat: mapLat,
-                  initialLon: mapLon,
-                ),
+    if (!mounted) return;
+    final service = context.read<StationService>();
+    final tncService = context.read<TncService>();
+
+    Navigator.pushReplacement(
+      context,
+      PageRouteBuilder<void>(
+        transitionDuration: const Duration(milliseconds: 300),
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            FadeThroughTransition(
+              animation: animation,
+              secondaryAnimation: secondaryAnimation,
+              child: MapScreen(
+                service: service,
+                tncService: tncService,
+                callsign: effectiveCallsign,
+                ssid: _ssid,
+                initialLat: mapLat,
+                initialLon: mapLon,
               ),
-        ),
-      );
-    }
+            ),
+      ),
+    );
   }
 
   void _nextPage() {

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -76,14 +76,30 @@ class _PacketLogBodyState extends State<PacketLogBody> {
     // Listen for new packets.
     _subscription = widget.service.packetStream.listen(_onPacket);
 
+    // Listen for bulk changes (e.g. clearPacketLog) that packetStream doesn't
+    // signal — sync local buffer when the service's packet count drops.
+    widget.service.addListener(_onServiceChanged);
+
     _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
+    widget.service.removeListener(_onServiceChanged);
     _subscription?.cancel();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _onServiceChanged() {
+    final current = widget.service.recentPackets;
+    if (current.length < _packets.length) {
+      setState(() {
+        _packets
+          ..clear()
+          ..addAll(current);
+      });
+    }
   }
 
   void _onPacket(AprsPacket packet) {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -14,6 +14,7 @@ import 'location_picker_screen.dart';
 import '../services/message_service.dart';
 import '../services/station_service.dart';
 import '../services/station_settings_service.dart';
+import '../ui/utils/platform_route.dart';
 import '../ui/widgets/aprs_symbol_widget.dart';
 import '../ui/widgets/callsign_field.dart';
 import '../theme/meridian_colors.dart';
@@ -29,24 +30,25 @@ class SettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final sections = [
+      const _AppearanceSection(),
+      const _AppColorSection(),
+      const _MyStationSection(),
+      const _BeaconingSection(),
+      const _ConnectionSection(),
+      const _HistorySection(),
+      const _DisplaySection(),
+      const _NotificationsSection(),
+      const _AccountSection(),
+      const _AboutSection(),
+    ];
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: ListView.separated(
-        itemCount: 11,
+        itemCount: sections.length,
         separatorBuilder: (context, index) =>
             const Divider(indent: 16, endIndent: 16),
-        itemBuilder: (context, index) => [
-          const _AppearanceSection(),
-          const _AppColorSection(),
-          const _MyStationSection(),
-          const _BeaconingSection(),
-          const _ConnectionSection(),
-          const _HistorySection(),
-          const _DisplaySection(),
-          const _NotificationsSection(),
-          const _AccountSection(),
-          const _AboutSection(),
-        ][index],
+        itemBuilder: (context, index) => sections[index],
       ),
     );
   }
@@ -128,15 +130,14 @@ class _AppearanceSection extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// App Color (Android only)
+// App Color
 // ---------------------------------------------------------------------------
 
-/// Seed color picker shown only on Android.
+/// Seed color picker shown on all platforms.
 ///
 /// On Android 12+ a "System" swatch appears first — selecting it re-enables
-/// wallpaper-derived dynamic color. On Android 11 and below only the fixed
-/// seed swatches are shown (dynamic color is not available on those devices).
-/// Hidden on iOS and desktop — the seed has no effect there.
+/// wallpaper-derived dynamic color. On all other platforms (iOS, desktop,
+/// Android 11 and below) only the fixed seed swatches are shown.
 class _AppColorSection extends StatelessWidget {
   const _AppColorSection();
 
@@ -153,8 +154,7 @@ class _AppColorSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Always included in the list to keep itemCount stable; invisible elsewhere.
-    if (kIsWeb || !Platform.isAndroid) return const SizedBox.shrink();
+    if (kIsWeb) return const SizedBox.shrink();
 
     final controller = context.watch<ThemeController>();
     final outline = Theme.of(context).colorScheme.outline;
@@ -844,10 +844,7 @@ class _LocationSourcePicker extends StatelessWidget {
         ? LatLng(svc.manualLat!, svc.manualLon!)
         : null;
     final result = await Navigator.of(context).push<LatLng>(
-      MaterialPageRoute(
-        // TODO(ios): CupertinoPageRoute
-        builder: (_) => LocationPickerScreen(initial: initial),
-      ),
+      buildPlatformRoute((_) => LocationPickerScreen(initial: initial)),
     );
     if (result != null && context.mounted) {
       latCtrl.text = result.latitude.toStringAsFixed(6);
@@ -928,10 +925,7 @@ class _BeaconingSection extends StatelessWidget {
             trailing: const Icon(Symbols.chevron_right),
             onTap: () => Navigator.push(
               context,
-              MaterialPageRoute(
-                // TODO(ios): CupertinoPageRoute
-                builder: (_) => const _SmartBeaconingParamsScreen(),
-              ),
+              buildPlatformRoute((_) => const _SmartBeaconingParamsScreen()),
             ),
           ),
         ],
@@ -1356,13 +1350,15 @@ class _NotificationsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Column(
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _SectionHeader('Notifications'),
-        SwitchListTile(
-          title: Text('Message alerts'),
-          subtitle: Text('Notify when a message addressed to you arrives.'),
+        const _SectionHeader('Notifications'),
+        SwitchListTile.adaptive(
+          title: const Text('Message alerts'),
+          subtitle: const Text(
+            'Notify when a message addressed to you arrives.',
+          ),
           value: false,
           onChanged: null, // Stub — not yet functional.
         ),

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -295,11 +295,27 @@ class BackgroundServiceManager extends ChangeNotifier
 
     _setState(BackgroundServiceState.starting);
 
+    // Android 15+ enforces that ACCESS_FINE_LOCATION is granted at runtime
+    // before startForeground() when foregroundServiceType includes 'location'.
+    // Request it here if not yet granted, regardless of beaconing state.
+    if (!context.mounted) return false;
+    final locStatus = await Permission.locationWhenInUse.status;
+    if (!locStatus.isGranted) {
+      final result = await Permission.locationWhenInUse.request();
+      if (!result.isGranted) {
+        _errorMessage =
+            'Location permission is required to run the background service.';
+        _setState(BackgroundServiceState.error);
+        return false;
+      }
+    }
+
     // Background location is only required when GPS beaconing will run while
     // the screen is locked. Connection-only keepalive does not need it.
     final needsGpsInBackground =
         _beaconing.isActive && _beaconing.mode != BeaconMode.manual;
     if (needsGpsInBackground) {
+      if (!context.mounted) return false;
       final granted = await _requestBackgroundLocationPermission(context);
       if (!granted) {
         _errorMessage =
@@ -483,6 +499,16 @@ class BackgroundServiceManager extends ChangeNotifier
     if (!Platform.isAndroid) return;
     if (isRunning || !_backgroundActivityEnabled) return;
     if (!_shouldBeRunning) return;
+
+    // Android 15+ enforces that ACCESS_FINE_LOCATION is granted at runtime
+    // before startForeground() when foregroundServiceType includes 'location'.
+    // This applies to every start — not just GPS-beaconing starts.
+    final locStatus = await Permission.locationWhenInUse.status;
+    if (!locStatus.isGranted) {
+      _needsPermission = true;
+      notifyListeners();
+      return;
+    }
 
     // Background location is only needed when GPS beaconing will fire while
     // the screen is locked. Connection keepalive alone does not require it.

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../core/packet/aprs_packet.dart';
 import '../core/packet/aprs_parser.dart';
 import '../core/packet/station.dart';
+import '../core/transport/aprs_is_transport.dart';
 import '../core/transport/aprs_transport.dart'
     show AprsTransport, ConnectionStatus;
 
@@ -105,6 +106,17 @@ class StationService extends ChangeNotifier {
     // No auto-connect: the user initiates connections explicitly via the
     // Connection screen. Once connected, the foreground service keeps the
     // connection alive when the app is backgrounded.
+  }
+
+  /// Updates the APRS-IS login and filter lines used on the next [connectAprsIs]
+  /// call. No-op if the underlying transport is not [AprsIsTransport].
+  void updateAprsIsCredentials({
+    required String loginLine,
+    String? filterLine,
+  }) {
+    if (_transport case final AprsIsTransport t) {
+      t.updateCredentials(loginLine: loginLine, filterLine: filterLine);
+    }
   }
 
   Future<void> connectAprsIs() async {

--- a/lib/theme/ios_theme.dart
+++ b/lib/theme/ios_theme.dart
@@ -19,8 +19,5 @@ CupertinoThemeData buildIosTheme({
   required Brightness brightness,
   Color primaryColor = MeridianColors.primary,
 }) {
-  return CupertinoThemeData(
-    brightness: brightness,
-    primaryColor: primaryColor,
-  );
+  return CupertinoThemeData(brightness: brightness, primaryColor: primaryColor);
 }

--- a/lib/theme/ios_theme.dart
+++ b/lib/theme/ios_theme.dart
@@ -4,7 +4,10 @@ import 'meridian_colors.dart';
 
 /// Builds the iOS [CupertinoThemeData] for the given [brightness].
 ///
-/// Uses fixed Meridian brand colors — no dynamic color or seed color on iOS.
+/// [primaryColor] sets the app tint color (buttons, links, active controls).
+/// Defaults to [MeridianColors.primary]. Pass [ThemeController.seedColor] to
+/// honour the user's color preference from the App Color picker.
+///
 /// San Francisco font is applied automatically by Flutter on iOS; no
 /// [CupertinoTextThemeData] override is needed.
 ///
@@ -12,9 +15,12 @@ import 'meridian_colors.dart';
 /// the app root resolves from [ThemeController.themeMode] before calling this
 /// function. [CupertinoColors] system colors (e.g. systemBackground) resolve
 /// automatically for the given brightness.
-CupertinoThemeData buildIosTheme({required Brightness brightness}) {
+CupertinoThemeData buildIosTheme({
+  required Brightness brightness,
+  Color primaryColor = MeridianColors.primary,
+}) {
   return CupertinoThemeData(
     brightness: brightness,
-    primaryColor: MeridianColors.primary,
+    primaryColor: primaryColor,
   );
 }

--- a/lib/ui/layout/desktop_scaffold.dart
+++ b/lib/ui/layout/desktop_scaffold.dart
@@ -255,7 +255,8 @@ class _DesktopScaffoldState extends State<DesktopScaffold> {
                         mapController: widget.mapController,
                         markers: widget.markers,
                         tileUrl: widget.tileUrl,
-                        tileProvider: widget.meridianTileProvider.buildTileProvider(),
+                        tileProvider: widget.meridianTileProvider
+                            .buildTileProvider(),
                         connectionStatus: widget.connectionStatus,
                         initialCenter: widget.initialCenter,
                         initialZoom: widget.initialZoom,

--- a/lib/ui/layout/desktop_scaffold.dart
+++ b/lib/ui/layout/desktop_scaffold.dart
@@ -6,6 +6,8 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:provider/provider.dart';
 
+import '../../map/meridian_tile_provider.dart';
+
 import '../../core/packet/station.dart';
 import '../../screens/connection_screen.dart';
 import '../../screens/location_picker_screen.dart';
@@ -19,6 +21,7 @@ import '../../services/tnc_service.dart';
 import '../../services/tx_service.dart';
 import '../../theme/meridian_colors.dart';
 import '../widgets/connection_nav_icon.dart';
+import '../utils/platform_route.dart';
 import '../widgets/station_search_delegate.dart';
 import 'meridian_map.dart';
 
@@ -36,6 +39,7 @@ class DesktopScaffold extends StatefulWidget {
     required this.mapController,
     required this.markers,
     required this.tileUrl,
+    required this.meridianTileProvider,
     required this.onNavigateToSettings,
     this.connectionStatus = ConnectionStatus.disconnected,
     this.tncConnectionStatus = ConnectionStatus.disconnected,
@@ -50,6 +54,7 @@ class DesktopScaffold extends StatefulWidget {
   final MapController mapController;
   final List<Marker> markers;
   final String tileUrl;
+  final MeridianTileProvider meridianTileProvider;
   final VoidCallback onNavigateToSettings;
   final ConnectionStatus connectionStatus;
   final ConnectionStatus tncConnectionStatus;
@@ -112,7 +117,7 @@ class _DesktopScaffoldState extends State<DesktopScaffold> {
       if (!mounted) return;
       final result = await Navigator.push<LatLng>(
         context,
-        MaterialPageRoute(builder: (_) => const LocationPickerScreen()),
+        buildPlatformRoute((_) => const LocationPickerScreen()),
       );
       if (result != null && mounted) {
         widget.mapController.move(result, 13.0);
@@ -170,10 +175,10 @@ class _DesktopScaffoldState extends State<DesktopScaffold> {
           ),
           IconButton(
             icon: _locating
-                ? const SizedBox(
+                ? SizedBox(
                     width: 20,
                     height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                   )
                 : const Icon(Symbols.my_location),
             tooltip: 'Center on my location',
@@ -250,6 +255,7 @@ class _DesktopScaffoldState extends State<DesktopScaffold> {
                         mapController: widget.mapController,
                         markers: widget.markers,
                         tileUrl: widget.tileUrl,
+                        tileProvider: widget.meridianTileProvider.buildTileProvider(),
                         connectionStatus: widget.connectionStatus,
                         initialCenter: widget.initialCenter,
                         initialZoom: widget.initialZoom,

--- a/lib/ui/layout/meridian_map.dart
+++ b/lib/ui/layout/meridian_map.dart
@@ -25,6 +25,7 @@ class MeridianMap extends StatelessWidget {
     required this.mapController,
     required this.markers,
     required this.tileUrl,
+    this.tileProvider,
     this.connectionStatus = ConnectionStatus.disconnected,
     this.initialCenter = const LatLng(39.0, -77.0),
     this.initialZoom = 9.0,
@@ -36,10 +37,12 @@ class MeridianMap extends StatelessWidget {
   final MapController mapController;
   final List<Marker> markers;
 
-  /// OSM-compatible tile URL with `{z}`, `{x}`, `{y}` placeholders.
-  /// For tiles that use subdomain rotation include `{s}` and set
-  /// the appropriate subdomains on [TileLayer].
+  /// Stadia Maps tile URL with `{z}`, `{x}`, `{y}` placeholders.
   final String tileUrl;
+
+  /// Optional tile provider — use a [CachedTileProvider] to avoid redundant
+  /// network requests. Falls back to flutter_map's default when null.
+  final TileProvider? tileProvider;
 
   final ConnectionStatus connectionStatus;
   final LatLng initialCenter;
@@ -56,53 +59,8 @@ class MeridianMap extends StatelessWidget {
   /// Called when the user taps the not-connected nudge chip.
   final VoidCallback? onNotConnectedTap;
 
-  /// Whether the tile URL requires subdomain rotation (CartoDB dark tiles).
-  bool get _usesSubdomains => tileUrl.contains('{s}');
-
-  /// Whether these are dark tiles that need a brightness boost to remain
-  /// readable (CartoDB dark_all is near-black by default).
-  bool get _isDarkTile => tileUrl.contains('dark');
-
-  // Lifts CartoDB dark tiles from near-black to a readable dark-gray.
-  // Adds ~26/255 (~10%) to every RGB channel without touching alpha.
-  static const _darkTileBrightnessFilter = ColorFilter.matrix([
-    1,
-    0,
-    0,
-    0,
-    26,
-    0,
-    1,
-    0,
-    0,
-    26,
-    0,
-    0,
-    1,
-    0,
-    26,
-    0,
-    0,
-    0,
-    1,
-    0,
-  ]);
-
   @override
   Widget build(BuildContext context) {
-    Widget tileLayer = TileLayer(
-      urlTemplate: tileUrl,
-      userAgentPackageName: 'com.meridianaprs.app',
-      subdomains: _usesSubdomains ? const ['a', 'b', 'c', 'd'] : const [],
-    );
-
-    if (_isDarkTile) {
-      tileLayer = ColorFiltered(
-        colorFilter: _darkTileBrightnessFilter,
-        child: tileLayer,
-      );
-    }
-
     return Stack(
       children: [
         FlutterMap(
@@ -117,8 +75,19 @@ class MeridianMap extends StatelessWidget {
             ),
           ),
           children: [
-            tileLayer,
+            TileLayer(
+              urlTemplate: tileUrl,
+              tileProvider: tileProvider,
+              userAgentPackageName: 'com.meridianaprs.app',
+            ),
             MarkerLayer(markers: markers),
+            RichAttributionWidget(
+              attributions: [
+                TextSourceAttribution('Stadia Maps'),
+                TextSourceAttribution('OpenMapTiles'),
+                TextSourceAttribution('OpenStreetMap contributors'),
+              ],
+            ),
           ],
         ),
         if (connectionStatus == ConnectionStatus.connecting)
@@ -189,10 +158,7 @@ class _ConnectingBanner extends StatelessWidget {
             SizedBox(
               width: 12,
               height: 12,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                strokeCap: StrokeCap.round,
-              ),
+              child: CircularProgressIndicator.adaptive(strokeWidth: 2),
             ),
             const SizedBox(width: 10),
             Text(

--- a/lib/ui/layout/mobile_scaffold.dart
+++ b/lib/ui/layout/mobile_scaffold.dart
@@ -7,6 +7,8 @@ import 'package:latlong2/latlong.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
+import '../../map/meridian_tile_provider.dart';
+
 import '../../core/packet/station.dart';
 import '../../screens/connection_screen.dart';
 import '../../screens/messages_screen.dart';
@@ -36,6 +38,7 @@ class MobileScaffold extends StatefulWidget {
     required this.mapController,
     required this.markers,
     required this.tileUrl,
+    required this.meridianTileProvider,
     required this.onNavigateToSettings,
     this.connectionStatus = ConnectionStatus.disconnected,
     this.tncConnectionStatus = ConnectionStatus.disconnected,
@@ -50,6 +53,7 @@ class MobileScaffold extends StatefulWidget {
   final MapController mapController;
   final List<Marker> markers;
   final String tileUrl;
+  final MeridianTileProvider meridianTileProvider;
   final VoidCallback onNavigateToSettings;
   final ConnectionStatus connectionStatus;
   final ConnectionStatus tncConnectionStatus;
@@ -236,6 +240,7 @@ class _MobileScaffoldState extends State<MobileScaffold> {
                 mapController: widget.mapController,
                 markers: widget.markers,
                 tileUrl: widget.tileUrl,
+                tileProvider: widget.meridianTileProvider.buildTileProvider(),
                 connectionStatus: widget.connectionStatus,
                 initialCenter: widget.initialCenter,
                 initialZoom: widget.initialZoom,
@@ -284,10 +289,10 @@ class _MobileScaffoldState extends State<MobileScaffold> {
                               onPressed: _locating ? null : _centerOnLocation,
                               tooltip: 'Center on my location',
                               child: _locating
-                                  ? const SizedBox(
+                                  ? SizedBox(
                                       width: 16,
                                       height: 16,
-                                      child: CircularProgressIndicator(
+                                      child: CircularProgressIndicator.adaptive(
                                         strokeWidth: 2,
                                       ),
                                     )

--- a/lib/ui/layout/responsive_layout.dart
+++ b/lib/ui/layout/responsive_layout.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../map/meridian_tile_provider.dart';
+
 import '../../services/station_service.dart';
 import '../../services/tnc_service.dart';
 import 'desktop_scaffold.dart';
@@ -22,6 +24,7 @@ class ResponsiveLayout extends StatelessWidget {
     required this.mapController,
     required this.markers,
     required this.tileUrl,
+    required this.meridianTileProvider,
     required this.onNavigateToSettings,
     this.connectionStatus = ConnectionStatus.disconnected,
     this.tncConnectionStatus = ConnectionStatus.disconnected,
@@ -36,6 +39,7 @@ class ResponsiveLayout extends StatelessWidget {
   final MapController mapController;
   final List<Marker> markers;
   final String tileUrl;
+  final MeridianTileProvider meridianTileProvider;
   final VoidCallback onNavigateToSettings;
   final ConnectionStatus connectionStatus;
   final ConnectionStatus tncConnectionStatus;
@@ -55,6 +59,7 @@ class ResponsiveLayout extends StatelessWidget {
         mapController: mapController,
         markers: markers,
         tileUrl: tileUrl,
+        meridianTileProvider: meridianTileProvider,
         onNavigateToSettings: onNavigateToSettings,
         connectionStatus: connectionStatus,
         tncConnectionStatus: tncConnectionStatus,
@@ -71,6 +76,7 @@ class ResponsiveLayout extends StatelessWidget {
         mapController: mapController,
         markers: markers,
         tileUrl: tileUrl,
+        meridianTileProvider: meridianTileProvider,
         onNavigateToSettings: onNavigateToSettings,
         connectionStatus: connectionStatus,
         tncConnectionStatus: tncConnectionStatus,
@@ -86,6 +92,7 @@ class ResponsiveLayout extends StatelessWidget {
       mapController: mapController,
       markers: markers,
       tileUrl: tileUrl,
+      meridianTileProvider: meridianTileProvider,
       onNavigateToSettings: onNavigateToSettings,
       connectionStatus: connectionStatus,
       tncConnectionStatus: tncConnectionStatus,

--- a/lib/ui/layout/tablet_scaffold.dart
+++ b/lib/ui/layout/tablet_scaffold.dart
@@ -9,6 +9,8 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:provider/provider.dart';
 
+import '../../map/meridian_tile_provider.dart';
+
 import '../../core/packet/station.dart';
 import '../../screens/connection_screen.dart';
 import '../../screens/messages_screen.dart';
@@ -36,6 +38,7 @@ class TabletScaffold extends StatefulWidget {
     required this.mapController,
     required this.markers,
     required this.tileUrl,
+    required this.meridianTileProvider,
     required this.onNavigateToSettings,
     this.connectionStatus = ConnectionStatus.disconnected,
     this.tncConnectionStatus = ConnectionStatus.disconnected,
@@ -50,6 +53,7 @@ class TabletScaffold extends StatefulWidget {
   final MapController mapController;
   final List<Marker> markers;
   final String tileUrl;
+  final MeridianTileProvider meridianTileProvider;
   final VoidCallback onNavigateToSettings;
   final ConnectionStatus connectionStatus;
   final ConnectionStatus tncConnectionStatus;
@@ -172,10 +176,10 @@ class _TabletScaffoldState extends State<TabletScaffold> {
           ),
           IconButton(
             icon: _locating
-                ? const SizedBox(
+                ? SizedBox(
                     width: 20,
                     height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                   )
                 : const Icon(Symbols.my_location),
             tooltip: 'Center on my location',
@@ -256,6 +260,7 @@ class _TabletScaffoldState extends State<TabletScaffold> {
                         mapController: widget.mapController,
                         markers: widget.markers,
                         tileUrl: widget.tileUrl,
+                        tileProvider: widget.meridianTileProvider.buildTileProvider(),
                         connectionStatus: widget.connectionStatus,
                         initialCenter: widget.initialCenter,
                         initialZoom: widget.initialZoom,

--- a/lib/ui/layout/tablet_scaffold.dart
+++ b/lib/ui/layout/tablet_scaffold.dart
@@ -260,7 +260,8 @@ class _TabletScaffoldState extends State<TabletScaffold> {
                         mapController: widget.mapController,
                         markers: widget.markers,
                         tileUrl: widget.tileUrl,
-                        tileProvider: widget.meridianTileProvider.buildTileProvider(),
+                        tileProvider: widget.meridianTileProvider
+                            .buildTileProvider(),
                         connectionStatus: widget.connectionStatus,
                         initialCenter: widget.initialCenter,
                         initialZoom: widget.initialZoom,

--- a/lib/ui/utils/platform_route.dart
+++ b/lib/ui/utils/platform_route.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Returns a [CupertinoPageRoute] on iOS and a [MaterialPageRoute] on all
+/// other platforms. Use this everywhere a push navigation is needed so that
+/// the swipe-back gesture and slide transition feel native on iOS.
+Route<T> buildPlatformRoute<T>(WidgetBuilder builder) {
+  if (!kIsWeb && Platform.isIOS) {
+    return CupertinoPageRoute<T>(builder: builder);
+  }
+  return MaterialPageRoute<T>(builder: builder);
+}

--- a/lib/ui/widgets/ble_scanner_sheet.dart
+++ b/lib/ui/widgets/ble_scanner_sheet.dart
@@ -312,10 +312,10 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
                 ),
                 const SizedBox(width: 12),
                 if (_scanning) ...[
-                  const SizedBox(
+                  SizedBox(
                     width: 16,
                     height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                   ),
                   const SizedBox(width: 8),
                 ],
@@ -370,10 +370,12 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
                     style: theme.textTheme.bodySmall,
                   ),
                   trailing: isConnecting
-                      ? const SizedBox(
+                      ? SizedBox(
                           width: 24,
                           height: 24,
-                          child: CircularProgressIndicator(strokeWidth: 2),
+                          child: CircularProgressIndicator.adaptive(
+                            strokeWidth: 2,
+                          ),
                         )
                       : FilledButton.tonal(
                           onPressed: _connectingDeviceId != null

--- a/lib/ui/widgets/compose_message_sheet.dart
+++ b/lib/ui/widgets/compose_message_sheet.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import '../../screens/message_thread_screen.dart';
 import '../../services/message_service.dart';
 import 'callsign_field.dart';
+import '../utils/platform_route.dart';
 
 class ComposeMessageSheet extends StatefulWidget {
   const ComposeMessageSheet({super.key, this.initialCallsign});
@@ -54,10 +55,7 @@ class _ComposeMessageSheetState extends State<ComposeMessageSheet> {
     Navigator.of(context).pop();
     Navigator.push(
       context,
-      MaterialPageRoute(
-        // TODO(ios): CupertinoPageRoute
-        builder: (_) => MessageThreadScreen(peerCallsign: callsign),
-      ),
+      buildPlatformRoute((_) => MessageThreadScreen(peerCallsign: callsign)),
     );
   }
 

--- a/lib/ui/widgets/station_info_sheet.dart
+++ b/lib/ui/widgets/station_info_sheet.dart
@@ -4,6 +4,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import '../../core/packet/station.dart';
 import '../../core/packet/symbol_resolver.dart';
 import '../../screens/message_thread_screen.dart';
+import '../utils/platform_route.dart';
 import 'aprs_symbol_widget.dart';
 
 String _formatLastHeard(DateTime lastHeard) {
@@ -155,9 +156,8 @@ class StationInfoSheet extends StatelessWidget {
                   final nav = Navigator.of(context);
                   nav.pop();
                   nav.push(
-                    MaterialPageRoute<void>(
-                      // TODO(ios): CupertinoPageRoute
-                      builder: (_) =>
+                    buildPlatformRoute<void>(
+                      (_) =>
                           MessageThreadScreen(peerCallsign: station.callsign),
                     ),
                   );

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -145,6 +145,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_cache_interceptor:
+    dependency: "direct main"
+    description:
+      name: dio_cache_interceptor
+      sha256: "3644ce3e0c9ba21885cbb0578b3d2ffe022c8badc6f6f4042cb56ecdbe90a7ad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.6"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   dylib:
     dependency: transitive
     description:
@@ -291,6 +315,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.2"
+  flutter_map_cache:
+    dependency: "direct main"
+    description:
+      name: flutter_map_cache
+      sha256: fc9697760dc95b6adf75110a23a800ace5d95a735a58ec43f05183bc675c7246
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -381,6 +413,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_cache_core:
+    dependency: "direct main"
+    description:
+      name: http_cache_core
+      sha256: ff0b6e6c3766d774d59b806f928b39e6a48f7b2c47ae1fe27410bfd792bee511
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
+  http_cache_file_store:
+    dependency: "direct main"
+    description:
+      name: http_cache_file_store
+      sha256: b7d2d67ad262a4b5c6ccde4378228100ab0e58371d40cb2f0443177922638c01
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -606,7 +654,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -906,6 +954,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,11 @@ dependencies:
   http: ^1.2.0
   flutter_foreground_task: ^8.17.0
   permission_handler: ^11.4.0
+  flutter_map_cache: ^2.0.0+1
+  dio_cache_interceptor: ^4.0.6
+  http_cache_file_store: ^2.0.1
+  http_cache_core: ^1.1.3
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- **Stadia Maps tile provider** — replaces CartoDB/OSM URLs with `alidade_smooth`/`alidade_smooth_dark`; `MeridianTileProvider` abstraction added; `FileCacheStore`-backed 30-day tile cache to reduce API credit usage; OSM attribution widget added; `AppConfig` + `--dart-define` for API key injection; CI wired
- **iOS Cupertino audit** — `buildPlatformRoute<T>()` helper resolves all `TODO(ios)` navigation sites; `SwitchListTile.adaptive` + `CircularProgressIndicator.adaptive` throughout; `ScaffoldMessenger` added to `CupertinoApp` builder; App Color picker exposed on all platforms; iOS theme now responds to `seedColor`; send button icon color fixed
- **iOS launch crash** — `BGTaskSchedulerPermittedIdentifiers`, `UIBackgroundModes`, `NSLocalNetworkUsageDescription` added to `Info.plist`; `platform :ios, '13.0'` uncommented in Podfile
- **Onboarding credentials bug** — `AprsIsTransport.updateCredentials()` + `StationService.updateAprsIsCredentials()` update the Provider tree in place on onboarding complete; no more reconfiguring in Settings after first launch
- **Android 15 FGS crash** — gate foreground service start on `locationWhenInUse` being granted (targetSDK=36 enforces runtime location permission for `foregroundServiceType=location`)
- **Settings RangeError** — `itemCount` was hardcoded to 11 for a 10-item list; now dynamic
- **Packet log clear** — `PacketLogScreen` now syncs local buffer via `ChangeNotifier` when service packet count drops
- **Android build** — removed hardcoded Linux JDK path from `android/gradle.properties`

ADRs 027–028 added. Physical device validated on iPhone 16 Pro and Pixel 10 Pro.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 289/289 passing
- [x] iOS (iPhone 16 Pro): onboarding flow, map tiles light/dark, beaconing, messaging, settings color picker, clear buttons with SnackBar feedback
- [x] Android (Pixel 10 Pro): APRS-IS connect, beaconing, foreground service notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)