### PR TITLE
docs: refresh roadmap and future features for post-v0.8 scope

### DIFF
--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -1,43 +1,80 @@
-# Future Features
+# Meridian APRS — Future Features
 
-Ideas and enhancements beyond the current milestone scope. Not committed to any release.
-
----
-
-## Messaging
-
-- **Group / bulletin messages** — APRS bulletin (`BLN`) and announcement (`BLN0`–`BLN9`) support; display in a separate Bulletins tab
-- **Message search / archive** — local SQLite persistence of message history; search by callsign or keyword
-- **Threaded replies** — link messages to a conversation with reply quoting, like a basic chat
+Features tracked here are planned but not yet committed to a milestone. They graduate to `docs/ROADMAP.md` when formally scheduled.
 
 ---
 
-## Beaconing
+## High Priority (v1.1 candidates)
 
-- **SmartBeaconing map overlay** — show the beacon path on the map with breadcrumb dots, fading with age
-- **Compressed position encoding** — APRS compressed format for shorter packets on RF
-- **Object / item TX** — create and transmit APRS objects and items (weather stations, repeaters, nets)
+### Offline Map Tile Caching
+Cache OSM/Stadia tiles locally for use without internet connectivity. The TileProvider abstraction introduced in v0.8 is designed to support this. Relevant for field use where connectivity is limited.
 
----
+### QRZ / HamDB Callsign Lookup
+Tap a station callsign to pull operator info (name, location, license class) from QRZ.com or HamDB. Requires QRZ XML subscription for full data; HamDB is free but limited.
 
-## Connection & Transport
+### Geo-fence Alerts
+Notify the operator when a tracked station enters or exits a defined geographic area.
 
-- **TCP KISS TNC** — TCP KISS transport (e.g., Direwolf running on a network host)
-- **Soundcard TNC** — integrate a pure-Dart or platform-native AFSK modem for RF TX/RX without dedicated hardware
-- **Multi-server support** — failover between APRS-IS tier-2 servers
-
----
-
-## Map & Stations
-
-- **Weather overlays** — display weather station data (WX) on map with colour-coded temperature / wind
-- **Offline tiles** — cache map tiles for offline use (MBTiles or similar)
+### Weather Overlay
+Display APRS weather station data as a map overlay. Includes WX symbol stations and optionally NWS data.
 
 ---
 
-## Platform & Polish
+## Medium Priority
 
-- **iPad multi-window** — support split-screen and Slide Over on iPad
-- **macOS menu bar** — native menu bar integration for connection management
-- **Keyboard shortcuts** — compose, send, beacon actions via keyboard on desktop
-- **Localisation** — i18n framework; initial target: EN, DE, JA
+### APRS Message Threading
+Group messages by callsign into conversation threads with full history. (Basic one-to-one messaging ships in v0.5; threading is a polish layer on top.)
+
+### Message Read Receipts / ACK Display
+Surface ACK packets as delivery confirmation in the message UI. Status indicators: sent, acked, failed.
+
+### Group / Bulletin Messages
+Send and receive APRS bulletin and group messages (`BLN`, `NWS`, etc.). Explicitly deferred from v0.5 scope.
+
+### Heard-By / Path Analysis
+Visual breakdown of which digipeaters and iGates heard a given packet. Useful for path optimization.
+
+### RF Path Optimizer
+Suggest optimal WIDE path settings based on local digipeater coverage and observed packet paths.
+
+### Object / Item Creation
+Allow operators to place APRS objects and items on the map and transmit them. (Object/item *display* is in v0.12; creation is a separate transmit-path feature.)
+
+---
+
+## Lower Priority / Exploratory
+
+### Satellite Pass Prediction
+Integrate orbital data (TLE) to predict APRS-capable satellite passes (ISS, ARISS events).
+
+### APRS-IS Tier 2 Server Selection
+Let operators manually select or pin a specific APRS-IS Tier 2 server rather than using `rotate.aprs2.net`.
+
+### Directed Query Support
+Send and respond to APRS directed queries (`?APRS?`, `?WX?`, etc.).
+
+### Voice Alert Integration
+Play an audio alert on incoming messages or tracked station events. Platform TTS or custom audio.
+
+### Dark Sky / NWS Severe Weather Alerts
+Surface NWS severe weather alerts relevant to the operator's location on the map.
+
+### Cross-Platform Sync
+Sync settings, filter presets, and station notes across devices via iCloud / Google Drive.
+
+### Web Platform
+Full web client via Flutter Web + WebSocket APRS-IS proxy. Web Serial and Web Bluetooth are Chromium-only — acceptable and documented.
+
+---
+
+## Deferred Integrations
+
+### HamAlert / DX Cluster
+Integration with HamAlert or DX Cluster for operator activity notifications beyond APRS.
+
+### Winlink Gateway Display
+Show nearby Winlink RMS gateways on the map as a convenience layer for hybrid operators.
+
+---
+
+*Last updated: 2026-04-05*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,228 +1,143 @@
-# Roadmap
+# Meridian APRS — Roadmap
 
-## Summary
-
-| Milestone | Goal |
-|---|---|
-| ~~v0.1 — Foundation~~ | ~~Flutter scaffold, map, APRS-IS, station display with symbols~~ ✓ |
-| ~~v0.2 — Packets~~ | ~~AX.25/APRS parser, packet log, message decoding~~ ✓ |
-| ~~UI Foundation~~ | ~~Theme system, adaptive scaffold, core widgets, onboarding~~ ✓ |
-| ~~v0.3 — TNC~~ | ~~KISS over USB serial, desktop first~~ ✓ |
-| ~~v0.4 — BLE~~ | ~~KISS over BLE, mobile platforms~~ ✓ |
-| ~~v0.5 — Beaconing~~ | ~~Transmit path, position beaconing, message sending~~ ✓ |
-| ~~v0.6~~ | ~~Connection UI + Map Polish~~ ✓ |
-| ~~v0.7~~ | ~~Android Background Beaconing (foreground service + persistent notification)~~ ✓ |
-| **v0.8** | Cross-platform parity pass (iOS Cupertino audit, OSM tile swap) |
-| **v0.9** | iOS Background Beaconing (background location + Live Activity) |
-| **v0.10** | Map filters + station profiles + track history + cluster markers + object/item display + altitude in position packets |
-| **v0.11** | Background notifications + in-app banner system |
-| **v0.12** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
-| **v0.13** | Battery & performance optimization pass |
-| **v1.0** | Final polish + store submission |
+Each milestone represents a shippable increment with a focused scope. Features deferred beyond v1.0 are tracked in `docs/FUTURE_FEATURES.md`.
 
 ---
 
-## v0.1 — Foundation
+## Status
 
-Goal: A working app that connects to APRS-IS, receives packets, and plots stations on a map.
-
-- [x] Flutter project created and pushed to GitHub
-- [x] GitHub repo configured (labels, milestones, templates, CI)
-- [x] CI pipeline running (flutter format, analyze, test)
-- [x] `flutter_map` integrated with OSM tile layer
-- [x] APRS-IS TCP connection established (`rotate.aprs2.net:14580`)
-- [x] Basic station position parsing (plain/compressed lat/lon)
-- [x] Station markers rendered on map
-- [x] Station info panel (callsign, symbol, last heard)
-- [x] APRS symbol extraction (symbolTable, symbolCode, comment) from position packets
-- [x] SymbolResolver — maps table+code to human-readable name
-- [x] Symbol-appropriate marker icons on map
-- [x] Tap-to-show station info bottom sheet
-
----
-
-## v0.2 — Packets
-
-Goal: Comprehensive APRS packet parsing and a packet log view.
-
-- [x] Full APRS parser with `AprsPacket` sealed class hierarchy (PositionPacket, WeatherPacket, MessagePacket, ObjectPacket, ItemPacket, StatusPacket, MicEPacket, UnknownPacket)
-- [x] All DTI types supported: `!`, `=`, `/`, `@`, `;`, `)`, `:`, `_`, `>`, `` ` ``, `'`
-- [x] Packet log screen (real-time scrolling, type filter chips, tap-to-detail)
-- [x] PacketDetailSheet — full decoded field view with selectable raw packet line
-- [x] AprsSymbolWidget — abstract symbol rendering widget, replaces inline symbolIcon helpers
-- [x] StationService updated: `packetStream` + `recentPackets` (500-packet rolling buffer)
-- [x] Unit test coverage: 92 tests passing (69 parser tests + existing suite)
-- [ ] ~~Message thread view~~ — deferred to v0.3+
+| Milestone | Focus | Status |
+|---|---|---|
+| v0.1 — Foundation | Flutter scaffold, map rendering, APRS-IS connection, basic station display | ✅ Complete |
+| v0.2 — Packets | AX.25/APRS parser, packet log view, symbol rendering | ✅ Complete |
+| v0.3 — TNC | KISS over USB serial, desktop platforms first | ✅ Complete |
+| v0.4 — BLE | KISS over BLE, mobile platforms; KissTncTransport interface; TransportManager | ✅ Complete |
+| v0.5 — Beaconing & Messaging | Manual/Auto/SmartBeaconing, one-to-one APRS messaging with retry, RF/APRS-IS TX toggle, My Station settings | ✅ Complete |
+| v0.6 — Connection UI | Connection screen overhaul, segmented APRS-IS/BLE TNC/Serial TNC tabs, map polish | ✅ Complete |
+| v0.7 — Android Background | MeridianConnectionService foreground service, persistent notification, bg packet capture + beaconing, auto-reconnect | ✅ Complete |
+| v0.8 — Platform Parity | iOS Cupertino audit, Stadia Maps tile swap (TileProvider abstraction) | ✅ Complete |
+| v0.9 — iOS Background | iOS background beaconing — background location + Live Activity | 🔜 Next |
+| v0.10 — APRS Symbol Icon Set | New repo: `meridian-aprs-symbols` (CC BY 4.0). Style guide, SVG generation, Figma polish, sprite sheets. Integration into Meridian. | — |
+| v0.11 — Map Filters & Stations | Map filters, station profiles | — |
+| v0.12 — Map Enhancement | Track history, cluster markers, object/item display, altitude in position packets | — |
+| v0.13 — Onboarding | BLE pairing flow in onboarding, APRS-IS connection before map, GPS centering on first launch, symbol picker + comment + location setup | — |
+| v0.14 — Notifications | Background notifications, in-app banner system, notification preferences | — |
+| v0.15 — Security | Passcode secure storage, APRS-IS filter configuration | — |
+| v0.16 — Performance | Battery & performance optimization pass (motivated by background service drain) | — |
+| v0.17 — Bug Triage | Dedicated triage and bugfix pass before final polish | — |
+| v1.0 — Launch | Final polish, all-platform store submission (iOS App Store, Google Play, macOS, Windows, Linux) | — |
 
 ---
 
-## UI Foundation
+## Milestone Detail
 
-Goal: A complete design system, adaptive layouts, core widget library, settings screen, and first-launch onboarding flow — across all three platform form factors.
+### v0.9 — iOS Background Beaconing
+Bring iOS to parity with Android's background beaconing capability.
 
-- [x] Theme system (token colors, light/dark/auto, ThemeProvider, SharedPreferences persistence)
-- [x] Adaptive scaffold (MobileScaffold, TabletScaffold, DesktopScaffold, ResponsiveLayout)
-- [x] MeridianMap widget — encapsulates flutter_map configuration, theme-aware tile URL
-- [x] Core widget library (MeridianStatusPill, MeridianBottomSheet, StationListTile, BeaconFAB, CallsignField)
-- [x] Settings screen shell (Appearance section functional — theme switching works; all other sections stubbed)
-- [x] Onboarding flow (3-screen PageView, first-launch gated via SharedPreferences)
-- [x] MapScreen updated to use ResponsiveLayout; service lifecycle remains in MapScreen
-- [x] Three-tier platform theme architecture — Android (M3 Expressive + Dynamic Color), iOS (Cupertino), Desktop (M3 static brand) — all tiers complete
+- Background location permission handling
+- Background packet capture while app is backgrounded
+- Position beaconing while backgrounded
+- Live Activity for persistent status on the Dynamic Island / Lock Screen
+- Auto-reconnect for APRS-IS and BLE TNC transports in background
 
 ---
 
-## v0.3 — TNC
+### v0.10 — APRS Symbol Icon Set
+A standalone, community-usable APRS symbol set released as a separate open-source project.
 
-Goal: Connect to a hardware TNC via KISS over USB serial on desktop.
+**Repo:** `meridian-aprs-symbols`
+**License:** CC BY 4.0 — free to use, attribution required ("APRS Symbols by Meridian APRS")
 
-- [x] KISS framing encode/decode (`KissFramer` — pure Dart)
-- [x] AX.25 frame decoding (`Ax25Parser` — pure Dart)
-- [x] USB serial transport via `flutter_libserialport` (`SerialKissTransport`)
-- [x] TNC preset system (`TncPreset` / `TncConfig`) — provides the foundation for v0.4 BLE presets
-- [x] Port selection UI (list available serial ports; `ConnectionSheet`)
-- [x] Connection status indicator (TNC + APRS-IS dual pills)
-- [x] Packets received via TNC appear on map/log
-- [x] Linux, macOS, Windows targeted
-
----
-
-## v0.4 — BLE
-
-Goal: Connect to a BLE-capable TNC (e.g. Mobilinkd) on mobile. Extends the `TncPreset` system established in v0.3.
-
-- [x] `KissTncTransport` abstract interface — raw AX.25 byte contract shared by serial and BLE
-- [x] `TransportManager` — lifecycle holder for the active transport; bridges `frameStream` and `connectionState`
-- [x] `SerialKissTransport` refactored to implement `KissTncTransport` (APRS parsing moved to service layer)
-- [x] `BleTncTransport` — BLE KISS TNC via `flutter_blue_plus`; MTU negotiation; KISS chunking; `KissFramer` reassembly
-- [x] `TncService` updated — owns `TransportManager`; parses AX.25 frames via `AprsParser.parseFrame`; exposes `connectBle()`
-- [x] BLE device scan and pairing UI (`BleScannerSheet`)
-- [x] `ConnectionSheet` updated — BLE section for iOS/Android, serial section for desktop
-- [x] `MobileScaffold` — TNC status pill enabled on non-web mobile; dynamic `TransportType` label
-- [x] Settings screen — BLE TNC section for iOS/Android
-- [x] Onboarding — BLE TNC option card enabled on iOS/Android
-- [x] Android BLE permissions (`BLUETOOTH_SCAN`, `BLUETOOTH_CONNECT`, `ACCESS_FINE_LOCATION`)
-- [x] iOS Bluetooth usage descriptions (`NSBluetoothAlwaysUsageDescription`)
-- [x] Tests: `BleTncTransport`, `TransportManager`, `TncService` (141 tests total)
-- [ ] Physical device validation — iOS + Android with Mobilinkd TNC4 (pending hardware test)
+- Define visual style guide (stroke weight, corner radius, color palette, grid)
+- Generate SVGs for all primary and overlay APRS symbols
+- Figma polish pass
+- Export sprite sheets indexed to standard APRS two-character symbol codes
+- Integrate into Meridian, replacing placeholder symbol rendering
 
 ---
 
-## v0.5 — Beaconing
+### v0.11 — Map Filters & Station Profiles
+Core usability features that make the map manageable at scale.
 
-Goal: Transmit position beacons and send/receive APRS messages.
-
-- [x] `AprsEncoder` — pure Dart APRS-IS text encoder (position, message, ACK, REJ)
-- [x] `Ax25Encoder` — pure Dart AX.25 UI frame encoder (round-trips with `Ax25Parser`)
-- [x] `SmartBeaconing` — pure Dart SmartBeaconing™ algorithm (interval + turn trigger)
-- [x] `StationSettingsService` — My Station prefs (callsign, SSID, symbol, comment) with ChangeNotifier
-- [x] `TxService` — global TX transport router (auto/APRS-IS/TNC preference, TNC disconnect events)
-- [x] `BeaconingService` — Manual / Auto / SmartBeaconing™ modes, GPS via geolocator
-- [x] `MessageService` — threaded conversations, APRS §14 retry scheduler, ACK/REJ handling, duplicate detection
-- [x] Settings — My Station section (callsign, SSID, symbol, comment), Beaconing section (mode, interval, SmartBeaconing params, TX transport toggle)
-- [x] BeaconFAB — last-beacon timestamp, mode label, long-press cooldown guard
-- [x] Messages screens — thread list (`MessagesScreen`), chat thread (`MessageThreadScreen`), compose sheet
-- [x] Scaffold nav — Messages destination wired on all three scaffolds; unread badge
-- [x] TNC disconnect/reconnect banners in `MapScreen`
-- [x] GPS platform permissions (Android, iOS, macOS)
-- [x] Tests: 252 passing (encoder, AX.25 encoder, SmartBeaconing, MessageService, widget test)
-- [ ] APRS-IS login with callsign + passcode (passcode field is in onboarding; TX auth deferred to v1.0)
-- [ ] Passcode stored in platform secure storage — deferred to v1.0
-- [ ] Physical device validation — TX beacon on APRS-IS + TNC (pending)
+- Filter by station type, symbol, distance, path, and more
+- Named filter presets (save and recall)
+- Station profile view — packet history, path info, heard-by digipeaters, message log
+- Map tap → station profile flow
 
 ---
 
-## v0.6 — Connection UI & Map Polish
+### v0.12 — Map Enhancement
+Deeper map capabilities for tracking and situational awareness.
 
-Goal: Promote Connection to a first-class navigation destination; targeted map improvements.
-
-**Status: Complete**
-
-### feat/v0.6-connection-screen
-- [x] `ConnectionNavIcon` widget — reactive nav icon (Selector2, signal/warning/muted)
-- [x] `ConnectionScreen` — full-screen destination replacing `ConnectionSheet` modal
-  - Active Connections section (APRS-IS + TNC cards, TX badge, Disconnect)
-  - Platform-adaptive segmented control (CupertinoSlidingSegmentedControl/SegmentedButton)
-  - APRS-IS tab (read-only server info, connect/disconnect)
-  - BLE TNC tab (BleScannerSheet inline, lazy instantiation; connected state: "Connected — disconnect from the card above")
-  - Serial TNC tab (port/baud/connect — desktop only)
-- [x] Mobile: 5th nav destination (Connection); status pill taps navigate to tab
-- [x] Tablet: Connection converted from transient sheet to real IndexedStack destination
-- [x] Desktop: Connection converted from transient sheet to real destination; `_ConnectionStatusChip` in AppBar replaces dual status pills
-- [x] `TncService.availablePorts()` wrapped in try-catch (safe in test environments without libserialport)
-- [x] Widget test updated (StationService added to provider tree)
-- [ ] Physical device validation
-
-### feat/v0.6-map-polish
-- [x] "Not connected" nudge chip overlay on map (AnimatedOpacity, tap → ConnectionScreen)
-- [x] Station marker tap targets: 36 → 44 px
-- [x] Connection screen UX: duplicate Disconnect buttons removed; BLE back-arrow fix (`showBackButton` param)
-- [x] Callsign search — `StationSearchDelegate` (`SearchDelegate<Station?>`); Nominatim geocoding; `showSearch` integration; map pan on result
-- [x] Center-on-location FAB — GPS on mobile/tablet via geolocator; desktop falls back to `LocationPickerScreen` address picker
-- [x] `BeaconFAB` loading spinner while sending (`Future<void> onTap`, `_isSending` state)
-- [x] Location button loading spinner on all three scaffold tiers
-- [x] TX transport selector reflects effective transport (falls back when TNC disconnected, not stored preference)
-- [x] TNC section removed from Settings screen (Connection screen is canonical)
-- [x] `connection_sheet.dart` deleted (orphaned dead code)
+- Track history — display position history trails for stations
+- Cluster markers at low zoom levels
+- Object and item packet display
+- Altitude field in outgoing position packets
 
 ---
 
-## v0.7 — Android Background Beaconing
+### v0.13 — Onboarding Improvements
+Make the first-launch experience complete and self-sufficient.
 
-Goal: Keep transport connections and beaconing alive when Meridian is backgrounded on Android.
-
-- [x] `flutter_foreground_task` + `permission_handler` added to pubspec.yaml
-- [x] `android/app/build.gradle.kts` — minSdk bumped to 21
-- [x] `AndroidManifest.xml` — `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`, `ACCESS_BACKGROUND_LOCATION`, `POST_NOTIFICATIONS`, `RECEIVE_BOOT_COMPLETED` permissions; foreground service element
-- [x] `MeridianConnectionTask` (`lib/services/meridian_connection_task.dart`) — minimal `TaskHandler` (background isolate heartbeat, no app logic)
-- [x] `BackgroundServiceManager` (`lib/services/background_service_manager.dart`) — ChangeNotifier; lifecycle + notification content + `BackgroundServiceState` enum; injectable `ForegroundServiceApi` for testing
-- [x] `lib/main.dart` — `FlutterForegroundTask.initCommunicationPort()` + `BackgroundServiceManager.initOptions()` before `runApp`; `BackgroundServiceManager` in provider tree
-- [x] `ConnectionScreen` — Android-only background service card (toggle + status pill + error message); reconnecting banner at top
-- [x] `ConnectionNavIcon` — badge dot overlay when service is running/reconnecting
-- [x] `test/services/background_service_manager_test.dart` — 15 unit tests (state machine, notification content, non-Android guard)
-- [x] `widget_test.dart` — `BackgroundServiceManager` added to provider tree
-- [x] ADR-025 (unified service via flutter_foreground_task) + ADR-026 (ACCESS_BACKGROUND_LOCATION flow)
-- [ ] Physical Android device validation (see test checklist in prompt)
+- BLE TNC selection in onboarding triggers BLE pairing flow
+- APRS-IS selection initiates connection before landing on map
+- Map centers on current GPS location (or manual coordinates) on first launch
+- Onboarding: add symbol picker, comment field, and location setup steps
 
 ---
 
-## v0.8 — Cross-Platform Parity
+### v0.14 — Notifications
+Keep operators informed when Meridian is in the background.
 
-Goal: Replace public OSM tile URLs with Stadia Maps and complete the first real iOS Cupertino audit on physical hardware.
-
-### Workstream A — Stadia Maps Tile Swap
-- [x] `lib/map/meridian_tile_provider.dart` — abstract `MeridianTileProvider` interface
-- [x] `lib/map/stadia_tile_provider.dart` — concrete `StadiaTileProvider` (`alidade_smooth` / `alidade_smooth_dark`)
-- [x] `lib/config/app_config.dart` — `AppConfig.stadiaMapsApiKey` via `String.fromEnvironment`
-- [x] `lib/screens/map_screen.dart` — wired to `StadiaTileProvider`; brightness resolved in `build()`
-- [x] `lib/ui/layout/meridian_map.dart` — CartoDB subdomain + brightness-boost artifacts removed; `RichAttributionWidget` added for OSM/Stadia attribution
-- [x] `.env.example` — developer key template (`.env` gitignored)
-- [x] `CLAUDE.md` — Local Development section added
-- [x] `.github/workflows/ci.yml` — `--dart-define=STADIA_MAPS_API_KEY` added to test + build steps
-- [x] ADR-027 (tile provider decision)
-- [ ] Physical device validation: light/dark tiles on Android, iOS, desktop
-
-### Workstream B — iOS Cupertino Audit
-- [x] `lib/ui/utils/platform_route.dart` — `buildPlatformRoute<T>()` helper (CupertinoPageRoute on iOS, MaterialPageRoute elsewhere)
-- [x] All `TODO(ios): CupertinoPageRoute` sites resolved: `messages_screen.dart`, `settings_screen.dart` (×2), `compose_message_sheet.dart`, `station_info_sheet.dart`
-- [x] `SwitchListTile` → `SwitchListTile.adaptive` (connection screen ×2, settings notifications stub)
-- [x] `CircularProgressIndicator` → `CircularProgressIndicator.adaptive` across all scaffold/widget spinners (BLE scanner, mobile/tablet/desktop scaffold, connection screen, location picker, map connecting banner)
-- [x] ADR-028 (iOS platform routing pattern)
-- [ ] Discovery pass on iPhone 16 Pro — document punch list
-- [ ] Settings → Appearance validation on iOS
-- [ ] Safe area + Dynamic Island verification on iPhone 16 Pro
-- [ ] Full re-test on iPhone 16 Pro
+- Background notifications for incoming APRS messages
+- In-app banner system for alerts
+- Notification preferences screen
 
 ---
 
-## v1.0 — Polish
+### v0.15 — Security
+Harden credential handling and network filtering.
 
-Goal: Release-quality app with full onboarding and documentation.
+- Passcode stored in platform secure storage (Keychain / Keystore)
+- APRS-IS server-side filter configuration UI
 
-- [ ] Settings screen (callsign, passcode, filter, map preferences)
-- [ ] Onboarding flow (first-launch setup)
-- [ ] App icon and splash screen (all platforms)
-- [ ] APRS-IS server filter configuration
-- [ ] Dark mode support
-- [ ] User-facing documentation / help
-- [ ] App Store / Play Store listings
-- [ ] 1.0 release tag
+---
+
+### v0.16 — Battery & Performance
+Optimize for real-world sustained use.
+
+- Profile and reduce background service battery drain
+- Packet processing efficiency review
+- Memory usage audit for large station counts
+
+---
+
+### v0.17 — Bug Triage
+Dedicated milestone for clearing the bug backlog before final polish.
+
+- Triage all open `bug` issues
+- Fix confirmed bugs prioritized by severity
+- Regression test pass across platforms
+
+---
+
+### v1.0 — Launch
+The release milestone. No new features — quality, stability, and store readiness only.
+
+- Final UI polish pass across all platforms
+- README and public documentation
+- App Store (iOS) and Google Play submission
+- macOS, Windows, Linux packaging
+- Final CI/CD and release pipeline review
+
+---
+
+## Pending Items
+
+- **Tocall:** `APMDNx` allocation filed via `aprsorg/aprs-deviceid`. Placeholder `APZMDN` with `TODO(tocall)` in use until confirmed.
+- **macOS/Windows serial TNC testing:** Deferred from v0.4. Still pending physical hardware validation.
+- **Stadia Maps tier:** Free tier in use (non-commercial OSS). Upgrade to paid tier when monetization begins.
+
+---
+
+*Last updated: 2026-04-05*


### PR DESCRIPTION
## Summary

- Rewrites `ROADMAP.md` with a cleaner status table, v0.8 marked complete, and expanded per-milestone detail for v0.9–v1.0
- Restructures `FUTURE_FEATURES.md` with priority tiers (High / Medium / Lower / Deferred) and updates items to reflect current project scope
- Adds `Pending Items` section to roadmap for cross-cutting tracked items (tocall, serial TNC validation, Stadia Maps tier)

## Test plan

- [ ] Review roadmap milestone ordering and task descriptions for accuracy
- [ ] Confirm v0.8 is correctly marked complete and v0.9 is marked as next
- [ ] Confirm no code changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)