### PR TITLE
feat: v0.11 — Background notifications + in-app banner system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev ninja-build
+          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev ninja-build libnotify-dev
 
       - name: Install dependencies
         run: flutter pub get

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,13 +56,15 @@ See `docs/ARCHITECTURE.md` for full detail.
 | ~~v0.7~~ | ~~Android Background Beaconing (foreground service + persistent notification)~~ ✓ |
 | ~~v0.8~~ | ~~Cross-platform parity pass (iOS Cupertino audit, Stadia Maps tile swap)~~ ✓ |
 | ~~v0.9~~ | ~~iOS Background Beaconing (background location + Live Activity)~~ ✓ |
-| **v0.10** | Map filters + station profiles + track history + cluster markers + object/item display + altitude in position packets |
+| ~~v0.10~~ | ~~Map experience — viewport-adaptive APRS-IS filter, time filter, track history, cluster markers, station type filters, object/item display~~ ✓ |
 | **v0.11** | Background notifications + in-app banner system |
-| **v0.12** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
-| **v0.13** | Battery & performance optimization pass |
+| **v0.12** | Onboarding improvements |
+| **v0.13** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
+| **v0.14** | Battery & performance optimization pass |
+| **v0.15** | Bug triage pass |
 | **v1.0** | Final polish + store submission |
 
-**Current status: v0.10 complete. Map experience milestone: viewport-adaptive APRS-IS area filter (`a/N/W/S/E` — use `a/`, never `b/` which is the callsign/budget filter; 25% padding, 50 km minimum floor, 500ms debounce); configurable station time filter (default 60 min, stored as `station_max_age_minutes`, immediate prune on change + 60s periodic timer started in `loadPersistedHistory`); per-station position history (`TimestampedPosition` list, capped at 500 entries, oldest-first); track polylines rendered via `PolylineLayer` in `MeridianMap`; `MapFilterPanel` widget accessible from filter FAB (mobile) or toolbar button (tablet/desktop); active filter chip on map surface when non-default window; Map section in Settings screen. ADRs 001–034 in `docs/DECISIONS.md`. Next: v0.11 — Background notifications + in-app banner system.**
+**Current status: v0.11 in progress (notifications milestone). v0.10 complete — map experience milestone (viewport-adaptive APRS-IS area filter, time filter, track history, cluster markers, station type filters). v0.11 adds: `NotificationService` (main-isolate dispatch, `flutter_local_notifications` on mobile/macOS, `local_notifier` on Windows/Linux); four notification channels (`messages`, `alerts`, `nearby`, `system`); Android `BigTextStyle`/`InboxStyle` + `RemoteInput` inline reply; iOS `UNTextInputAction` inline reply + foreground delivery; `InAppBannerOverlay` at app root; `NotificationPreferences` model + settings UI; cold-start navigation via global `navigatorKey`. ADRs 001–038 in `docs/DECISIONS.md`.**
 
 **Conventions added in v0.5:**
 - `TODO(tocall)` — marks `APZMDN` destination; register with WB4APR before v1.0 release
@@ -186,6 +188,7 @@ All three tiers fully implemented. iOS pending simulator validation.
 | `station_info_sheet.dart` | `StationInfoSheet` | Station summary bottom sheet (callsign, symbol, comment, last heard) |
 | `station_list_tile.dart` | `StationListTile` | ListTile for station list; symbol + callsign + relative timestamp |
 | `station_search_delegate.dart` | `StationSearchDelegate` | `SearchDelegate<Station?>` for callsign search; Nominatim-powered map pan |
+| `in_app_banner_overlay.dart` | `InAppBannerOverlay`, `InAppBannerController` | Slide-in notification banner at app root; `InAppBannerController` triggers from `NotificationService`; full-width mobile, 320 px top-right desktop |
 
 ### Screens (`lib/screens/`)
 
@@ -219,6 +222,14 @@ All three tiers fully implemented. iOS pending simulator validation.
 | `lib/core/transport/ble_constants.dart` | `kMobilinkdServiceUuid` etc. | Mobilinkd UART-over-BLE GATT service/characteristic UUIDs |
 | `lib/services/tnc_service.dart` | `TncService` | ChangeNotifier; owns `TransportManager`; parses AX.25 frames via `AprsParser`; bridges to `StationService.ingestLine` |
 | `lib/ui/widgets/ble_scanner_sheet.dart` | `BleScannerSheet` | BLE scan + connect UI; filters to Mobilinkd devices; device list with RSSI icons |
+
+### Notification files (v0.11)
+
+| File | Class / Symbol | Description |
+|---|---|---|
+| `lib/services/notification_service.dart` | `NotificationService` | ChangeNotifier; subscribes to `MessageService`; dispatches via `flutter_local_notifications` (mobile/macOS) or `local_notifier` (desktop); triggers `InAppBannerController`; handles inline reply + cold-start navigation |
+| `lib/models/notification_preferences.dart` | `NotificationPreferences`, `NotificationChannels` | Immutable prefs model; per-channel enabled/sound/vibration; `load`/`save` via SharedPreferences; `copyWith*` helpers |
+| `lib/ui/widgets/in_app_banner_overlay.dart` | `InAppBannerOverlay`, `InAppBannerController` | Slide-in banner at app root; auto-dismiss 4s; swipe-up dismiss; tap → `MessageThreadScreen`; desktop anchors top-right 320 px |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,14 +57,14 @@ See `docs/ARCHITECTURE.md` for full detail.
 | ~~v0.8~~ | ~~Cross-platform parity pass (iOS Cupertino audit, Stadia Maps tile swap)~~ ✓ |
 | ~~v0.9~~ | ~~iOS Background Beaconing (background location + Live Activity)~~ ✓ |
 | ~~v0.10~~ | ~~Map experience — viewport-adaptive APRS-IS filter, time filter, track history, cluster markers, station type filters, object/item display~~ ✓ |
-| **v0.11** | Background notifications + in-app banner system |
+| ~~v0.11~~ | ~~Background notifications + in-app banner system~~ ✓ |
 | **v0.12** | Onboarding improvements |
 | **v0.13** | Security & connectivity (passcode secure storage, APRS-IS filter config) |
 | **v0.14** | Battery & performance optimization pass |
 | **v0.15** | Bug triage pass |
 | **v1.0** | Final polish + store submission |
 
-**Current status: v0.11 in progress (notifications milestone). v0.10 complete — map experience milestone (viewport-adaptive APRS-IS area filter, time filter, track history, cluster markers, station type filters). v0.11 adds: `NotificationService` (main-isolate dispatch, `flutter_local_notifications` on mobile/macOS, `local_notifier` on Windows/Linux); four notification channels (`messages`, `alerts`, `nearby`, `system`); Android `BigTextStyle`/`InboxStyle` + `RemoteInput` inline reply; iOS `UNTextInputAction` inline reply + foreground delivery; `InAppBannerOverlay` at app root; `NotificationPreferences` model + settings UI; cold-start navigation via global `navigatorKey`. ADRs 001–038 in `docs/DECISIONS.md`.**
+**Current status: v0.11 complete (notifications milestone). v0.12 next — Onboarding improvements. v0.11 added: `NotificationService` (main-isolate dispatch, `flutter_local_notifications` on mobile/macOS, `local_notifier` on Windows/Linux); four notification channels (`messages`, `alerts`, `nearby`, `system`); Android `MessagingStyle` + `RemoteInput` inline reply via native `BroadcastReceiver` + `FlutterEngineCache`; iOS `UNTextInputAction` inline reply + foreground delivery; `InAppBannerOverlay` at app root; `NotificationPreferences` model + settings UI; cold-start navigation via global `navigatorKey`; APRS-IS connection opt-in (no auto-connect on launch). ADRs 001–038 in `docs/DECISIONS.md`.**
 
 **Conventions added in v0.5:**
 - `TODO(tocall)` — marks `APZMDN` destination; register with WB4APR before v1.0 release

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,7 @@
             <intent-filter>
                 <action android:name="com.meridianaprs.meridian_aprs.NOTIFICATION_REPLY" />
                 <action android:name="com.meridianaprs.meridian_aprs.NOTIFICATION_MARK_READ" />
+                <action android:name="com.meridianaprs.meridian_aprs.NOTIFICATION_DISMISSED" />
             </intent-filter>
         </receiver>
         <!-- Don't delete the meta-data below.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,15 @@
             android:foregroundServiceType="dataSync|location"
             android:stopWithTask="false"
             android:exported="false" />
+        <!-- Handles inline reply and mark-as-read from message notifications. -->
+        <receiver
+            android:name=".MeridianNotificationActionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.meridianaprs.meridian_aprs.NOTIFICATION_REPLY" />
+                <action android:name="com.meridianaprs.meridian_aprs.NOTIFICATION_MARK_READ" />
+            </intent-filter>
+        </receiver>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
@@ -134,10 +134,22 @@ class MainActivity : FlutterActivity() {
             PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
         )
 
+        // Delete intent — fired when the user swipes the notification away.
+        val dismissedIntent = Intent(MeridianNotificationActionReceiver.ACTION_DISMISSED).apply {
+            setClass(appContext, MeridianNotificationActionReceiver::class.java)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN, callsign)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+        }
+        val dismissedPi = PendingIntent.getBroadcast(
+            appContext, notifId + 400_000, dismissedIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
+        )
+
         val notification = NotificationCompat.Builder(appContext, CHANNEL_ID_MESSAGES)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setStyle(style)
             .setContentIntent(tapPi)
+            .setDeleteIntent(dismissedPi)
             .setAutoCancel(false)
             .setGroup(GROUP_KEY)
             .setOnlyAlertOnce(alertOnce)

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
@@ -85,7 +85,10 @@ class MainActivity : FlutterActivity() {
 
         val mePerson = Person.Builder().setName("You").setBot(true).build()
         val peerPerson = Person.Builder().setName(callsign).setBot(true).build()
+        val baseCallsign = callsign.substringBefore('-')
         val style = NotificationCompat.MessagingStyle(mePerson)
+            .setGroupConversation(true)
+            .setConversationTitle("Message from $baseCallsign")
         for (msg in messages) {
             val sender = msg["sender"] as? String
             val text = msg["text"] as? String ?: continue

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
@@ -1,5 +1,162 @@
 package com.meridianaprs.meridian_aprs
 
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.Person
+import androidx.core.app.RemoteInput
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    private lateinit var appContext: Context
+    private var pendingNavCallsign: String? = null
+
+    companion object {
+        const val MAIN_ENGINE_ID = "meridian_main_engine"
+        const val CHANNEL = "meridian/notifications"
+        private const val CHANNEL_ID_MESSAGES = "messages"
+        private const val GROUP_KEY = "meridian_messages"
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        appContext = applicationContext
+
+        // Capture callsign if the process was cold-started by a notification tap.
+        intent?.getStringExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN)
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { pendingNavCallsign = it }
+
+        FlutterEngineCache.getInstance().put(MAIN_ENGINE_ID, flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "postMessageNotification" -> {
+                        @Suppress("UNCHECKED_CAST")
+                        handlePostMessageNotification(call.arguments as Map<String, Any?>)
+                        result.success(null)
+                    }
+                    "getPendingNavigation" -> {
+                        result.success(pendingNavCallsign)
+                        pendingNavCallsign = null
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        FlutterEngineCache.getInstance().remove(MAIN_ENGINE_ID)
+        super.cleanUpFlutterEngine(flutterEngine)
+    }
+
+    // Handles notification tap while the app is already running (singleTop reuse).
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val callsign = intent.getStringExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN)
+        if (callsign.isNullOrEmpty()) return
+
+        val engine = FlutterEngineCache.getInstance().get(MAIN_ENGINE_ID)
+        if (engine != null) {
+            try {
+                MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL)
+                    .invokeMethod("navigateToThread", mapOf("callsign" to callsign))
+            } catch (e: Exception) { /* engine detached */ }
+        } else {
+            pendingNavCallsign = callsign
+        }
+    }
+
+    private fun handlePostMessageNotification(args: Map<String, Any?>) {
+        val callsign = args["callsign"] as? String ?: return
+        val notifId = (args["notificationId"] as? Int) ?: return
+        @Suppress("UNCHECKED_CAST")
+        val messages = args["messages"] as? List<Map<String, Any?>> ?: emptyList()
+        val withSound = args["withSound"] as? Boolean ?: true
+        val alertOnce = args["alertOnce"] as? Boolean ?: false
+
+        val mePerson = Person.Builder().setName("You").setBot(true).build()
+        val peerPerson = Person.Builder().setName(callsign).setBot(true).build()
+        val style = NotificationCompat.MessagingStyle(mePerson)
+        for (msg in messages) {
+            val sender = msg["sender"] as? String
+            val text = msg["text"] as? String ?: continue
+            val tsMs = when (val ts = msg["timestampMs"]) {
+                is Int -> ts.toLong()
+                is Long -> ts
+                else -> System.currentTimeMillis()
+            }
+            style.addMessage(text, tsMs, if (sender != null) peerPerson else null)
+        }
+
+        // Tap → bring the app to foreground and navigate to the conversation.
+        val tapIntent = appContext.packageManager
+            .getLaunchIntentForPackage(appContext.packageName)
+            ?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                putExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN, callsign)
+            } ?: return
+        val tapPi = PendingIntent.getActivity(
+            appContext, notifId, tapIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
+        )
+
+        // Inline reply with RemoteInput (FLAG_MUTABLE required for Android 12+).
+        val remoteInput = RemoteInput.Builder(MeridianNotificationActionReceiver.KEY_REPLY)
+            .setLabel("Reply")
+            .build()
+        val replyIntent = Intent(MeridianNotificationActionReceiver.ACTION_REPLY).apply {
+            setClass(appContext, MeridianNotificationActionReceiver::class.java)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN, callsign)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+        }
+        val replyPi = PendingIntent.getBroadcast(
+            appContext, notifId, replyIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or mutableFlag()
+        )
+
+        // Mark-as-read (request code offset prevents PendingIntent collision with reply PI).
+        val markReadIntent = Intent(MeridianNotificationActionReceiver.ACTION_MARK_READ).apply {
+            setClass(appContext, MeridianNotificationActionReceiver::class.java)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_CALLSIGN, callsign)
+            putExtra(MeridianNotificationActionReceiver.EXTRA_NOTIFICATION_ID, notifId)
+        }
+        val markReadPi = PendingIntent.getBroadcast(
+            appContext, notifId + 200_000, markReadIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
+        )
+
+        val notification = NotificationCompat.Builder(appContext, CHANNEL_ID_MESSAGES)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setStyle(style)
+            .setContentIntent(tapPi)
+            .setAutoCancel(false)
+            .setGroup(GROUP_KEY)
+            .setOnlyAlertOnce(alertOnce)
+            .setSilent(!withSound)
+            .addAction(NotificationCompat.Action.Builder(0, "Mark as read", markReadPi).build())
+            .addAction(
+                NotificationCompat.Action.Builder(0, "Reply", replyPi)
+                    .addRemoteInput(remoteInput)
+                    .setAllowGeneratedReplies(false)
+                    .build()
+            )
+            .build()
+
+        NotificationManagerCompat.from(appContext).notify(notifId, notification)
+    }
+
+    private fun immutableFlag() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+
+    private fun mutableFlag() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+}

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MeridianNotificationActionReceiver.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MeridianNotificationActionReceiver.kt
@@ -1,0 +1,67 @@
+package com.meridianaprs.meridian_aprs
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
+
+class MeridianNotificationActionReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_REPLY = "com.meridianaprs.meridian_aprs.NOTIFICATION_REPLY"
+        const val ACTION_MARK_READ = "com.meridianaprs.meridian_aprs.NOTIFICATION_MARK_READ"
+        const val ACTION_DISMISSED = "com.meridianaprs.meridian_aprs.NOTIFICATION_DISMISSED"
+        const val EXTRA_CALLSIGN = "callsign"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+        const val KEY_REPLY = "reply_text"
+        const val MAIN_ENGINE_ID = "meridian_main_engine"
+        const val CHANNEL = "meridian/notifications"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val callsign = intent.getStringExtra(EXTRA_CALLSIGN) ?: return
+        val notifId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
+        if (notifId < 0) return
+
+        when (intent.action) {
+            ACTION_REPLY -> handleReply(intent, callsign, notifId)
+            ACTION_MARK_READ -> handleMarkRead(context, callsign, notifId)
+            ACTION_DISMISSED -> relayToEngine("handleDismissed", mapOf("callsign" to callsign))
+        }
+    }
+
+    private fun handleReply(intent: Intent, callsign: String, notifId: Int) {
+        val bundle = RemoteInput.getResultsFromIntent(intent) ?: return
+        val replyText = bundle.getCharSequence(KEY_REPLY)?.toString()?.trim() ?: return
+        if (replyText.isEmpty()) return
+        relayToEngine(
+            "handleReply",
+            mapOf("callsign" to callsign, "text" to replyText, "notificationId" to notifId),
+        )
+    }
+
+    private fun handleMarkRead(context: Context, callsign: String, notifId: Int) {
+        NotificationManagerCompat.from(context).cancel(notifId)
+        relayToEngine("handleMarkRead", mapOf("callsign" to callsign))
+    }
+
+    private fun relayToEngine(method: String, args: Map<String, Any>) {
+        val engine = try {
+            FlutterEngineCache.getInstance().get(MAIN_ENGINE_ID) ?: return
+        } catch (e: Exception) { return }
+
+        try {
+            val messenger = engine.dartExecutor.binaryMessenger
+            Handler(Looper.getMainLooper()).post {
+                try {
+                    MethodChannel(messenger, CHANNEL).invokeMethod(method, args)
+                } catch (e: Exception) { /* Engine detached */ }
+            }
+        } catch (e: Exception) { /* Engine detached */ }
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -484,6 +484,62 @@ The `NSLocationWhenInUseUsageDescription` and Bluetooth usage description keys a
 
 ---
 
+## Notification System (v0.11)
+
+### Overview
+
+v0.11 adds a full notification layer for incoming APRS messages. Delivery happens on the **main Dart isolate** on both platforms — there is no cross-isolate dispatch path needed because both Android (via `flutter_foreground_task` foreground service) and iOS (via VoIP `UIBackgroundMode`) keep the main isolate alive while backgrounded. See ADR-035.
+
+### Channel Taxonomy
+
+Four notification channels are registered at startup and serve as an extensible taxonomy for future alert types:
+
+| Channel ID | Label | Default | Purpose |
+|---|---|---|---|
+| `messages` | Messages | Sound + vibration | Inbound APRS messages addressed to user |
+| `alerts` | Alerts | Sound + vibration | WX/NWS alerts (reserved for future milestone) |
+| `nearby` | Nearby | Vibration only | Nearby station activity (reserved) |
+| `system` | System | Silent | Connection and TNC status (reserved) |
+
+### `NotificationService` (`lib/services/notification_service.dart`)
+
+`ChangeNotifier` service initialized in `main.dart` before `runApp`. Sits between `MessageService` and all platform delivery paths.
+
+Responsibilities:
+- Subscribes to `MessageService` via `addListener`; detects new inbound messages by comparing current vs. previous unread counts per callsign
+- Checks `NotificationPreferences` (channel enabled, sound, vibration) before dispatching
+- Dispatches system notifications via `flutter_local_notifications` on Android/iOS/macOS
+- Dispatches desktop toasts via `local_notifier` on Windows/Linux (tap-to-navigate, no inline reply)
+- Triggers `InAppBannerController` unless the user is already in that conversation's thread
+- Handles inline reply action payloads from Android `RemoteInput` and iOS `UNTextInputAction`; routes reply text to `MessageService.sendMessage()`
+- Handles cold-start navigation via `getNotificationAppLaunchDetails()` (post-frame callback)
+- Drains a SharedPreferences reply outbox on startup for terminated-app inline replies
+
+**Android:** `BigTextStyleInformation` for single messages; `InboxStyleInformation` grouped summary when 3+ conversations have unread messages. `RemoteInput` inline reply action on the `messages` channel.
+
+**iOS:** `DarwinNotificationCategory('messages')` with `DarwinNotificationAction.text` for inline reply. Notifications present in foreground via `presentAlert: true` (handled automatically by `flutter_local_notifications` — no custom `AppDelegate` code needed).
+
+**Background inline reply (terminated app):** The `@pragma('vm:entry-point')` top-level handler `onNotificationBackgroundResponse` writes replies to a SharedPreferences outbox (`notification_reply_outbox`). `NotificationService._drainReplyOutbox()` processes the queue on the next main-isolate startup.
+
+**Navigation from notification tap:** A `GlobalKey<NavigatorState> navigatorKey` is declared in `lib/main.dart` and passed to all three `MaterialApp`/`CupertinoApp` instances. `NotificationService` holds a reference and calls `navigatorKey.currentState?.push(buildPlatformRoute(...))`.
+
+### `InAppBannerOverlay` (`lib/ui/widgets/in_app_banner_overlay.dart`)
+
+In-app slide-in notification banner. Wraps the home widget in `MeridianApp.build()` so it appears on every screen.
+
+- **Mobile:** Full-width, anchored top, slides in from above using `SlideTransition`
+- **Desktop (>1024 px):** Fixed-width (320 px), anchored top-right via `Positioned`
+- Auto-dismisses after 4 seconds; swipe up to dismiss early; tap navigates to `MessageThreadScreen`
+- Suppressed if `MessageThreadScreen` for that callsign is the current route (set via `NotificationService.setActiveThread`)
+
+`InAppBannerController` is a `ChangeNotifier` that the overlay widget watches. Both it and `NotificationService` are added to the Provider tree in `main.dart`.
+
+### `NotificationPreferences` (`lib/models/notification_preferences.dart`)
+
+Immutable value object persisted to SharedPreferences (keys: `notif_channel_<id>`, `notif_sound_<id>`, `notif_vibration_<id>`). Defaults: all channels enabled; sound/vibration on for `messages` and `alerts`, off for `nearby` and `system`. `copyWithChannel`/`copyWithSound`/`copyWithVibration` return new instances; `NotificationService` holds the current instance and calls `notifyListeners()` after each update.
+
+---
+
 ## Key Dependencies
 
 | Package | Purpose |
@@ -495,6 +551,8 @@ The `NSLocationWhenInUseUsageDescription` and Bluetooth usage description keys a
 | `flutter_foreground_task` | Android foreground service keepalive (added v0.7) |
 | `permission_handler` | Android permission requests (background location, notifications); iOS background location check (added v0.7, upgraded ^12.0.1 in v0.9) |
 | `live_activities` | iOS Live Activity bridge — Dart → ActivityKit → Lock Screen / Dynamic Island (added v0.9) |
+| `flutter_local_notifications` | System notification dispatch on Android, iOS, and macOS; inline reply via RemoteInput/UNTextInputAction (added v0.11) |
+| `local_notifier` | Desktop system tray toast notifications on macOS, Windows, and Linux (added v0.11) |
 | `provider` | ChangeNotifier wiring throughout service layer |
 | `shared_preferences` | Theme mode, settings, beaconing config, and session state persistence |
 | `dynamic_color` | Android 12+ wallpaper-derived ColorScheme |

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -556,3 +556,65 @@ The 500-entry history cap prevents unbounded memory growth for high-speed mobile
 **Consequences:**
 - First-run users see at most 60 minutes of history; users who previously ran without a filter will see their station map trimmed on the first prune pass.
 - Position history is not persisted across app restarts (only `lat`/`lon`/`lastHeard` are serialised). This is acceptable — history rebuilds organically as new packets arrive.
+
+---
+
+## ADR-035: Main-isolate notification dispatch — no cross-isolate path needed
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+**Decision:** `NotificationService` subscribes to `MessageService` on the main Dart isolate and dispatches system notifications from there. No cross-isolate communication path is implemented for notification delivery.
+
+**Rationale:** The `flutter_foreground_task` `TaskHandler` (`MeridianConnectionTask`) is a beaconing heartbeat only — it does not process incoming APRS packets. All packet ingestion, `StationService` updates, and `MessageService` listener callbacks run on the main Dart isolate. On Android, the foreground service (declared via `flutter_foreground_task`) keeps the main isolate alive when backgrounded. On iOS, the `voip` UIBackgroundMode keeps the process alive. In both cases, a simple `messageService.addListener` fires reliably while backgrounded, so no background-isolate notification path is needed.
+
+The handoff spec described a "background isolate" dispatch path — this was based on a misread of the architecture. Correcting it here so future implementers don't build a cross-isolate path that's unnecessary and more fragile.
+
+**Consequences:** `NotificationService.initialize()` must be called before `runApp()` so the listener is wired before the first background event. The `@pragma('vm:entry-point')` `onNotificationBackgroundResponse` top-level function handles the one true background-isolate case: Android inline reply when the app process is **terminated** (not just backgrounded). In that case, the app is cold-launched in a background context; the handler writes the reply to a SharedPreferences outbox that `_drainReplyOutbox()` processes on the next main-isolate startup.
+
+---
+
+## ADR-036: InAppBannerOverlay at the app root rather than per-screen
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+**Decision:** `InAppBannerOverlay` wraps the `home` widget in `MeridianApp.build()` — a single insertion point that covers every screen.
+
+**Rationale:** Placing the banner per-screen (e.g. only in `MapScreen`) would require every screen that could receive a message while active to replicate the overlay code. APRS messages can arrive while the user is on the Packet Log, Station List, Settings, or Connection screen. A single root-level overlay costs nothing extra (it's a `Stack` with a conditionally-visible child) and requires zero per-screen wiring.
+
+**Alternatives considered:**
+- Overlay entry via `Navigator.of(context).overlay.insert(...)`: more powerful, but harder to dismiss cleanly and requires a reference to the navigator at insertion time.
+- `ScaffoldMessenger.of(context).showSnackBar(...)`: zero custom code, but SnackBar appears at the bottom, lacks callsign+preview layout, and cannot carry tap-to-navigate behavior without a custom SnackBar widget.
+
+**Consequences:** `InAppBannerController` must be provided above the `MeridianApp` builder (i.e., in the `MultiProvider` in `main.dart`) so `InAppBannerOverlay` can access it.
+
+---
+
+## ADR-037: System notification fires even while app is foregrounded
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+**Decision:** System notifications (via `flutter_local_notifications`) are dispatched regardless of whether the app is in the foreground. On iOS, `DarwinInitializationSettings` sets `presentAlert: true` and `presentSound: true` for foreground delivery.
+
+**Rationale:** Meridian is a radio communications tool. Missed messages have real operational consequences — the user may be looking at the map or a different screen and would not notice an incoming message without an audible/visual alert. Both the in-app banner and the system notification fire independently; they serve different user attention states (foreground awareness vs. OS-level intrusion).
+
+**Alternatives considered:**
+- Suppress system notification when app is foregrounded (common in chat apps): rejected because foreground ≠ "user is looking at the message thread". The user could be watching the map while a message comes in.
+- Fire only the in-app banner in foreground: rejected for the same reason — the banner is visual-only and could be missed.
+
+**Consequences:** Users may see both the banner and the notification center entry simultaneously when foregrounded. This is intentional and matches the behavior of push-to-talk and emergency communications apps.
+
+---
+
+## ADR-038: Desktop inline reply not implemented
+
+**Status:** Accepted
+**Date:** 2026-04-18
+
+**Decision:** Desktop platforms (macOS, Windows, Linux) do not support inline reply from the notification. Tapping a desktop toast navigates to `MessageThreadScreen` for the reply.
+
+**Rationale:** `local_notifier` (the desktop toast library) does not expose a text input action API. macOS `UNUserNotificationCenter` does support text input replies, but wiring it through `local_notifier` → Dart would require a custom platform channel, which is out of scope for v0.11. The `flutter_local_notifications` package also does not support Windows or Linux notifications. Desktop APRS operators typically have the app visible on screen — the click-to-navigate flow is adequate.
+
+**Future path:** If macOS inline reply becomes a priority, it can be implemented via a custom Swift platform channel that registers a `UNTextInputNotificationAction`, fires the reply into a named `ReceivePort` on the main isolate, and calls `MessageService.sendMessage`. This is a discrete addition that does not require changing the `NotificationService` dispatch path.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,13 +18,11 @@ Each milestone represents a shippable increment with a focused scope. Features d
 | v0.8 — Platform Parity | iOS Cupertino audit, Stadia Maps tile swap (TileProvider abstraction) | ✅ Complete |
 | v0.9 — iOS Background | iOS background beaconing — background location + Live Activity | ✅ Complete |
 | v0.10 — Map Experience | Viewport-adaptive APRS-IS filter, configurable time filter, track history polylines, map filters UI | ✅ Complete |
-| v0.11 — Map Filters & Stations | Map filters, station profiles | — |
-| v0.12 — Map Enhancement | Track history, cluster markers, object/item display, altitude in position packets | — |
-| v0.13 — Onboarding | BLE pairing flow in onboarding, APRS-IS connection before map, GPS centering on first launch, symbol picker + comment + location setup | — |
-| v0.14 — Notifications | Background notifications, in-app banner system, notification preferences | — |
-| v0.15 — Security | Passcode secure storage, APRS-IS filter configuration | — |
-| v0.16 — Performance | Battery & performance optimization pass (motivated by background service drain) | — |
-| v0.17 — Bug Triage | Dedicated triage and bugfix pass before final polish | — |
+| v0.11 — Notifications | Background notifications, in-app banner system, notification preferences | 🔄 In progress |
+| v0.12 — Onboarding | BLE pairing flow in onboarding, APRS-IS connection before map, GPS centering on first launch, symbol picker + comment + location setup | — |
+| v0.13 — Security | Passcode secure storage, APRS-IS filter configuration | — |
+| v0.14 — Performance | Battery & performance optimization pass (motivated by background service drain) | — |
+| v0.15 — Bug Triage | Dedicated triage and bugfix pass before final polish | — |
 | v1.0 — Launch | Final polish, all-platform store submission (iOS App Store, Google Play, macOS, Windows, Linux) | — |
 
 ---
@@ -56,27 +54,27 @@ Make the map functional at real-world scale with adaptive data fetching, time-bo
 
 ---
 
-### v0.11 — Map Filters & Station Profiles
-Core usability features that make the map manageable at scale.
+### v0.11 — Notifications
+Keep operators informed when Meridian is in the background.
 
-- Filter by station type, symbol, distance, path, and more
-- Named filter presets (save and recall)
-- Station profile view — packet history, path info, heard-by digipeaters, message log
-- Map tap → station profile flow
+- ✅ `NotificationService` — main-isolate dispatch to `flutter_local_notifications` (Android/iOS/macOS) and `local_notifier` (Windows/Linux)
+- ✅ Four notification channels registered: `messages`, `alerts`, `nearby`, `system`
+- ✅ Android `BigTextStyle` single + `InboxStyle` grouped (3+ conversations) notifications
+- ✅ Android inline reply via `RemoteInput` action; terminated-app replies via SharedPreferences outbox
+- ✅ iOS inline reply via `UNTextInputAction` / `DarwinNotificationCategory`; foreground delivery via `presentAlert: true`
+- ✅ `InAppBannerOverlay` at app root — slide-in banner with callsign/preview/timestamp; full-width mobile, 320 px top-right desktop
+- ✅ Banner suppressed when `MessageThreadScreen` for that callsign is active
+- ✅ `NotificationPreferences` model — per-channel enabled/sound/vibration, persisted to SharedPreferences, default-on for messages+alerts
+- ✅ Notifications settings section — per-channel toggles with sound/vibration sub-toggles (mobile only)
+- ✅ Cold-start navigation via `getNotificationAppLaunchDetails()` post-frame
+- ✅ Global `navigatorKey` wired to all three `MaterialApp`/`CupertinoApp` variants
+- ✅ Nav badge persistence verified (no-op: `unreadCount` was already serialized in `MessageService`)
+- ✅ Unit tests: `NotificationPreferences` round-trip, banner dispatch logic, inline reply routing, reply outbox drain
+- ✅ ADRs 035–038 in `docs/DECISIONS.md`
 
 ---
 
-### v0.12 — Map Enhancement
-Deeper map capabilities for tracking and situational awareness.
-
-- Track history — display position history trails for stations
-- Cluster markers at low zoom levels
-- Object and item packet display
-- Altitude field in outgoing position packets
-
----
-
-### v0.13 — Onboarding Improvements
+### v0.12 — Onboarding Improvements
 Make the first-launch experience complete and self-sufficient.
 
 - BLE TNC selection in onboarding triggers BLE pairing flow
@@ -86,16 +84,7 @@ Make the first-launch experience complete and self-sufficient.
 
 ---
 
-### v0.14 — Notifications
-Keep operators informed when Meridian is in the background.
-
-- Background notifications for incoming APRS messages
-- In-app banner system for alerts
-- Notification preferences screen
-
----
-
-### v0.15 — Security
+### v0.13 — Security
 Harden credential handling and network filtering.
 
 - Passcode stored in platform secure storage (Keychain / Keystore)
@@ -103,7 +92,7 @@ Harden credential handling and network filtering.
 
 ---
 
-### v0.16 — Battery & Performance
+### v0.14 — Battery & Performance
 Optimize for real-world sustained use.
 
 - Profile and reduce background service battery drain
@@ -113,7 +102,7 @@ Optimize for real-world sustained use.
 
 ---
 
-### v0.17 — Bug Triage
+### v0.15 — Bug Triage
 Dedicated milestone for clearing the bug backlog before final polish.
 
 - Triage all open `bug` issues
@@ -142,4 +131,4 @@ The release milestone. No new features — quality, stability, and store readine
 
 ---
 
-*Last updated: 2026-04-11*
+*Last updated: 2026-04-17*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ Each milestone represents a shippable increment with a focused scope. Features d
 | v0.8 — Platform Parity | iOS Cupertino audit, Stadia Maps tile swap (TileProvider abstraction) | ✅ Complete |
 | v0.9 — iOS Background | iOS background beaconing — background location + Live Activity | ✅ Complete |
 | v0.10 — Map Experience | Viewport-adaptive APRS-IS filter, configurable time filter, track history polylines, map filters UI | ✅ Complete |
-| v0.11 — Notifications | Background notifications, in-app banner system, notification preferences | 🔄 In progress |
+| v0.11 — Notifications | Background notifications, in-app banner system, notification preferences | ✅ Complete |
 | v0.12 — Onboarding | BLE pairing flow in onboarding, APRS-IS connection before map, GPS centering on first launch, symbol picker + comment + location setup | — |
 | v0.13 — Security | Passcode secure storage, APRS-IS filter configuration | — |
 | v0.14 — Performance | Battery & performance optimization pass (motivated by background service drain) | — |
@@ -54,7 +54,7 @@ Make the map functional at real-world scale with adaptive data fetching, time-bo
 
 ---
 
-### v0.11 — Notifications
+### ~~v0.11 — Notifications~~ ✅
 Keep operators informed when Meridian is in the background.
 
 - ✅ `NotificationService` — main-isolate dispatch to `flutter_local_notifications` (Android/iOS/macOS) and `local_notifier` (Windows/Linux)
@@ -131,4 +131,4 @@ The release milestone. No new features — quality, stability, and store readine
 
 ---
 
-*Last updated: 2026-04-17*
+*Last updated: 2026-04-18*

--- a/lib/core/connection/aprs_is_connection.dart
+++ b/lib/core/connection/aprs_is_connection.dart
@@ -25,8 +25,15 @@ class AprsIsConnection extends MeridianConnection {
   StreamSubscription<ConnectionStatus>? _stateSub;
 
   static const _kBeaconingKey = 'beacon_enabled_aprs_is';
+  static const _kAutoConnectKey = 'aprs_is_auto_connect';
 
   bool _beaconingEnabled = true;
+  bool _autoConnect = false;
+
+  /// Whether the user last chose to have this connection active.
+  /// Seeded from SharedPreferences in [loadPersistedSettings]; defaults false
+  /// so the connection is opt-in on first launch.
+  bool get autoConnect => _autoConnect;
 
   // ---------------------------------------------------------------------------
   // MeridianConnection — identity
@@ -93,12 +100,20 @@ class AprsIsConnection extends MeridianConnection {
   @override
   Future<void> connect() async {
     await _transport.connect();
+    _autoConnect = true;
+    SharedPreferences.getInstance().then(
+      (p) => p.setBool(_kAutoConnectKey, true),
+    );
     notifyListeners();
   }
 
   @override
   Future<void> disconnect() async {
     await _transport.disconnect();
+    _autoConnect = false;
+    SharedPreferences.getInstance().then(
+      (p) => p.setBool(_kAutoConnectKey, false),
+    );
     notifyListeners();
   }
 
@@ -113,6 +128,7 @@ class AprsIsConnection extends MeridianConnection {
   Future<void> loadPersistedSettings() async {
     final prefs = await SharedPreferences.getInstance();
     _beaconingEnabled = prefs.getBool(_kBeaconingKey) ?? true;
+    _autoConnect = prefs.getBool(_kAutoConnectKey) ?? false;
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -137,10 +137,13 @@ Future<void> main() async {
     );
   }
 
-  // Start APRS-IS connection on launch.
-  aprsIsConn.connect().catchError((Object e) {
-    debugPrint('APRS-IS connection failed: $e');
-  });
+  // Reconnect APRS-IS only if the user chose to connect last session.
+  // Defaults to off on first launch so the connection is always opt-in.
+  if (aprsIsConn.autoConnect) {
+    aprsIsConn.connect().catchError((Object e) {
+      debugPrint('APRS-IS connection failed: $e');
+    });
+  }
 
   final stationSettings = StationSettingsService(prefs);
   final txService = TxService(registry);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,9 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'services/notification_service.dart';
+import 'ui/widgets/in_app_banner_overlay.dart';
+
 import 'config/app_config.dart';
 import 'core/connection/aprs_is_connection.dart';
 import 'core/connection/ble_connection.dart';
@@ -35,6 +38,10 @@ import 'theme/meridian_colors.dart';
 import 'theme/theme_controller.dart';
 
 const String _kVersion = '0.1.0';
+
+/// Global navigator key so [NotificationService] can push routes from outside
+/// the widget tree (notification taps, inline reply navigation).
+final navigatorKey = GlobalKey<NavigatorState>();
 
 /// Maps a [ConnectionType] to the [PacketSource] tag used in [StationService].
 PacketSource _packetSourceFor(ConnectionType type) => switch (type) {
@@ -150,6 +157,15 @@ Future<void> main() async {
   final messageService = MessageService(stationSettings, txService, service);
   await messageService.loadHistory();
 
+  final bannerController = InAppBannerController();
+  final notificationService = NotificationService(
+    messageService: messageService,
+    prefs: prefs,
+    navigatorKey: navigatorKey,
+    bannerController: bannerController,
+  );
+  await notificationService.initialize();
+
   // Tile cache: persist tiles to disk for 30 days so repeated sessions don't
   // re-fetch the same tiles and burn through Stadia Maps API credits.
   final cacheDir = await getTemporaryDirectory();
@@ -211,6 +227,12 @@ Future<void> main() async {
         ChangeNotifierProvider<BackgroundServiceManager>.value(
           value: bgServiceManager,
         ),
+        ChangeNotifierProvider<NotificationService>.value(
+          value: notificationService,
+        ),
+        ChangeNotifierProvider<InAppBannerController>.value(
+          value: bannerController,
+        ),
         if (iosBackgroundService != null)
           ChangeNotifierProvider<IosBackgroundService>.value(
             value: iosBackgroundService,
@@ -225,6 +247,7 @@ Future<void> main() async {
         mapZoom: mapZoom,
         service: service,
         tileProvider: tileProvider,
+        bannerController: bannerController,
       ),
     ),
   );
@@ -241,6 +264,7 @@ class MeridianApp extends StatelessWidget {
     this.mapZoom = 9.0,
     required this.service,
     required this.tileProvider,
+    required this.bannerController,
   });
 
   final bool onboardingComplete;
@@ -251,15 +275,32 @@ class MeridianApp extends StatelessWidget {
   final double mapZoom;
   final StationService service;
   final StadiaTileProvider tileProvider;
+  final InAppBannerController bannerController;
 
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<ThemeController>();
 
+    Widget homeWidget() => InAppBannerOverlay(
+      controller: bannerController,
+      child: onboardingComplete
+          ? MapScreen(
+              service: service,
+              tileProvider: tileProvider,
+              callsign: userCallsign,
+              ssid: userSsid,
+              initialLat: mapLat,
+              initialLon: mapLon,
+              initialZoom: mapZoom,
+            )
+          : const OnboardingScreen(),
+    );
+
     if (!kIsWeb && Platform.isIOS) {
       final brightness = _resolveIosBrightness(controller.themeMode);
       return CupertinoApp(
         title: 'Meridian APRS',
+        navigatorKey: navigatorKey,
         theme: buildIosTheme(
           brightness: brightness,
           primaryColor: controller.seedColor,
@@ -274,17 +315,7 @@ class MeridianApp extends StatelessWidget {
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: const [Locale('en', 'US')],
-        home: onboardingComplete
-            ? MapScreen(
-                service: service,
-                tileProvider: tileProvider,
-                callsign: userCallsign,
-                ssid: userSsid,
-                initialLat: mapLat,
-                initialLon: mapLon,
-                initialZoom: mapZoom,
-              )
-            : const OnboardingScreen(),
+        home: homeWidget(),
       );
     }
 
@@ -293,6 +324,7 @@ class MeridianApp extends StatelessWidget {
       final themes = buildDesktopTheme(seedColor: MeridianColors.primary);
       return MaterialApp(
         title: 'Meridian APRS',
+        navigatorKey: navigatorKey,
         themeMode: controller.themeMode,
         theme: themes.light,
         darkTheme: themes.dark,
@@ -303,17 +335,7 @@ class MeridianApp extends StatelessWidget {
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: const [Locale('en', 'US')],
-        home: onboardingComplete
-            ? MapScreen(
-                service: service,
-                tileProvider: tileProvider,
-                callsign: userCallsign,
-                ssid: userSsid,
-                initialLat: mapLat,
-                initialLon: mapLon,
-                initialZoom: mapZoom,
-              )
-            : const OnboardingScreen(),
+        home: homeWidget(),
       );
     }
 
@@ -329,20 +351,11 @@ class MeridianApp extends StatelessWidget {
 
         return MaterialApp(
           title: 'Meridian APRS',
+          navigatorKey: navigatorKey,
           themeMode: controller.themeMode,
           theme: themes.light,
           darkTheme: themes.dark,
-          home: onboardingComplete
-              ? MapScreen(
-                  service: service,
-                  tileProvider: tileProvider,
-                  callsign: userCallsign,
-                  ssid: userSsid,
-                  initialLat: mapLat,
-                  initialLon: mapLon,
-                  initialZoom: mapZoom,
-                )
-              : const OnboardingScreen(),
+          home: homeWidget(),
         );
       },
     );

--- a/lib/models/notification_preferences.dart
+++ b/lib/models/notification_preferences.dart
@@ -1,0 +1,105 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Notification channel IDs — extensible taxonomy established in v0.11.
+abstract final class NotificationChannels {
+  static const messages = 'messages';
+  static const alerts = 'alerts';
+  static const nearby = 'nearby';
+  static const system = 'system';
+
+  static const all = [messages, alerts, nearby, system];
+}
+
+/// Per-channel notification preferences persisted to SharedPreferences.
+class NotificationPreferences {
+  const NotificationPreferences({
+    required this.channelEnabled,
+    required this.soundEnabled,
+    required this.vibrationEnabled,
+  });
+
+  final Map<String, bool> channelEnabled;
+  final Map<String, bool> soundEnabled;
+  final Map<String, bool> vibrationEnabled;
+
+  // Default sound/vibration: on for messages+alerts, off for nearby+system.
+  static const _defaultSound = {
+    NotificationChannels.messages: true,
+    NotificationChannels.alerts: true,
+    NotificationChannels.nearby: false,
+    NotificationChannels.system: false,
+  };
+
+  static const _defaultVibration = {
+    NotificationChannels.messages: true,
+    NotificationChannels.alerts: true,
+    NotificationChannels.nearby: false,
+    NotificationChannels.system: false,
+  };
+
+  static NotificationPreferences defaults() => NotificationPreferences(
+    channelEnabled: {for (final c in NotificationChannels.all) c: true},
+    soundEnabled: Map.of(_defaultSound),
+    vibrationEnabled: Map.of(_defaultVibration),
+  );
+
+  bool isChannelEnabled(String id) => channelEnabled[id] ?? true;
+
+  bool isSoundEnabled(String id) =>
+      soundEnabled[id] ?? (_defaultSound[id] ?? false);
+
+  bool isVibrationEnabled(String id) =>
+      vibrationEnabled[id] ?? (_defaultVibration[id] ?? false);
+
+  static Future<NotificationPreferences> load(SharedPreferences prefs) async {
+    final channelEnabled = <String, bool>{};
+    final soundEnabled = <String, bool>{};
+    final vibrationEnabled = <String, bool>{};
+    for (final ch in NotificationChannels.all) {
+      channelEnabled[ch] = prefs.getBool('notif_channel_$ch') ?? true;
+      soundEnabled[ch] =
+          prefs.getBool('notif_sound_$ch') ?? (_defaultSound[ch] ?? false);
+      vibrationEnabled[ch] =
+          prefs.getBool('notif_vibration_$ch') ??
+          (_defaultVibration[ch] ?? false);
+    }
+    return NotificationPreferences(
+      channelEnabled: channelEnabled,
+      soundEnabled: soundEnabled,
+      vibrationEnabled: vibrationEnabled,
+    );
+  }
+
+  Future<void> save(SharedPreferences prefs) async {
+    for (final e in channelEnabled.entries) {
+      await prefs.setBool('notif_channel_${e.key}', e.value);
+    }
+    for (final e in soundEnabled.entries) {
+      await prefs.setBool('notif_sound_${e.key}', e.value);
+    }
+    for (final e in vibrationEnabled.entries) {
+      await prefs.setBool('notif_vibration_${e.key}', e.value);
+    }
+  }
+
+  NotificationPreferences copyWithChannel(String id, bool enabled) =>
+      NotificationPreferences(
+        channelEnabled: Map.of(channelEnabled)..[id] = enabled,
+        soundEnabled: Map.of(soundEnabled),
+        vibrationEnabled: Map.of(vibrationEnabled),
+      );
+
+  NotificationPreferences copyWithSound(String id, bool enabled) =>
+      NotificationPreferences(
+        channelEnabled: Map.of(channelEnabled),
+        soundEnabled: Map.of(soundEnabled)..[id] = enabled,
+        vibrationEnabled: Map.of(vibrationEnabled),
+      );
+
+  NotificationPreferences copyWithVibration(String id, bool enabled) =>
+      NotificationPreferences(
+        channelEnabled: Map.of(channelEnabled),
+        soundEnabled: Map.of(soundEnabled),
+        vibrationEnabled: Map.of(vibrationEnabled)..[id] = enabled,
+      );
+}

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -10,6 +10,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../services/message_service.dart';
+import '../services/notification_service.dart';
 import '../services/tx_service.dart';
 
 class MessageThreadScreen extends StatefulWidget {
@@ -28,14 +29,16 @@ class _MessageThreadScreenState extends State<MessageThreadScreen> {
   @override
   void initState() {
     super.initState();
-    // Mark conversation as read when thread is opened.
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       context.read<MessageService>().markRead(widget.peerCallsign);
+      context.read<NotificationService>().setActiveThread(widget.peerCallsign);
     });
   }
 
   @override
   void dispose() {
+    context.read<NotificationService>().setActiveThread(null);
     _inputCtrl.dispose();
     _scrollCtrl.dispose();
     super.dispose();

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -23,6 +23,8 @@ import '../ui/utils/distance_formatter.dart';
 import '../ui/utils/platform_route.dart';
 import '../ui/widgets/aprs_symbol_widget.dart';
 import '../ui/widgets/callsign_field.dart';
+import '../models/notification_preferences.dart';
+import '../services/notification_service.dart';
 import '../theme/meridian_colors.dart';
 import '../theme/theme_controller.dart';
 
@@ -1696,18 +1698,102 @@ class _NotificationsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final notif = context.watch<NotificationService>();
+    final prefs = notif.preferences;
+    final isMobile = !kIsWeb && (Platform.isAndroid || Platform.isIOS);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const _SectionHeader('Notifications'),
-        SwitchListTile.adaptive(
-          title: const Text('Message alerts'),
-          subtitle: const Text(
-            'Notify when a message addressed to you arrives.',
-          ),
-          value: false,
-          onChanged: null, // Stub — not yet functional.
+        _NotificationChannelTile(
+          channelId: NotificationChannels.messages,
+          label: 'Messages',
+          description: 'Notify when a message addressed to you arrives.',
+          prefs: prefs,
+          notif: notif,
+          isMobile: isMobile,
         ),
+        _NotificationChannelTile(
+          channelId: NotificationChannels.alerts,
+          label: 'Alerts',
+          description: 'WX and NWS alerts (reserved for a future feature).',
+          prefs: prefs,
+          notif: notif,
+          isMobile: isMobile,
+        ),
+        _NotificationChannelTile(
+          channelId: NotificationChannels.nearby,
+          label: 'Nearby',
+          description:
+              'Activity from stations in your area (reserved for a future feature).',
+          prefs: prefs,
+          notif: notif,
+          isMobile: isMobile,
+        ),
+        _NotificationChannelTile(
+          channelId: NotificationChannels.system,
+          label: 'System',
+          description: 'Connection and TNC status updates.',
+          prefs: prefs,
+          notif: notif,
+          isMobile: isMobile,
+        ),
+      ],
+    );
+  }
+}
+
+class _NotificationChannelTile extends StatelessWidget {
+  const _NotificationChannelTile({
+    required this.channelId,
+    required this.label,
+    required this.description,
+    required this.prefs,
+    required this.notif,
+    required this.isMobile,
+  });
+
+  final String channelId;
+  final String label;
+  final String description;
+  final NotificationPreferences prefs;
+  final NotificationService notif;
+  final bool isMobile;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = prefs.isChannelEnabled(channelId);
+    return Column(
+      children: [
+        SwitchListTile.adaptive(
+          title: Text(label),
+          subtitle: Text(description),
+          value: enabled,
+          onChanged: (v) => notif.setChannelEnabled(channelId, v),
+        ),
+        if (isMobile) ...[
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: SwitchListTile.adaptive(
+              title: const Text('Sound'),
+              value: prefs.isSoundEnabled(channelId),
+              onChanged: enabled
+                  ? (v) => notif.setSoundEnabled(channelId, v)
+                  : null,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: SwitchListTile.adaptive(
+              title: const Text('Vibration'),
+              value: prefs.isVibrationEnabled(channelId),
+              onChanged: enabled
+                  ? (v) => notif.setVibrationEnabled(channelId, v)
+                  : null,
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -10,8 +10,6 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
-import 'dart:isolate';
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -36,76 +34,35 @@ const _kMarkReadActionId = 'mark_read';
 const _kGroupKey = 'meridian_messages';
 const _kReplyOutboxKey = 'notification_reply_outbox';
 
-/// IsolateNameServer port name for routing background replies to the live main
-/// isolate (foreground service keeps it alive even when no Activity is visible).
-const _kReplyPortName = 'meridian_notification_reply';
-
 /// Top-level handler for background/terminated-app inline reply and mark-read
 /// actions.
 ///
-/// When the foreground service is running, the main Dart isolate is alive and
-/// has registered [_kReplyPortName] — messages are routed directly via
-/// [IsolateNameServer] so they are processed immediately without touching the
-/// reply outbox.
+/// flutter_local_notifications spawns the background handler in a fresh
+/// FlutterEngine, so cross-isolate mechanisms like IsolateNameServer do not
+/// see the main isolate's registered ports. The reliable path is: queue the
+/// reply in SharedPreferences, let the main isolate drain it on resume (or on
+/// the next cold start via [NotificationService.initialize]).
 ///
-/// When the app is fully terminated, the outbox path is used instead and the
-/// spinner is cleared by cancelling the notification after plugin init.
+/// The Reply action uses [cancelNotification: true] so Android auto-dismisses
+/// the notification (and its RemoteInput spinner) the moment the user taps
+/// Send — no explicit cancel needed here.
 @pragma('vm:entry-point')
 void onNotificationBackgroundResponse(NotificationResponse response) async {
   if (response.notificationResponseType !=
       NotificationResponseType.selectedNotificationAction) {
     return;
   }
-  WidgetsFlutterBinding.ensureInitialized();
-  final callsign = response.payload ?? '';
+  if (response.actionId != _kReplyActionId) return;
 
-  // --- Mark as read ---
-  if (response.actionId == _kMarkReadActionId) {
-    final mainPort = IsolateNameServer.lookupPortByName(_kReplyPortName);
-    if (mainPort != null) {
-      mainPort.send({'action': 'mark_read', 'callsign': callsign});
-      return;
-    }
-    // Terminated — just dismiss the notification (no MessageService to call).
-    await _cancelNotificationForCallsign(callsign);
-    return;
-  }
-
-  // --- Inline reply ---
   final input = response.input;
-  if (input == null || input.isEmpty) return;
+  final callsign = response.payload ?? '';
+  if (input == null || input.isEmpty || callsign.isEmpty) return;
 
-  final mainPort = IsolateNameServer.lookupPortByName(_kReplyPortName);
-  if (mainPort != null) {
-    // Foreground service is running — route reply directly to main isolate.
-    mainPort.send({'action': 'reply', 'callsign': callsign, 'text': input});
-    return;
-  }
-
-  // Terminated-app fallback: queue in outbox, drain on next foreground resume.
+  WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
   final outbox = prefs.getStringList(_kReplyOutboxKey) ?? [];
   outbox.add(jsonEncode({'callsign': callsign, 'text': input}));
   await prefs.setStringList(_kReplyOutboxKey, outbox);
-
-  // Dismiss the spinner by cancelling the notification.
-  await _cancelNotificationForCallsign(callsign);
-}
-
-/// Cancels a per-callsign notification and the group summary.
-/// Initialises the plugin minimally when called from a background isolate.
-Future<void> _cancelNotificationForCallsign(String callsign) async {
-  final notifId = callsign.hashCode.abs() % 100000 + 1;
-  try {
-    final plugin = FlutterLocalNotificationsPlugin();
-    await plugin.initialize(
-      const InitializationSettings(
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-      ),
-    );
-    await plugin.cancel(notifId);
-    await plugin.cancel(_kGroupSummaryId);
-  } catch (_) {}
 }
 
 class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
@@ -134,15 +91,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Snapshot of per-callsign unread counts used to detect new messages.
   final _lastUnread = <String, int>{};
-
-  /// Index into [Conversation.messages] at which the current notification
-  /// thread started (i.e. the first message that triggered the notification).
-  /// Cleared when the user opens the thread via [setActiveThread].
-  final _notifStartIndex = <String, int>{};
-
-  /// ReceivePort registered under [_kReplyPortName] so the background handler
-  /// can route replies directly to the live main isolate.
-  ReceivePort? _replyPort;
 
   bool _initialized = false;
   bool _androidEnabled = true;
@@ -177,7 +125,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       }
     }
 
-    _registerReplyPort();
     await _drainReplyOutbox();
     _schedulePostFrameLaunchCheck();
 
@@ -187,41 +134,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     // new messages, not for all persisted unread counts on cold start.
     for (final conv in _messageService.conversations) {
       _lastUnread[conv.peerCallsign] = conv.unreadCount;
-    }
-  }
-
-  void _registerReplyPort() {
-    _replyPort = ReceivePort();
-    IsolateNameServer.removePortNameMapping(_kReplyPortName);
-    IsolateNameServer.registerPortWithName(
-      _replyPort!.sendPort,
-      _kReplyPortName,
-    );
-    _replyPort!.listen(_handleIsolateMessage);
-  }
-
-  void _handleIsolateMessage(dynamic message) {
-    if (message is! Map) return;
-    final action = message['action'] as String?;
-    final callsign = (message['callsign'] as String?) ?? '';
-    if (callsign.isEmpty) return;
-
-    if (action == 'reply') {
-      final text = (message['text'] as String?) ?? '';
-      if (text.isNotEmpty) {
-        _messageService.sendMessage(
-          callsign,
-          text,
-        ); // ignore: unawaited_futures
-        _postReplyUpdate(callsign); // ignore: unawaited_futures
-      }
-    } else if (action == 'mark_read') {
-      _messageService.markRead(callsign);
-      if (_initialized) {
-        final notifId = callsign.hashCode.abs() % 100000 + 1;
-        _plugin.cancel(notifId); // ignore: unawaited_futures
-        _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
-      }
     }
   }
 
@@ -332,7 +244,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       final notifId = callsign.hashCode.abs() % 100000 + 1;
       _plugin.cancel(notifId); // ignore: unawaited_futures
     }
-    _notifStartIndex.remove(callsign?.toUpperCase());
     _activeThreadCallsign = callsign?.toUpperCase();
   }
 
@@ -368,15 +279,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       final peer = conv.peerCallsign;
       final prevUnread = _lastUnread[peer] ?? 0;
       if (conv.unreadCount > prevUnread) {
-        // Record the thread anchor on the 0→1+ unread transition so the
-        // notification shows only messages from this notification event onward.
-        if (prevUnread == 0) {
-          final startIdx = (conv.messages.length - conv.unreadCount).clamp(
-            0,
-            conv.messages.length,
-          );
-          _notifStartIndex[peer.toUpperCase()] = startIdx;
-        }
         final lastMsg = conv.lastMessage;
         if (lastMsg != null && !lastMsg.isOutgoing) {
           _dispatchMessage(peer, lastMsg.text);
@@ -457,7 +359,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       playSound: withSound,
       enableVibration: withVibration,
       groupKey: _kGroupKey,
-      styleInformation: _buildMessagingStyle(callsign),
+      styleInformation: BigTextStyleInformation(preview),
       actions: [
         const AndroidNotificationAction(
           _kMarkReadActionId,
@@ -470,7 +372,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
           'Reply',
           inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
           showsUserInterface: false,
-          cancelNotification: false,
+          cancelNotification: true,
         ),
       ],
     );
@@ -492,75 +394,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         iOS: darwinDetails,
         macOS: darwinDetails,
       ),
-      payload: callsign,
-    );
-  }
-
-  /// Builds a [MessagingStyleInformation] anchored at the message that first
-  /// triggered the notification for this callsign.
-  ///
-  /// Reads directly from [MessageService] so the thread stays in sync without
-  /// a parallel state map. The [Person] for the peer uses only a key (no name
-  /// or icon) so Android does not render an avatar bubble.
-  MessagingStyleInformation _buildMessagingStyle(String callsign) {
-    final conv = _messageService.conversationWith(callsign);
-    final all = conv?.messages ?? [];
-    final startIdx =
-        _notifStartIndex[callsign.toUpperCase()] ??
-        (all.length > 10 ? all.length - 10 : 0);
-    final slice = startIdx < all.length ? all.sublist(startIdx) : all;
-
-    final peer = Person(name: callsign);
-    const me = Person(name: 'You');
-
-    return MessagingStyleInformation(
-      me,
-      groupConversation: false,
-      conversationTitle: callsign,
-      messages: slice
-          .map((m) => Message(m.text, m.timestamp, m.isOutgoing ? null : peer))
-          .toList(),
-    );
-  }
-
-  /// Re-posts the per-callsign notification after an outgoing reply so the
-  /// Android thread stays visible without playing sound or vibrating again.
-  Future<void> _postReplyUpdate(String callsign) async {
-    if (!_initialized || kIsWeb) return;
-    if (!Platform.isAndroid) return;
-
-    final notifId = callsign.hashCode.abs() % 100000 + 1;
-    final androidDetails = AndroidNotificationDetails(
-      NotificationChannels.messages,
-      'Messages',
-      channelDescription: 'Incoming APRS messages addressed to you.',
-      importance: Importance.defaultImportance,
-      priority: Priority.defaultPriority,
-      playSound: false,
-      enableVibration: false,
-      groupKey: _kGroupKey,
-      styleInformation: _buildMessagingStyle(callsign),
-      actions: [
-        const AndroidNotificationAction(
-          _kMarkReadActionId,
-          'Mark as read',
-          showsUserInterface: false,
-          cancelNotification: true,
-        ),
-        AndroidNotificationAction(
-          _kReplyActionId,
-          'Reply',
-          inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
-          showsUserInterface: false,
-          cancelNotification: false,
-        ),
-      ],
-    );
-    await _plugin.show(
-      notifId,
-      callsign,
-      'Message sent',
-      NotificationDetails(android: androidDetails),
       payload: callsign,
     );
   }
@@ -633,10 +466,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   @visibleForTesting
   Future<void> drainReplyOutboxForTest() => _drainReplyOutbox();
 
-  @visibleForTesting
-  MessagingStyleInformation buildMessagingStyleForTest(String callsign) =>
-      _buildMessagingStyle(callsign);
-
   void _onNotificationResponse(NotificationResponse response) {
     final callsign = response.payload ?? '';
 
@@ -659,7 +488,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
             callsign,
             input,
           ); // ignore: unawaited_futures
-          _postReplyUpdate(callsign); // ignore: unawaited_futures
         }
         return;
       }
@@ -697,6 +525,9 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   // ---------------------------------------------------------------------------
 
   Future<void> _drainReplyOutbox() async {
+    // Reload is required: the background handler (separate isolate/engine)
+    // writes to disk, but _prefs holds a stale in-memory cache until reloaded.
+    await _prefs.reload();
     final outbox = _prefs.getStringList(_kReplyOutboxKey);
     if (outbox == null || outbox.isEmpty) return;
     await _prefs.remove(_kReplyOutboxKey);
@@ -707,7 +538,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         final text = map['text'] as String? ?? '';
         if (callsign.isNotEmpty && text.isNotEmpty) {
           await _messageService.sendMessage(callsign, text);
-          await _postReplyUpdate(callsign);
         }
       } catch (e) {
         debugPrint('NotificationService: failed to drain reply: $e');
@@ -728,9 +558,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _messageService.removeListener(_onMessageServiceChange);
-    IsolateNameServer.removePortNameMapping(_kReplyPortName);
-    _replyPort?.close();
-    _replyPort = null;
     super.dispose();
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,525 @@
+/// Central notification dispatch service for Meridian APRS.
+///
+/// Subscribes to [MessageService] on the main Dart isolate (which stays alive
+/// on both Android via the foreground service and iOS via VoIP mode), detects
+/// new inbound messages, and dispatches system notifications and in-app banners.
+///
+/// See ADR-035 in docs/DECISIONS.md for the main-isolate dispatch rationale.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:local_notifier/local_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/notification_preferences.dart';
+import '../screens/message_thread_screen.dart';
+import '../ui/utils/platform_route.dart';
+import '../ui/widgets/in_app_banner_overlay.dart';
+import 'message_service.dart';
+
+/// Notification IDs.
+///
+/// Per-callsign IDs are derived from the callsign hash so repeated messages
+/// from the same peer replace the existing notification rather than stacking.
+/// The group summary uses a fixed ID so it can be updated in place.
+const _kGroupSummaryId = 0;
+const _kReplyActionId = 'reply';
+const _kGroupKey = 'meridian_messages';
+const _kReplyOutboxKey = 'notification_reply_outbox';
+
+/// Top-level handler for background/terminated-app inline reply actions.
+///
+/// Called by flutter_local_notifications when an Android [RemoteInput] action
+/// fires while the app is not in the foreground. Writes the reply to a
+/// SharedPreferences outbox; [NotificationService._drainReplyOutbox] processes
+/// it when the main isolate is next live.
+@pragma('vm:entry-point')
+void onNotificationBackgroundResponse(NotificationResponse response) async {
+  if (response.notificationResponseType !=
+      NotificationResponseType.selectedNotificationAction) {
+    return;
+  }
+  final input = response.input;
+  if (input == null || input.isEmpty) return;
+
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  final outbox = prefs.getStringList(_kReplyOutboxKey) ?? [];
+  outbox.add(jsonEncode({'callsign': response.payload ?? '', 'text': input}));
+  await prefs.setStringList(_kReplyOutboxKey, outbox);
+}
+
+class NotificationService extends ChangeNotifier {
+  NotificationService({
+    required MessageService messageService,
+    required SharedPreferences prefs,
+    required GlobalKey<NavigatorState> navigatorKey,
+    required InAppBannerController bannerController,
+  }) : _messageService = messageService,
+       _prefs = prefs,
+       _navigatorKey = navigatorKey,
+       _bannerController = bannerController;
+
+  final MessageService _messageService;
+  final SharedPreferences _prefs;
+  final GlobalKey<NavigatorState> _navigatorKey;
+  final InAppBannerController _bannerController;
+
+  final _plugin = FlutterLocalNotificationsPlugin();
+
+  NotificationPreferences _notifPrefs = NotificationPreferences.defaults();
+  NotificationPreferences get preferences => _notifPrefs;
+
+  /// Callsign of the thread currently open in [MessageThreadScreen], if any.
+  /// Set by [setActiveThread]; cleared on thread close.
+  String? _activeThreadCallsign;
+
+  /// Snapshot of per-callsign unread counts used to detect new messages.
+  final _lastUnread = <String, int>{};
+
+  bool _initialized = false;
+  bool _androidEnabled = true;
+  bool _desktopNotifierReady = false;
+
+  bool get notificationsEnabled =>
+      !kIsWeb && (Platform.isAndroid || Platform.isIOS)
+      ? _androidEnabled
+      : true;
+
+  // ---------------------------------------------------------------------------
+  // Initialization
+  // ---------------------------------------------------------------------------
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    _initialized = true;
+
+    _notifPrefs = await NotificationPreferences.load(_prefs);
+
+    if (!kIsWeb) {
+      if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
+        await _initMobileNotifications();
+      }
+      if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+        await localNotifier.setup(
+          appName: 'Meridian APRS',
+          shortcutPolicy: ShortcutPolicy.requireCreate,
+        );
+        _desktopNotifierReady = true;
+      }
+    }
+
+    await _drainReplyOutbox();
+    _schedulePostFrameLaunchCheck();
+
+    _messageService.addListener(_onMessageServiceChange);
+
+    // Seed the snapshot so the first notification fires only for genuinely
+    // new messages, not for all persisted unread counts on cold start.
+    for (final conv in _messageService.conversations) {
+      _lastUnread[conv.peerCallsign] = conv.unreadCount;
+    }
+  }
+
+  Future<void> _initMobileNotifications() async {
+    const androidSettings = AndroidInitializationSettings(
+      '@mipmap/ic_launcher',
+    );
+    final darwinSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+      notificationCategories: [
+        DarwinNotificationCategory(
+          NotificationChannels.messages,
+          actions: [
+            DarwinNotificationAction.text(
+              _kReplyActionId,
+              'Reply',
+              buttonTitle: 'Send',
+              placeholder: 'Your reply',
+            ),
+          ],
+          options: {DarwinNotificationCategoryOption.hiddenPreviewShowTitle},
+        ),
+        const DarwinNotificationCategory(NotificationChannels.alerts),
+        const DarwinNotificationCategory(NotificationChannels.nearby),
+        const DarwinNotificationCategory(NotificationChannels.system),
+      ],
+    );
+
+    final settings = InitializationSettings(
+      android: androidSettings,
+      iOS: darwinSettings,
+      macOS: darwinSettings,
+    );
+
+    await _plugin.initialize(
+      settings,
+      onDidReceiveNotificationResponse: _onNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse:
+          onNotificationBackgroundResponse,
+    );
+
+    if (!kIsWeb && Platform.isAndroid) {
+      await _registerAndroidChannels();
+      final androidPlugin = _plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >();
+      _androidEnabled = await androidPlugin?.areNotificationsEnabled() ?? true;
+    }
+  }
+
+  Future<void> _registerAndroidChannels() async {
+    final androidPlugin = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    if (androidPlugin == null) return;
+
+    const channels = [
+      AndroidNotificationChannel(
+        NotificationChannels.messages,
+        'Messages',
+        description: 'Incoming APRS messages addressed to you.',
+        importance: Importance.defaultImportance,
+        playSound: true,
+        enableVibration: true,
+      ),
+      AndroidNotificationChannel(
+        NotificationChannels.alerts,
+        'Alerts',
+        description: 'WX and NWS APRS alerts.',
+        importance: Importance.high,
+        playSound: true,
+        enableVibration: true,
+      ),
+      AndroidNotificationChannel(
+        NotificationChannels.nearby,
+        'Nearby',
+        description: 'Activity from stations in your area.',
+        importance: Importance.low,
+        playSound: false,
+        enableVibration: true,
+      ),
+      AndroidNotificationChannel(
+        NotificationChannels.system,
+        'System',
+        description: 'Connection and TNC status updates.',
+        importance: Importance.min,
+        playSound: false,
+        enableVibration: false,
+      ),
+    ];
+
+    for (final ch in channels) {
+      await androidPlugin.createNotificationChannel(ch);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Thread tracking (called from MessageThreadScreen)
+  // ---------------------------------------------------------------------------
+
+  void setActiveThread(String? callsign) {
+    _activeThreadCallsign = callsign?.toUpperCase();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Preferences
+  // ---------------------------------------------------------------------------
+
+  Future<void> setChannelEnabled(String channelId, bool enabled) async {
+    _notifPrefs = _notifPrefs.copyWithChannel(channelId, enabled);
+    await _notifPrefs.save(_prefs);
+    notifyListeners();
+  }
+
+  Future<void> setSoundEnabled(String channelId, bool enabled) async {
+    _notifPrefs = _notifPrefs.copyWithSound(channelId, enabled);
+    await _notifPrefs.save(_prefs);
+    notifyListeners();
+  }
+
+  Future<void> setVibrationEnabled(String channelId, bool enabled) async {
+    _notifPrefs = _notifPrefs.copyWithVibration(channelId, enabled);
+    await _notifPrefs.save(_prefs);
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // MessageService listener
+  // ---------------------------------------------------------------------------
+
+  void _onMessageServiceChange() {
+    final conversations = _messageService.conversations;
+    for (final conv in conversations) {
+      final peer = conv.peerCallsign;
+      final prevUnread = _lastUnread[peer] ?? 0;
+      if (conv.unreadCount > prevUnread) {
+        final lastMsg = conv.lastMessage;
+        if (lastMsg != null && !lastMsg.isOutgoing) {
+          _dispatchMessage(peer, lastMsg.text);
+        }
+      }
+      _lastUnread[peer] = conv.unreadCount;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dispatch
+  // ---------------------------------------------------------------------------
+
+  Future<void> _dispatchMessage(String callsign, String text) async {
+    if (!_notifPrefs.isChannelEnabled(NotificationChannels.messages)) return;
+
+    // In-app banner (fires regardless of foreground/background state,
+    // but not if the user is already looking at that thread).
+    if (_activeThreadCallsign?.toUpperCase() != callsign.toUpperCase()) {
+      _bannerController.show(callsign, text);
+    }
+
+    if (kIsWeb) return;
+
+    if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
+      await _dispatchMobileNotification(callsign, text);
+    } else if (Platform.isWindows || Platform.isLinux) {
+      await _dispatchDesktopNotification(callsign, text);
+    }
+  }
+
+  Future<void> _dispatchMobileNotification(String callsign, String text) async {
+    final withSound = _notifPrefs.isSoundEnabled(NotificationChannels.messages);
+    final withVibration = _notifPrefs.isVibrationEnabled(
+      NotificationChannels.messages,
+    );
+
+    // Count how many conversations currently have unread messages.
+    final unreadConvs = _messageService.conversations
+        .where((c) => c.unreadCount > 0)
+        .toList();
+
+    final notifId = callsign.hashCode.abs() % 100000 + 1;
+
+    if (unreadConvs.length >= 3) {
+      // Grouped InboxStyle summary.
+      await _dispatchGroupedNotification(unreadConvs, withSound, withVibration);
+    } else {
+      // Single BigTextStyle notification for this callsign.
+      await _dispatchSingleNotification(
+        notifId,
+        callsign,
+        text,
+        withSound,
+        withVibration,
+      );
+    }
+  }
+
+  Future<void> _dispatchSingleNotification(
+    int id,
+    String callsign,
+    String text,
+    bool withSound,
+    bool withVibration,
+  ) async {
+    final preview = text.length > 80 ? '${text.substring(0, 80)}…' : text;
+
+    final androidDetails = AndroidNotificationDetails(
+      NotificationChannels.messages,
+      'Messages',
+      channelDescription: 'Incoming APRS messages addressed to you.',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+      playSound: withSound,
+      enableVibration: withVibration,
+      groupKey: _kGroupKey,
+      styleInformation: BigTextStyleInformation(
+        text,
+        contentTitle: callsign,
+        summaryText: 'APRS Message',
+      ),
+      actions: [
+        AndroidNotificationAction(
+          _kReplyActionId,
+          'Reply',
+          inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
+          showsUserInterface: false,
+          cancelNotification: true,
+        ),
+      ],
+    );
+
+    final darwinDetails = DarwinNotificationDetails(
+      categoryIdentifier: NotificationChannels.messages,
+      presentAlert: true,
+      presentSound: withSound,
+      presentBadge: true,
+    );
+
+    await _plugin.show(
+      id,
+      callsign,
+      preview,
+      NotificationDetails(
+        android: androidDetails,
+        iOS: darwinDetails,
+        macOS: darwinDetails,
+      ),
+      payload: callsign,
+    );
+  }
+
+  Future<void> _dispatchGroupedNotification(
+    List<Conversation> unreadConvs,
+    bool withSound,
+    bool withVibration,
+  ) async {
+    final total = unreadConvs.fold<int>(0, (s, c) => s + c.unreadCount);
+    final lines = unreadConvs.map((c) {
+      final preview = c.lastMessage?.text ?? '';
+      return '${c.peerCallsign}: ${preview.length > 40 ? '${preview.substring(0, 40)}…' : preview}';
+    }).toList();
+
+    final androidDetails = AndroidNotificationDetails(
+      NotificationChannels.messages,
+      'Messages',
+      channelDescription: 'Incoming APRS messages addressed to you.',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+      playSound: withSound,
+      enableVibration: withVibration,
+      groupKey: _kGroupKey,
+      setAsGroupSummary: true,
+      styleInformation: InboxStyleInformation(
+        lines,
+        summaryText: '$total new APRS messages',
+      ),
+    );
+
+    await _plugin.show(
+      _kGroupSummaryId,
+      'Meridian APRS',
+      '$total new messages',
+      NotificationDetails(android: androidDetails),
+      payload: '',
+    );
+  }
+
+  Future<void> _dispatchDesktopNotification(
+    String callsign,
+    String text,
+  ) async {
+    if (!_desktopNotifierReady) return;
+    final preview = text.length > 80 ? '${text.substring(0, 80)}…' : text;
+    final notification = LocalNotification(title: callsign, body: preview);
+    notification.onClick = () => _navigateToThread(callsign);
+    await notification.show();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  void _navigateToThread(String callsign) {
+    final nav = _navigatorKey.currentState;
+    if (nav == null) return;
+    nav.push(
+      buildPlatformRoute((_) => MessageThreadScreen(peerCallsign: callsign)),
+    );
+  }
+
+  @visibleForTesting
+  void handleNotificationResponse(NotificationResponse response) =>
+      _onNotificationResponse(response);
+
+  @visibleForTesting
+  void handleMessageServiceChange() => _onMessageServiceChange();
+
+  @visibleForTesting
+  Future<void> drainReplyOutboxForTest() => _drainReplyOutbox();
+
+  void _onNotificationResponse(NotificationResponse response) {
+    final callsign = response.payload ?? '';
+
+    if (response.notificationResponseType ==
+        NotificationResponseType.selectedNotificationAction) {
+      // Inline reply action.
+      final input = response.input;
+      if (response.actionId == _kReplyActionId &&
+          input != null &&
+          input.isNotEmpty &&
+          callsign.isNotEmpty) {
+        _messageService.sendMessage(
+          callsign,
+          input,
+        ); // ignore: unawaited_futures
+      }
+      return;
+    }
+
+    // Regular tap — navigate to thread.
+    if (callsign.isNotEmpty) {
+      // Post-frame to let runApp() settle if we were cold-launched.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _navigateToThread(callsign);
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cold-start launch details
+  // ---------------------------------------------------------------------------
+
+  void _schedulePostFrameLaunchCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (kIsWeb) return;
+      if (!Platform.isAndroid && !Platform.isIOS) return;
+      try {
+        final details = await _plugin.getNotificationAppLaunchDetails();
+        if (details == null || !details.didNotificationLaunchApp) return;
+        final response = details.notificationResponse;
+        if (response != null) _onNotificationResponse(response);
+      } catch (_) {
+        // Plugin not initialized or platform error — silently ignore.
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reply outbox (terminated-app inline replies)
+  // ---------------------------------------------------------------------------
+
+  Future<void> _drainReplyOutbox() async {
+    final outbox = _prefs.getStringList(_kReplyOutboxKey);
+    if (outbox == null || outbox.isEmpty) return;
+    await _prefs.remove(_kReplyOutboxKey);
+    for (final entry in outbox) {
+      try {
+        final map = jsonDecode(entry) as Map<String, dynamic>;
+        final callsign = map['callsign'] as String? ?? '';
+        final text = map['text'] as String? ?? '';
+        if (callsign.isNotEmpty && text.isNotEmpty) {
+          await _messageService.sendMessage(callsign, text);
+        }
+      } catch (e) {
+        debugPrint('NotificationService: failed to drain reply: $e');
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+
+  @override
+  void dispose() {
+    _messageService.removeListener(_onMessageServiceChange);
+    super.dispose();
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -304,6 +304,25 @@ class NotificationService extends ChangeNotifier {
     }
   }
 
+  MessagingStyleInformation _buildMessagingStyle(String callsign) {
+    const mePerson = Person(name: 'You', bot: true);
+    final peerPerson = Person(name: callsign, bot: true);
+
+    final conv = _messageService.conversationWith(callsign);
+    final all = conv?.messages ?? [];
+    final recent = all.length > 6 ? all.sublist(all.length - 6) : all;
+
+    return MessagingStyleInformation(
+      mePerson,
+      messages: recent.map((m) {
+        final body = m.text.length > 80
+            ? '${m.text.substring(0, 80)}…'
+            : m.text;
+        return Message(body, m.timestamp, m.isOutgoing ? null : peerPerson);
+      }).toList(),
+    );
+  }
+
   Future<void> _dispatchSingleNotification(
     int id,
     String callsign,
@@ -311,8 +330,6 @@ class NotificationService extends ChangeNotifier {
     bool withSound,
     bool withVibration,
   ) async {
-    final preview = text.length > 80 ? '${text.substring(0, 80)}…' : text;
-
     final androidDetails = AndroidNotificationDetails(
       NotificationChannels.messages,
       'Messages',
@@ -322,7 +339,7 @@ class NotificationService extends ChangeNotifier {
       playSound: withSound,
       enableVibration: withVibration,
       groupKey: _kGroupKey,
-      styleInformation: BigTextStyleInformation(preview),
+      styleInformation: _buildMessagingStyle(callsign),
       actions: [
         const AndroidNotificationAction(
           _kMarkReadActionId,
@@ -348,6 +365,7 @@ class NotificationService extends ChangeNotifier {
       presentBadge: true,
     );
 
+    final preview = text.length > 80 ? '${text.substring(0, 80)}…' : text;
     await _plugin.show(
       id,
       callsign,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -237,6 +237,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         DarwinNotificationCategory(
           NotificationChannels.messages,
           actions: [
+            DarwinNotificationAction.plain(_kMarkReadActionId, 'Mark as Read'),
             DarwinNotificationAction.text(
               _kReplyActionId,
               'Reply',
@@ -470,6 +471,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
 
     final darwinDetails = DarwinNotificationDetails(
       categoryIdentifier: NotificationChannels.messages,
+      threadIdentifier: callsign,
       presentAlert: true,
       presentSound: withSound,
       presentBadge: true,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -229,16 +229,13 @@ class NotificationService extends ChangeNotifier {
         final text = call.arguments['text'] as String;
         final notifId = call.arguments['notificationId'] as int;
         await _messageService.sendMessage(callsign, text);
-        // Re-post with alertOnce:true so the spinner dismisses without heads-up.
-        if (!kIsWeb && Platform.isAndroid) {
-          await _dispatchAndroidNotification(
-            notifId,
-            callsign,
-            _notifPrefs.isSoundEnabled(NotificationChannels.messages),
-            _notifPrefs.isVibrationEnabled(NotificationChannels.messages),
-            alertOnce: true,
-          );
-        }
+        // Re-post with alertOnce:true so the spinner clears without heads-up.
+        await _dispatchAndroidNotification(
+          notifId,
+          callsign,
+          _notifPrefs.isSoundEnabled(NotificationChannels.messages),
+          alertOnce: true,
+        );
 
       case 'handleMarkRead':
         final callsign = call.arguments['callsign'] as String;
@@ -368,12 +365,7 @@ class NotificationService extends ChangeNotifier {
 
     if (!kIsWeb && Platform.isAndroid) {
       // Android: post natively so inline reply works without opening the app.
-      await _dispatchAndroidNotification(
-        notifId,
-        callsign,
-        withSound,
-        withVibration,
-      );
+      await _dispatchAndroidNotification(notifId, callsign, withSound);
 
       // Group summary for 2+ unread conversations.
       final unreadConvs = _messageService.conversations
@@ -400,8 +392,7 @@ class NotificationService extends ChangeNotifier {
   Future<void> _dispatchAndroidNotification(
     int id,
     String callsign,
-    bool withSound,
-    bool withVibration, {
+    bool withSound, {
     bool alertOnce = false,
   }) async {
     final conv = _messageService.conversationWith(callsign);
@@ -437,7 +428,6 @@ class NotificationService extends ChangeNotifier {
         'notificationId': id,
         'messages': messages,
         'withSound': withSound,
-        'withVibration': withVibration,
         'alertOnce': alertOnce,
       });
     } catch (_) {}
@@ -581,9 +571,9 @@ class NotificationService extends ChangeNotifier {
 
   void _schedulePostFrameLaunchCheck() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (kIsWeb) return;
-      if (!Platform.isAndroid && !Platform.isIOS) return;
-      if (Platform.isAndroid) return; // Android uses _schedulePendingNavCheck.
+      // Android uses _schedulePendingNavCheck (pull model via MainActivity).
+      // All other platforms and web don't need this check.
+      if (kIsWeb || !Platform.isIOS) return;
       try {
         final details = await _plugin.getNotificationAppLaunchDetails();
         if (details == null || !details.didNotificationLaunchApp) return;

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -8,7 +8,6 @@
 library;
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
@@ -32,40 +31,8 @@ const _kGroupSummaryId = 0;
 const _kReplyActionId = 'reply';
 const _kMarkReadActionId = 'mark_read';
 const _kGroupKey = 'meridian_messages';
-const _kReplyOutboxKey = 'notification_reply_outbox';
 
-/// Top-level handler for background/terminated-app inline reply and mark-read
-/// actions.
-///
-/// flutter_local_notifications spawns the background handler in a fresh
-/// FlutterEngine, so cross-isolate mechanisms like IsolateNameServer do not
-/// see the main isolate's registered ports. The reliable path is: queue the
-/// reply in SharedPreferences, let the main isolate drain it on resume (or on
-/// the next cold start via [NotificationService.initialize]).
-///
-/// The Reply action uses [cancelNotification: true] so Android auto-dismisses
-/// the notification (and its RemoteInput spinner) the moment the user taps
-/// Send — no explicit cancel needed here.
-@pragma('vm:entry-point')
-void onNotificationBackgroundResponse(NotificationResponse response) async {
-  if (response.notificationResponseType !=
-      NotificationResponseType.selectedNotificationAction) {
-    return;
-  }
-  if (response.actionId != _kReplyActionId) return;
-
-  final input = response.input;
-  final callsign = response.payload ?? '';
-  if (input == null || input.isEmpty || callsign.isEmpty) return;
-
-  WidgetsFlutterBinding.ensureInitialized();
-  final prefs = await SharedPreferences.getInstance();
-  final outbox = prefs.getStringList(_kReplyOutboxKey) ?? [];
-  outbox.add(jsonEncode({'callsign': callsign, 'text': input}));
-  await prefs.setStringList(_kReplyOutboxKey, outbox);
-}
-
-class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
+class NotificationService extends ChangeNotifier {
   NotificationService({
     required MessageService messageService,
     required SharedPreferences prefs,
@@ -109,7 +76,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     if (_initialized) return;
     _initialized = true;
 
-    WidgetsBinding.instance.addObserver(this);
     _notifPrefs = await NotificationPreferences.load(_prefs);
 
     if (!kIsWeb) {
@@ -125,7 +91,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       }
     }
 
-    await _drainReplyOutbox();
     _schedulePostFrameLaunchCheck();
 
     _messageService.addListener(_onMessageServiceChange);
@@ -174,8 +139,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     await _plugin.initialize(
       settings,
       onDidReceiveNotificationResponse: _onNotificationResponse,
-      onDidReceiveBackgroundNotificationResponse:
-          onNotificationBackgroundResponse,
     );
 
     if (!kIsWeb && Platform.isAndroid) {
@@ -242,7 +205,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   void setActiveThread(String? callsign) {
     if (callsign != null && _initialized) {
       final notifId = callsign.hashCode.abs() % 100000 + 1;
-      _plugin.cancel(notifId); // ignore: unawaited_futures
+      _plugin.cancel(notifId).catchError((_) {}); // ignore: unawaited_futures
     }
     _activeThreadCallsign = callsign?.toUpperCase();
   }
@@ -371,7 +334,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
           _kReplyActionId,
           'Reply',
           inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
-          showsUserInterface: false,
+          showsUserInterface: true,
           cancelNotification: true,
         ),
       ],
@@ -463,9 +426,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   @visibleForTesting
   void handleMessageServiceChange() => _onMessageServiceChange();
 
-  @visibleForTesting
-  Future<void> drainReplyOutboxForTest() => _drainReplyOutbox();
-
   void _onNotificationResponse(NotificationResponse response) {
     final callsign = response.payload ?? '';
 
@@ -520,43 +480,8 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     });
   }
 
-  // ---------------------------------------------------------------------------
-  // Reply outbox (terminated-app inline replies)
-  // ---------------------------------------------------------------------------
-
-  Future<void> _drainReplyOutbox() async {
-    // Reload is required: the background handler (separate isolate/engine)
-    // writes to disk, but _prefs holds a stale in-memory cache until reloaded.
-    await _prefs.reload();
-    final outbox = _prefs.getStringList(_kReplyOutboxKey);
-    if (outbox == null || outbox.isEmpty) return;
-    await _prefs.remove(_kReplyOutboxKey);
-    for (final entry in outbox) {
-      try {
-        final map = jsonDecode(entry) as Map<String, dynamic>;
-        final callsign = map['callsign'] as String? ?? '';
-        final text = map['text'] as String? ?? '';
-        if (callsign.isNotEmpty && text.isNotEmpty) {
-          await _messageService.sendMessage(callsign, text);
-        }
-      } catch (e) {
-        debugPrint('NotificationService: failed to drain reply: $e');
-      }
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _drainReplyOutbox(); // ignore: unawaited_futures
-    }
-  }
-
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
     _messageService.removeListener(_onMessageServiceChange);
     super.dispose();
   }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -66,6 +66,12 @@ class NotificationService extends ChangeNotifier {
   /// Snapshot of per-callsign unread counts used to detect new messages.
   final _lastUnread = <String, int>{};
 
+  /// Per-callsign index into the messages list marking where the current
+  /// notification session started. Only messages at or after this index are
+  /// shown in the notification. Reset when the notification is dismissed,
+  /// mark-as-read, or the thread is opened.
+  final _notifAnchor = <String, int>{};
+
   bool _initialized = false;
   bool _androidEnabled = true;
   bool _desktopNotifierReady = false;
@@ -237,6 +243,7 @@ class NotificationService extends ChangeNotifier {
       case 'handleMarkRead':
         final callsign = call.arguments['callsign'] as String;
         _messageService.markRead(callsign);
+        _notifAnchor.remove(callsign);
         // Cancel group summary if fewer than 2 conversations remain unread.
         final remaining = _messageService.conversations
             .where((c) => c.unreadCount > 0)
@@ -246,6 +253,10 @@ class NotificationService extends ChangeNotifier {
               .cancel(_kGroupSummaryId)
               .catchError((_) {}); // ignore: unawaited_futures
         }
+
+      case 'handleDismissed':
+        final callsign = call.arguments['callsign'] as String;
+        _notifAnchor.remove(callsign);
 
       case 'navigateToThread':
         final callsign = call.arguments['callsign'] as String;
@@ -280,6 +291,7 @@ class NotificationService extends ChangeNotifier {
     if (callsign != null && _initialized) {
       final notifId = callsign.hashCode.abs() % 100000 + 1;
       _plugin.cancel(notifId).catchError((_) {}); // ignore: unawaited_futures
+      _notifAnchor.remove(callsign);
     }
     _activeThreadCallsign = callsign?.toUpperCase();
   }
@@ -394,7 +406,21 @@ class NotificationService extends ChangeNotifier {
   }) async {
     final conv = _messageService.conversationWith(callsign);
     final all = conv?.messages ?? [];
-    final recent = all.length > 6 ? all.sublist(all.length - 6) : all;
+
+    // Set the anchor to the triggering message on the first dispatch, then
+    // keep it so subsequent messages accumulate while the notification is open.
+    // Cleared on dismiss, mark-as-read, or thread open — so the next message
+    // always starts a fresh notification with no pre-dismissal history.
+    if (!_notifAnchor.containsKey(callsign) && all.isNotEmpty) {
+      _notifAnchor[callsign] = all.length - 1;
+    }
+    final anchor = _notifAnchor[callsign] ?? (all.isEmpty ? 0 : all.length - 1);
+    final fromAnchor = anchor < all.length
+        ? all.sublist(anchor)
+        : (all.isNotEmpty ? [all.last] : []);
+    final recent = fromAnchor.length > 6
+        ? fromAnchor.sublist(fromAnchor.length - 6)
+        : fromAnchor;
 
     final messages = recent.map((m) {
       final body = m.text.length > 80 ? '${m.text.substring(0, 80)}…' : m.text;

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -10,6 +10,8 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
+import 'dart:isolate';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -30,36 +32,80 @@ import 'message_service.dart';
 /// The group summary uses a fixed ID so it can be updated in place.
 const _kGroupSummaryId = 0;
 const _kReplyActionId = 'reply';
+const _kMarkReadActionId = 'mark_read';
 const _kGroupKey = 'meridian_messages';
 const _kReplyOutboxKey = 'notification_reply_outbox';
 
-/// Top-level handler for background/terminated-app inline reply actions.
+/// IsolateNameServer port name for routing background replies to the live main
+/// isolate (foreground service keeps it alive even when no Activity is visible).
+const _kReplyPortName = 'meridian_notification_reply';
+
+/// Top-level handler for background/terminated-app inline reply and mark-read
+/// actions.
 ///
-/// Called by flutter_local_notifications when an Android [RemoteInput] action
-/// fires while the app is not in the foreground. Writes the reply to a
-/// SharedPreferences outbox; [NotificationService._drainReplyOutbox] processes
-/// it when the main isolate is next live.
+/// When the foreground service is running, the main Dart isolate is alive and
+/// has registered [_kReplyPortName] — messages are routed directly via
+/// [IsolateNameServer] so they are processed immediately without touching the
+/// reply outbox.
+///
+/// When the app is fully terminated, the outbox path is used instead and the
+/// spinner is cleared by cancelling the notification after plugin init.
 @pragma('vm:entry-point')
 void onNotificationBackgroundResponse(NotificationResponse response) async {
   if (response.notificationResponseType !=
       NotificationResponseType.selectedNotificationAction) {
     return;
   }
+  WidgetsFlutterBinding.ensureInitialized();
+  final callsign = response.payload ?? '';
+
+  // --- Mark as read ---
+  if (response.actionId == _kMarkReadActionId) {
+    final mainPort = IsolateNameServer.lookupPortByName(_kReplyPortName);
+    if (mainPort != null) {
+      mainPort.send({'action': 'mark_read', 'callsign': callsign});
+      return;
+    }
+    // Terminated — just dismiss the notification (no MessageService to call).
+    await _cancelNotificationForCallsign(callsign);
+    return;
+  }
+
+  // --- Inline reply ---
   final input = response.input;
   if (input == null || input.isEmpty) return;
 
-  WidgetsFlutterBinding.ensureInitialized();
+  final mainPort = IsolateNameServer.lookupPortByName(_kReplyPortName);
+  if (mainPort != null) {
+    // Foreground service is running — route reply directly to main isolate.
+    mainPort.send({'action': 'reply', 'callsign': callsign, 'text': input});
+    return;
+  }
+
+  // Terminated-app fallback: queue in outbox, drain on next foreground resume.
   final prefs = await SharedPreferences.getInstance();
   final outbox = prefs.getStringList(_kReplyOutboxKey) ?? [];
-  outbox.add(jsonEncode({'callsign': response.payload ?? '', 'text': input}));
+  outbox.add(jsonEncode({'callsign': callsign, 'text': input}));
   await prefs.setStringList(_kReplyOutboxKey, outbox);
 
-  // Dismiss the notification so Android clears the inline-reply spinner.
-  final callsign = response.payload ?? '';
+  // Dismiss the spinner by cancelling the notification.
+  await _cancelNotificationForCallsign(callsign);
+}
+
+/// Cancels a per-callsign notification and the group summary.
+/// Initialises the plugin minimally when called from a background isolate.
+Future<void> _cancelNotificationForCallsign(String callsign) async {
   final notifId = callsign.hashCode.abs() % 100000 + 1;
-  final plugin = FlutterLocalNotificationsPlugin();
-  await plugin.cancel(notifId);
-  await plugin.cancel(_kGroupSummaryId);
+  try {
+    final plugin = FlutterLocalNotificationsPlugin();
+    await plugin.initialize(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      ),
+    );
+    await plugin.cancel(notifId);
+    await plugin.cancel(_kGroupSummaryId);
+  } catch (_) {}
 }
 
 class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
@@ -84,11 +130,19 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   NotificationPreferences get preferences => _notifPrefs;
 
   /// Callsign of the thread currently open in [MessageThreadScreen], if any.
-  /// Set by [setActiveThread]; cleared on thread close.
   String? _activeThreadCallsign;
 
   /// Snapshot of per-callsign unread counts used to detect new messages.
   final _lastUnread = <String, int>{};
+
+  /// Index into [Conversation.messages] at which the current notification
+  /// thread started (i.e. the first message that triggered the notification).
+  /// Cleared when the user opens the thread via [setActiveThread].
+  final _notifStartIndex = <String, int>{};
+
+  /// ReceivePort registered under [_kReplyPortName] so the background handler
+  /// can route replies directly to the live main isolate.
+  ReceivePort? _replyPort;
 
   bool _initialized = false;
   bool _androidEnabled = true;
@@ -123,6 +177,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       }
     }
 
+    _registerReplyPort();
     await _drainReplyOutbox();
     _schedulePostFrameLaunchCheck();
 
@@ -132,6 +187,41 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     // new messages, not for all persisted unread counts on cold start.
     for (final conv in _messageService.conversations) {
       _lastUnread[conv.peerCallsign] = conv.unreadCount;
+    }
+  }
+
+  void _registerReplyPort() {
+    _replyPort = ReceivePort();
+    IsolateNameServer.removePortNameMapping(_kReplyPortName);
+    IsolateNameServer.registerPortWithName(
+      _replyPort!.sendPort,
+      _kReplyPortName,
+    );
+    _replyPort!.listen(_handleIsolateMessage);
+  }
+
+  void _handleIsolateMessage(dynamic message) {
+    if (message is! Map) return;
+    final action = message['action'] as String?;
+    final callsign = (message['callsign'] as String?) ?? '';
+    if (callsign.isEmpty) return;
+
+    if (action == 'reply') {
+      final text = (message['text'] as String?) ?? '';
+      if (text.isNotEmpty) {
+        _messageService.sendMessage(
+          callsign,
+          text,
+        ); // ignore: unawaited_futures
+        _postReplyUpdate(callsign); // ignore: unawaited_futures
+      }
+    } else if (action == 'mark_read') {
+      _messageService.markRead(callsign);
+      if (_initialized) {
+        final notifId = callsign.hashCode.abs() % 100000 + 1;
+        _plugin.cancel(notifId); // ignore: unawaited_futures
+        _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
+      }
     }
   }
 
@@ -241,6 +331,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       final notifId = callsign.hashCode.abs() % 100000 + 1;
       _plugin.cancel(notifId); // ignore: unawaited_futures
     }
+    _notifStartIndex.remove(callsign?.toUpperCase());
     _activeThreadCallsign = callsign?.toUpperCase();
   }
 
@@ -276,6 +367,15 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       final peer = conv.peerCallsign;
       final prevUnread = _lastUnread[peer] ?? 0;
       if (conv.unreadCount > prevUnread) {
+        // Record the thread anchor on the 0→1+ unread transition so the
+        // notification shows only messages from this notification event onward.
+        if (prevUnread == 0) {
+          final startIdx = (conv.messages.length - conv.unreadCount).clamp(
+            0,
+            conv.messages.length,
+          );
+          _notifStartIndex[peer.toUpperCase()] = startIdx;
+        }
         final lastMsg = conv.lastMessage;
         if (lastMsg != null && !lastMsg.isOutgoing) {
           _dispatchMessage(peer, lastMsg.text);
@@ -313,7 +413,6 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       NotificationChannels.messages,
     );
 
-    // Count how many conversations currently have unread messages.
     final unreadConvs = _messageService.conversations
         .where((c) => c.unreadCount > 0)
         .toList();
@@ -321,10 +420,8 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     final notifId = callsign.hashCode.abs() % 100000 + 1;
 
     if (unreadConvs.length >= 3) {
-      // Grouped InboxStyle summary.
       await _dispatchGroupedNotification(unreadConvs, withSound, withVibration);
     } else {
-      // Single BigTextStyle notification for this callsign.
       await _dispatchSingleNotification(
         notifId,
         callsign,
@@ -355,6 +452,12 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       groupKey: _kGroupKey,
       styleInformation: _buildMessagingStyle(callsign),
       actions: [
+        const AndroidNotificationAction(
+          _kMarkReadActionId,
+          'Mark as read',
+          showsUserInterface: false,
+          cancelNotification: true,
+        ),
         AndroidNotificationAction(
           _kReplyActionId,
           'Reply',
@@ -385,21 +488,28 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     );
   }
 
-  /// Builds a [MessagingStyleInformation] from the live conversation history.
+  /// Builds a [MessagingStyleInformation] anchored at the message that first
+  /// triggered the notification for this callsign.
   ///
-  /// Reads the last 10 messages from [MessageService] so the notification
-  /// thread stays in sync without a parallel state map.
+  /// Reads directly from [MessageService] so the thread stays in sync without
+  /// a parallel state map. The [Person] for the peer uses only a key (no name
+  /// or icon) so Android does not render an avatar bubble.
   MessagingStyleInformation _buildMessagingStyle(String callsign) {
     final conv = _messageService.conversationWith(callsign);
     final all = conv?.messages ?? [];
-    final recent = all.length > 10 ? all.sublist(all.length - 10) : all;
-    final peer = Person(name: callsign);
-    final me = Person(name: 'You');
+    final startIdx =
+        _notifStartIndex[callsign.toUpperCase()] ??
+        (all.length > 10 ? all.length - 10 : 0);
+    final slice = startIdx < all.length ? all.sublist(startIdx) : all;
+
+    final peer = Person(key: callsign);
+    const me = Person(key: 'me');
+
     return MessagingStyleInformation(
       me,
       groupConversation: false,
       conversationTitle: callsign,
-      messages: recent
+      messages: slice
           .map((m) => Message(m.text, m.timestamp, m.isOutgoing ? null : peer))
           .toList(),
     );
@@ -423,6 +533,12 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       groupKey: _kGroupKey,
       styleInformation: _buildMessagingStyle(callsign),
       actions: [
+        const AndroidNotificationAction(
+          _kMarkReadActionId,
+          'Mark as read',
+          showsUserInterface: false,
+          cancelNotification: true,
+        ),
         AndroidNotificationAction(
           _kReplyActionId,
           'Reply',
@@ -519,26 +635,33 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
 
     if (response.notificationResponseType ==
         NotificationResponseType.selectedNotificationAction) {
-      // Inline reply action.
-      final input = response.input;
-      if (response.actionId == _kReplyActionId &&
-          input != null &&
-          input.isNotEmpty &&
-          callsign.isNotEmpty) {
-        _messageService.sendMessage(
-          callsign,
-          input,
-        ); // ignore: unawaited_futures
-        // Re-post the notification with the reply appended so the thread stays
-        // visible; this also clears the Android inline-reply spinner.
-        _postReplyUpdate(callsign); // ignore: unawaited_futures
+      if (response.actionId == _kMarkReadActionId && callsign.isNotEmpty) {
+        _messageService.markRead(callsign);
+        // cancelNotification: true on the action dismisses the notification
+        // automatically; also clear the group summary to be safe.
+        if (_initialized) {
+          _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
+        }
+        return;
       }
+
+      if (response.actionId == _kReplyActionId) {
+        final input = response.input;
+        if (input != null && input.isNotEmpty && callsign.isNotEmpty) {
+          _messageService.sendMessage(
+            callsign,
+            input,
+          ); // ignore: unawaited_futures
+          _postReplyUpdate(callsign); // ignore: unawaited_futures
+        }
+        return;
+      }
+
       return;
     }
 
     // Regular tap — navigate to thread.
     if (callsign.isNotEmpty) {
-      // Post-frame to let runApp() settle if we were cold-launched.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _navigateToThread(callsign);
       });
@@ -558,9 +681,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         if (details == null || !details.didNotificationLaunchApp) return;
         final response = details.notificationResponse;
         if (response != null) _onNotificationResponse(response);
-      } catch (_) {
-        // Plugin not initialized or platform error — silently ignore.
-      }
+      } catch (_) {}
     });
   }
 
@@ -600,6 +721,9 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _messageService.removeListener(_onMessageServiceChange);
+    IsolateNameServer.removePortNameMapping(_kReplyPortName);
+    _replyPort?.close();
+    _replyPort = null;
     super.dispose();
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -62,7 +62,7 @@ void onNotificationBackgroundResponse(NotificationResponse response) async {
   await plugin.cancel(_kGroupSummaryId);
 }
 
-class NotificationService extends ChangeNotifier {
+class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   NotificationService({
     required MessageService messageService,
     required SharedPreferences prefs,
@@ -107,6 +107,7 @@ class NotificationService extends ChangeNotifier {
     if (_initialized) return;
     _initialized = true;
 
+    WidgetsBinding.instance.addObserver(this);
     _notifPrefs = await NotificationPreferences.load(_prefs);
 
     if (!kIsWeb) {
@@ -531,7 +532,15 @@ class NotificationService extends ChangeNotifier {
   // ---------------------------------------------------------------------------
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _drainReplyOutbox(); // ignore: unawaited_futures
+    }
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _messageService.removeListener(_onMessageServiceChange);
     super.dispose();
   }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -414,22 +414,28 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       NotificationChannels.messages,
     );
 
+    final notifId = callsign.hashCode.abs() % 100000 + 1;
+
+    // Always post/update the per-callsign notification so the new-message
+    // heads-up alert fires regardless of how many other conversations are
+    // unread. Replacing an existing notification by the same ID still triggers
+    // heads-up on Android when there is new content.
+    await _dispatchSingleNotification(
+      notifId,
+      callsign,
+      text,
+      withSound,
+      withVibration,
+    );
+
+    // When multiple conversations are unread, also post a silent group summary
+    // so Android groups them in the shade — matching the Google Messages model
+    // of one summary + N individual conversation notifications.
     final unreadConvs = _messageService.conversations
         .where((c) => c.unreadCount > 0)
         .toList();
-
-    final notifId = callsign.hashCode.abs() % 100000 + 1;
-
-    if (unreadConvs.length >= 3) {
-      await _dispatchGroupedNotification(unreadConvs, withSound, withVibration);
-    } else {
-      await _dispatchSingleNotification(
-        notifId,
-        callsign,
-        text,
-        withSound,
-        withVibration,
-      );
+    if (unreadConvs.length >= 2) {
+      await _dispatchGroupSummary(unreadConvs);
     }
   }
 
@@ -559,11 +565,10 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
     );
   }
 
-  Future<void> _dispatchGroupedNotification(
-    List<Conversation> unreadConvs,
-    bool withSound,
-    bool withVibration,
-  ) async {
+  /// Posts a silent Android group summary so the notification shade groups all
+  /// per-callsign notifications together. Does not play sound or vibrate —
+  /// the per-callsign notification already alerted the user.
+  Future<void> _dispatchGroupSummary(List<Conversation> unreadConvs) async {
     final total = unreadConvs.fold<int>(0, (s, c) => s + c.unreadCount);
     final lines = unreadConvs.map((c) {
       final preview = c.lastMessage?.text ?? '';
@@ -576,8 +581,8 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       channelDescription: 'Incoming APRS messages addressed to you.',
       importance: Importance.defaultImportance,
       priority: Priority.defaultPriority,
-      playSound: withSound,
-      enableVibration: withVibration,
+      playSound: false,
+      enableVibration: false,
       groupKey: _kGroupKey,
       setAsGroupSummary: true,
       styleInformation: InboxStyleInformation(

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -53,6 +53,13 @@ void onNotificationBackgroundResponse(NotificationResponse response) async {
   final outbox = prefs.getStringList(_kReplyOutboxKey) ?? [];
   outbox.add(jsonEncode({'callsign': response.payload ?? '', 'text': input}));
   await prefs.setStringList(_kReplyOutboxKey, outbox);
+
+  // Dismiss the notification so Android clears the inline-reply spinner.
+  final callsign = response.payload ?? '';
+  final notifId = callsign.hashCode.abs() % 100000 + 1;
+  final plugin = FlutterLocalNotificationsPlugin();
+  await plugin.cancel(notifId);
+  await plugin.cancel(_kGroupSummaryId);
 }
 
 class NotificationService extends ChangeNotifier {
@@ -461,6 +468,12 @@ class NotificationService extends ChangeNotifier {
           callsign,
           input,
         ); // ignore: unawaited_futures
+        // Dismiss the notification so Android clears the inline-reply spinner.
+        if (_initialized) {
+          final notifId = callsign.hashCode.abs() % 100000 + 1;
+          _plugin.cancel(notifId); // ignore: unawaited_futures
+          _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
+        }
       }
       return;
     }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -237,6 +237,10 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   // ---------------------------------------------------------------------------
 
   void setActiveThread(String? callsign) {
+    if (callsign != null && _initialized) {
+      final notifId = callsign.hashCode.abs() % 100000 + 1;
+      _plugin.cancel(notifId); // ignore: unawaited_futures
+    }
     _activeThreadCallsign = callsign?.toUpperCase();
   }
 
@@ -349,18 +353,14 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
       playSound: withSound,
       enableVibration: withVibration,
       groupKey: _kGroupKey,
-      styleInformation: BigTextStyleInformation(
-        text,
-        contentTitle: callsign,
-        summaryText: 'APRS Message',
-      ),
+      styleInformation: _buildMessagingStyle(callsign),
       actions: [
         AndroidNotificationAction(
           _kReplyActionId,
           'Reply',
           inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
           showsUserInterface: false,
-          cancelNotification: true,
+          cancelNotification: false,
         ),
       ],
     );
@@ -381,6 +381,62 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         iOS: darwinDetails,
         macOS: darwinDetails,
       ),
+      payload: callsign,
+    );
+  }
+
+  /// Builds a [MessagingStyleInformation] from the live conversation history.
+  ///
+  /// Reads the last 10 messages from [MessageService] so the notification
+  /// thread stays in sync without a parallel state map.
+  MessagingStyleInformation _buildMessagingStyle(String callsign) {
+    final conv = _messageService.conversationWith(callsign);
+    final all = conv?.messages ?? [];
+    final recent = all.length > 10 ? all.sublist(all.length - 10) : all;
+    final peer = Person(name: callsign);
+    final me = Person(name: 'You');
+    return MessagingStyleInformation(
+      me,
+      groupConversation: false,
+      conversationTitle: callsign,
+      messages: recent
+          .map((m) => Message(m.text, m.timestamp, m.isOutgoing ? null : peer))
+          .toList(),
+    );
+  }
+
+  /// Re-posts the per-callsign notification after an outgoing reply so the
+  /// Android thread stays visible without playing sound or vibrating again.
+  Future<void> _postReplyUpdate(String callsign) async {
+    if (!_initialized || kIsWeb) return;
+    if (!Platform.isAndroid) return;
+
+    final notifId = callsign.hashCode.abs() % 100000 + 1;
+    final androidDetails = AndroidNotificationDetails(
+      NotificationChannels.messages,
+      'Messages',
+      channelDescription: 'Incoming APRS messages addressed to you.',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+      playSound: false,
+      enableVibration: false,
+      groupKey: _kGroupKey,
+      styleInformation: _buildMessagingStyle(callsign),
+      actions: [
+        AndroidNotificationAction(
+          _kReplyActionId,
+          'Reply',
+          inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
+          showsUserInterface: false,
+          cancelNotification: false,
+        ),
+      ],
+    );
+    await _plugin.show(
+      notifId,
+      callsign,
+      'Message sent',
+      NotificationDetails(android: androidDetails),
       payload: callsign,
     );
   }
@@ -454,6 +510,10 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
   @visibleForTesting
   Future<void> drainReplyOutboxForTest() => _drainReplyOutbox();
 
+  @visibleForTesting
+  MessagingStyleInformation buildMessagingStyleForTest(String callsign) =>
+      _buildMessagingStyle(callsign);
+
   void _onNotificationResponse(NotificationResponse response) {
     final callsign = response.payload ?? '';
 
@@ -469,12 +529,9 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
           callsign,
           input,
         ); // ignore: unawaited_futures
-        // Dismiss the notification so Android clears the inline-reply spinner.
-        if (_initialized) {
-          final notifId = callsign.hashCode.abs() % 100000 + 1;
-          _plugin.cancel(notifId); // ignore: unawaited_futures
-          _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
-        }
+        // Re-post the notification with the reply appended so the thread stays
+        // visible; this also clears the Android inline-reply spinner.
+        _postReplyUpdate(callsign); // ignore: unawaited_futures
       }
       return;
     }
@@ -522,6 +579,7 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         final text = map['text'] as String? ?? '';
         if (callsign.isNotEmpty && text.isNotEmpty) {
           await _messageService.sendMessage(callsign, text);
+          await _postReplyUpdate(callsign);
         }
       } catch (e) {
         debugPrint('NotificationService: failed to drain reply: $e');

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -12,6 +12,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:local_notifier/local_notifier.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -31,6 +32,12 @@ const _kGroupSummaryId = 0;
 const _kReplyActionId = 'reply';
 const _kMarkReadActionId = 'mark_read';
 const _kGroupKey = 'meridian_messages';
+
+// MethodChannel shared with MainActivity and MeridianNotificationActionReceiver.
+// Used for bidirectional Android notification coordination:
+//   Dart  → native: postMessageNotification, getPendingNavigation
+//   native → Dart:  handleReply, handleMarkRead, navigateToThread
+const _kNativeChannel = MethodChannel('meridian/notifications');
 
 class NotificationService extends ChangeNotifier {
   NotificationService({
@@ -88,6 +95,13 @@ class NotificationService extends ChangeNotifier {
           shortcutPolicy: ShortcutPolicy.requireCreate,
         );
         _desktopNotifierReady = true;
+      }
+
+      // Android-specific: register the native MethodChannel handler and check
+      // for a pending navigation from a cold-start notification tap.
+      if (Platform.isAndroid) {
+        _kNativeChannel.setMethodCallHandler(_handleNativeCall);
+        _schedulePendingNavCheck();
       }
     }
 
@@ -199,6 +213,66 @@ class NotificationService extends ChangeNotifier {
   }
 
   // ---------------------------------------------------------------------------
+  // Android native channel handler
+  // ---------------------------------------------------------------------------
+
+  Future<dynamic> _handleNativeCall(MethodCall call) async {
+    switch (call.method) {
+      case 'handleReply':
+        final callsign = call.arguments['callsign'] as String;
+        final text = call.arguments['text'] as String;
+        final notifId = call.arguments['notificationId'] as int;
+        await _messageService.sendMessage(callsign, text);
+        // Re-post with alertOnce:true so the spinner dismisses without heads-up.
+        if (!kIsWeb && Platform.isAndroid) {
+          await _dispatchAndroidNotification(
+            notifId,
+            callsign,
+            _notifPrefs.isSoundEnabled(NotificationChannels.messages),
+            _notifPrefs.isVibrationEnabled(NotificationChannels.messages),
+            alertOnce: true,
+          );
+        }
+
+      case 'handleMarkRead':
+        final callsign = call.arguments['callsign'] as String;
+        _messageService.markRead(callsign);
+        // Cancel group summary if fewer than 2 conversations remain unread.
+        final remaining = _messageService.conversations
+            .where((c) => c.unreadCount > 0)
+            .length;
+        if (remaining < 2 && _initialized) {
+          _plugin
+              .cancel(_kGroupSummaryId)
+              .catchError((_) {}); // ignore: unawaited_futures
+        }
+
+      case 'navigateToThread':
+        final callsign = call.arguments['callsign'] as String;
+        if (callsign.isNotEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _navigateToThread(callsign);
+          });
+        }
+    }
+  }
+
+  /// Checks for a pending notification-tap navigation from a cold start.
+  /// MainActivity holds the callsign until Dart calls `getPendingNavigation`.
+  void _schedulePendingNavCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      try {
+        final callsign = await _kNativeChannel.invokeMethod<String>(
+          'getPendingNavigation',
+        );
+        if (callsign != null && callsign.isNotEmpty) {
+          _navigateToThread(callsign);
+        }
+      } catch (_) {}
+    });
+  }
+
+  // ---------------------------------------------------------------------------
   // Thread tracking (called from MessageThreadScreen)
   // ---------------------------------------------------------------------------
 
@@ -278,49 +352,69 @@ class NotificationService extends ChangeNotifier {
     final withVibration = _notifPrefs.isVibrationEnabled(
       NotificationChannels.messages,
     );
-
     final notifId = callsign.hashCode.abs() % 100000 + 1;
 
-    // Always post/update the per-callsign notification so the new-message
-    // heads-up alert fires regardless of how many other conversations are
-    // unread. Replacing an existing notification by the same ID still triggers
-    // heads-up on Android when there is new content.
-    await _dispatchSingleNotification(
-      notifId,
-      callsign,
-      text,
-      withSound,
-      withVibration,
-    );
+    if (!kIsWeb && Platform.isAndroid) {
+      // Android: post natively so inline reply works without opening the app.
+      await _dispatchAndroidNotification(
+        notifId,
+        callsign,
+        withSound,
+        withVibration,
+      );
 
-    // When multiple conversations are unread, also post a silent group summary
-    // so Android groups them in the shade — matching the Google Messages model
-    // of one summary + N individual conversation notifications.
-    final unreadConvs = _messageService.conversations
-        .where((c) => c.unreadCount > 0)
-        .toList();
-    if (unreadConvs.length >= 2) {
-      await _dispatchGroupSummary(unreadConvs);
+      // Group summary for 2+ unread conversations.
+      final unreadConvs = _messageService.conversations
+          .where((c) => c.unreadCount > 0)
+          .toList();
+      if (unreadConvs.length >= 2) {
+        await _dispatchGroupSummary(unreadConvs);
+      }
+    } else {
+      // iOS / macOS: use flutter_local_notifications.
+      await _dispatchSingleNotification(
+        notifId,
+        callsign,
+        text,
+        withSound,
+        withVibration,
+      );
     }
   }
 
-  MessagingStyleInformation _buildMessagingStyle(String callsign) {
-    const mePerson = Person(name: 'You', bot: true);
-    final peerPerson = Person(name: callsign, bot: true);
-
+  /// Posts an Android notification natively via [MainActivity] so that the
+  /// custom [MeridianNotificationActionReceiver] PendingIntents are used for
+  /// inline reply and mark-as-read — enabling reply without opening the app.
+  Future<void> _dispatchAndroidNotification(
+    int id,
+    String callsign,
+    bool withSound,
+    bool withVibration, {
+    bool alertOnce = false,
+  }) async {
     final conv = _messageService.conversationWith(callsign);
     final all = conv?.messages ?? [];
     final recent = all.length > 6 ? all.sublist(all.length - 6) : all;
 
-    return MessagingStyleInformation(
-      mePerson,
-      messages: recent.map((m) {
-        final body = m.text.length > 80
-            ? '${m.text.substring(0, 80)}…'
-            : m.text;
-        return Message(body, m.timestamp, m.isOutgoing ? null : peerPerson);
-      }).toList(),
-    );
+    final messages = recent.map((m) {
+      final body = m.text.length > 80 ? '${m.text.substring(0, 80)}…' : m.text;
+      return <String, Object?>{
+        'sender': m.isOutgoing ? null : callsign,
+        'text': body,
+        'timestampMs': m.timestamp.millisecondsSinceEpoch,
+      };
+    }).toList();
+
+    try {
+      await _kNativeChannel.invokeMethod<void>('postMessageNotification', {
+        'callsign': callsign,
+        'notificationId': id,
+        'messages': messages,
+        'withSound': withSound,
+        'withVibration': withVibration,
+        'alertOnce': alertOnce,
+      });
+    } catch (_) {}
   }
 
   Future<void> _dispatchSingleNotification(
@@ -330,33 +424,7 @@ class NotificationService extends ChangeNotifier {
     bool withSound,
     bool withVibration,
   ) async {
-    final androidDetails = AndroidNotificationDetails(
-      NotificationChannels.messages,
-      'Messages',
-      channelDescription: 'Incoming APRS messages addressed to you.',
-      importance: Importance.defaultImportance,
-      priority: Priority.defaultPriority,
-      playSound: withSound,
-      enableVibration: withVibration,
-      groupKey: _kGroupKey,
-      styleInformation: _buildMessagingStyle(callsign),
-      actions: [
-        const AndroidNotificationAction(
-          _kMarkReadActionId,
-          'Mark as read',
-          showsUserInterface: false,
-          cancelNotification: true,
-        ),
-        AndroidNotificationAction(
-          _kReplyActionId,
-          'Reply',
-          inputs: [const AndroidNotificationActionInput(label: 'Your reply')],
-          showsUserInterface: true,
-          cancelNotification: true,
-        ),
-      ],
-    );
-
+    // iOS / macOS only — Android uses _dispatchAndroidNotification.
     final darwinDetails = DarwinNotificationDetails(
       categoryIdentifier: NotificationChannels.messages,
       threadIdentifier: callsign,
@@ -370,11 +438,7 @@ class NotificationService extends ChangeNotifier {
       id,
       callsign,
       preview,
-      NotificationDetails(
-        android: androidDetails,
-        iOS: darwinDetails,
-        macOS: darwinDetails,
-      ),
+      NotificationDetails(iOS: darwinDetails, macOS: darwinDetails),
       payload: callsign,
     );
   }
@@ -444,6 +508,10 @@ class NotificationService extends ChangeNotifier {
   @visibleForTesting
   void handleMessageServiceChange() => _onMessageServiceChange();
 
+  @visibleForTesting
+  Future<dynamic> handleNativeCallForTest(MethodCall call) =>
+      _handleNativeCall(call);
+
   void _onNotificationResponse(NotificationResponse response) {
     final callsign = response.payload ?? '';
 
@@ -482,13 +550,14 @@ class NotificationService extends ChangeNotifier {
   }
 
   // ---------------------------------------------------------------------------
-  // Cold-start launch details
+  // Cold-start launch details (iOS / macOS via FLN)
   // ---------------------------------------------------------------------------
 
   void _schedulePostFrameLaunchCheck() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (kIsWeb) return;
       if (!Platform.isAndroid && !Platform.isIOS) return;
+      if (Platform.isAndroid) return; // Android uses _schedulePendingNavCheck.
       try {
         final details = await _plugin.getNotificationAppLaunchDetails();
         if (details == null || !details.didNotificationLaunchApp) return;

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -510,8 +510,8 @@ class NotificationService extends ChangeNotifier with WidgetsBindingObserver {
         (all.length > 10 ? all.length - 10 : 0);
     final slice = startIdx < all.length ? all.sublist(startIdx) : all;
 
-    final peer = Person(key: callsign);
-    const me = Person(key: 'me');
+    final peer = Person(name: callsign);
+    const me = Person(name: 'You');
 
     return MessagingStyleInformation(
       me,

--- a/lib/ui/layout/meridian_map.dart
+++ b/lib/ui/layout/meridian_map.dart
@@ -161,25 +161,25 @@ class MeridianMap extends StatelessWidget {
             right: 0,
             child: Center(child: _ConnectingBanner()),
           ),
-        if (onNotConnectedTap != null)
-          Positioned(
-            top: 12,
-            left: 0,
-            right: 0,
-            child: Center(
-              child: _NotConnectedNudge(
-                visible: !isAnyConnected,
-                onTap: onNotConnectedTap!,
-              ),
-            ),
-          ),
-        if (activeFilterLabel != null)
+        if (onNotConnectedTap != null || activeFilterLabel != null)
           Positioned(
             top: 12,
             left: 12,
-            child: _ActiveFilterChip(
-              label: activeFilterLabel!,
-              onTap: onActiveFilterTap,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (onNotConnectedTap != null)
+                  _NotConnectedNudge(
+                    visible: !isAnyConnected,
+                    onTap: onNotConnectedTap!,
+                  ),
+                if (activeFilterLabel != null)
+                  _ActiveFilterChip(
+                    label: activeFilterLabel!,
+                    onTap: onActiveFilterTap,
+                  ),
+              ],
             ),
           ),
         if (showCountChip &&
@@ -216,18 +216,32 @@ class _NotConnectedNudge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedOpacity(
-      opacity: visible ? 1.0 : 0.0,
-      duration: const Duration(milliseconds: 400),
-      child: IgnorePointer(
-        ignoring: !visible,
+    final colors = Theme.of(context).colorScheme;
+    return AnimatedCrossFade(
+      duration: const Duration(milliseconds: 300),
+      sizeCurve: Curves.easeInOut,
+      crossFadeState: visible
+          ? CrossFadeState.showFirst
+          : CrossFadeState.showSecond,
+      firstChild: Padding(
+        padding: const EdgeInsets.only(bottom: 8),
         child: ActionChip(
-          avatar: const Icon(Symbols.signal_disconnected, size: 16),
-          label: const Text('Not connected — tap to connect'),
+          avatar: Icon(
+            Symbols.signal_disconnected,
+            size: 16,
+            color: colors.onErrorContainer,
+          ),
+          label: Text(
+            'Not connected',
+            style: TextStyle(color: colors.onErrorContainer),
+          ),
+          backgroundColor: colors.errorContainer,
+          side: BorderSide.none,
           onPressed: onTap,
           visualDensity: VisualDensity.compact,
         ),
       ),
+      secondChild: const SizedBox.shrink(),
     );
   }
 }

--- a/lib/ui/widgets/in_app_banner_overlay.dart
+++ b/lib/ui/widgets/in_app_banner_overlay.dart
@@ -1,0 +1,259 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+
+import '../../screens/message_thread_screen.dart';
+import '../../theme/meridian_colors.dart';
+import '../utils/platform_route.dart';
+
+/// Payload carried by a single in-app notification banner.
+class BannerPayload {
+  const BannerPayload({
+    required this.callsign,
+    required this.text,
+    required this.timestamp,
+  });
+
+  final String callsign;
+  final String text;
+  final DateTime timestamp;
+}
+
+/// Controls the [InAppBannerOverlay] from outside the widget tree.
+///
+/// Holds the currently visible banner (if any). [NotificationService] calls
+/// [show] after dispatching a system notification; the overlay widget reacts
+/// via ChangeNotifier.
+class InAppBannerController extends ChangeNotifier {
+  BannerPayload? _current;
+
+  BannerPayload? get current => _current;
+
+  /// Show a banner for the message from [callsign].
+  ///
+  /// If a banner is already showing it is replaced immediately.
+  void show(String callsign, String text) {
+    _current = BannerPayload(
+      callsign: callsign,
+      text: text,
+      timestamp: DateTime.now(),
+    );
+    notifyListeners();
+  }
+
+  /// Dismiss the currently visible banner.
+  void dismiss() {
+    if (_current == null) return;
+    _current = null;
+    notifyListeners();
+  }
+}
+
+/// Wraps [child] with a slide-in notification banner anchored at the top (or
+/// top-right on wide screens).
+///
+/// Insert this widget around the responsive scaffold so the banner appears on
+/// every screen without per-screen wiring.
+class InAppBannerOverlay extends StatefulWidget {
+  const InAppBannerOverlay({
+    super.key,
+    required this.controller,
+    required this.child,
+  });
+
+  final InAppBannerController controller;
+  final Widget child;
+
+  @override
+  State<InAppBannerOverlay> createState() => _InAppBannerOverlayState();
+}
+
+class _InAppBannerOverlayState extends State<InAppBannerOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+  late final Animation<Offset> _slide;
+
+  BannerPayload? _payload;
+  Timer? _dismissTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    _slide = Tween<Offset>(
+      begin: const Offset(0, -1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _anim, curve: Curves.easeOut));
+
+    widget.controller.addListener(_onControllerChange);
+  }
+
+  @override
+  void didUpdateWidget(InAppBannerOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChange);
+      widget.controller.addListener(_onControllerChange);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChange);
+    _dismissTimer?.cancel();
+    _anim.dispose();
+    super.dispose();
+  }
+
+  void _onControllerChange() {
+    final next = widget.controller.current;
+    if (next == null) {
+      _dismiss();
+    } else {
+      setState(() => _payload = next);
+      _anim.forward(from: 0);
+      _dismissTimer?.cancel();
+      _dismissTimer = Timer(const Duration(seconds: 4), _autoDismiss);
+    }
+  }
+
+  void _autoDismiss() {
+    if (!mounted) return;
+    _dismiss();
+  }
+
+  void _dismiss() {
+    _dismissTimer?.cancel();
+    _anim.reverse().then((_) {
+      if (mounted) setState(() => _payload = null);
+    });
+    widget.controller.dismiss();
+  }
+
+  void _onTap() {
+    final payload = _payload;
+    if (payload == null) return;
+    _dismiss();
+    Navigator.of(context).push(
+      buildPlatformRoute(
+        (_) => MessageThreadScreen(peerCallsign: payload.callsign),
+      ),
+    );
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    if (details.primaryVelocity != null && details.primaryVelocity! < -200) {
+      _dismiss();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final isWide = width > 1024 && !kIsWeb;
+
+    return Stack(
+      children: [
+        widget.child,
+        if (_payload != null)
+          Positioned(
+            top: isWide ? 16 : 0,
+            right: isWide ? 16 : 0,
+            left: isWide ? null : 0,
+            child: SafeArea(
+              child: isWide
+                  ? SizedBox(width: 320, child: _buildBanner(context))
+                  : _buildBanner(context),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBanner(BuildContext context) {
+    final payload = _payload!;
+    final theme = Theme.of(context);
+    final preview = payload.text.length > 60
+        ? '${payload.text.substring(0, 60)}…'
+        : payload.text;
+    final elapsed = DateTime.now().difference(payload.timestamp);
+    final timeLabel = elapsed.inSeconds < 10
+        ? 'Just now'
+        : elapsed.inMinutes < 1
+        ? '${elapsed.inSeconds}s ago'
+        : '${elapsed.inMinutes}m ago';
+
+    return SlideTransition(
+      position: _slide,
+      child: GestureDetector(
+        onTap: _onTap,
+        onVerticalDragEnd: _onVerticalDragEnd,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Card(
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Left accent bar.
+                    Container(width: 4, color: MeridianColors.primary),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    payload.callsign,
+                                    style: theme.textTheme.titleSmall?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    preview,
+                                    style: theme.textTheme.bodySmall,
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              timeLabel,
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <flutter_libserialport/flutter_libserialport_plugin.h>
+#include <local_notifier/local_notifier_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_libserialport_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterLibserialportPlugin");
   flutter_libserialport_plugin_register_with_registrar(flutter_libserialport_registrar);
+  g_autoptr(FlPluginRegistrar) local_notifier_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "LocalNotifierPlugin");
+  local_notifier_plugin_register_with_registrar(local_notifier_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   flutter_libserialport
+  local_notifier
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,9 @@ import dynamic_color
 import flutter_app_group_directory
 import flutter_blue_plus_darwin
 import flutter_libserialport
+import flutter_local_notifications
 import geolocator_apple
+import local_notifier
 import shared_preferences_foundation
 import url_launcher_macos
 
@@ -18,7 +20,9 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterAppGroupDirectoryPlugin.register(with: registry.registrar(forPlugin: "FlutterAppGroupDirectoryPlugin"))
   FlutterBluePlusPlugin.register(with: registry.registrar(forPlugin: "FlutterBluePlusPlugin"))
   FlutterLibserialportPlugin.register(with: registry.registrar(forPlugin: "FlutterLibserialportPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  LocalNotifierPlugin.register(with: registry.registrar(forPlugin: "LocalNotifierPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,6 +310,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -549,6 +573,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.7"
+  local_notifier:
+    dependency: "direct main"
+    description:
+      name: local_notifier
+      sha256: f6cfc933c6fbc961f4e52b5c880f68e41b2d3cd29aad557cc654fd211093a025
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   logger:
     dependency: transitive
     description:
@@ -1034,6 +1066,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   live_activities: ^2.4.7
+  flutter_local_notifications: ^18.0.0
+  local_notifier: ^0.1.6
 
 dev_dependencies:
   flutter_test:

--- a/test/models/notification_preferences_test.dart
+++ b/test/models/notification_preferences_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/models/notification_preferences.dart';
+
+void main() {
+  group('NotificationPreferences', () {
+    test('defaults — all channels enabled', () {
+      final prefs = NotificationPreferences.defaults();
+      for (final ch in NotificationChannels.all) {
+        expect(prefs.isChannelEnabled(ch), isTrue, reason: 'channel $ch');
+      }
+    });
+
+    test('defaults — sound on for messages and alerts, off elsewhere', () {
+      final prefs = NotificationPreferences.defaults();
+      expect(prefs.isSoundEnabled(NotificationChannels.messages), isTrue);
+      expect(prefs.isSoundEnabled(NotificationChannels.alerts), isTrue);
+      expect(prefs.isSoundEnabled(NotificationChannels.nearby), isFalse);
+      expect(prefs.isSoundEnabled(NotificationChannels.system), isFalse);
+    });
+
+    test('defaults — vibration on for messages and alerts, off elsewhere', () {
+      final prefs = NotificationPreferences.defaults();
+      expect(prefs.isVibrationEnabled(NotificationChannels.messages), isTrue);
+      expect(prefs.isVibrationEnabled(NotificationChannels.alerts), isTrue);
+      expect(prefs.isVibrationEnabled(NotificationChannels.nearby), isFalse);
+      expect(prefs.isVibrationEnabled(NotificationChannels.system), isFalse);
+    });
+
+    test('copyWithChannel toggles one channel without affecting others', () {
+      final original = NotificationPreferences.defaults();
+      final updated = original.copyWithChannel(
+        NotificationChannels.messages,
+        false,
+      );
+      expect(updated.isChannelEnabled(NotificationChannels.messages), isFalse);
+      expect(updated.isChannelEnabled(NotificationChannels.alerts), isTrue);
+    });
+
+    test(
+      'copyWithSound toggles one channel sound without affecting others',
+      () {
+        final original = NotificationPreferences.defaults();
+        final updated = original.copyWithSound(
+          NotificationChannels.messages,
+          false,
+        );
+        expect(updated.isSoundEnabled(NotificationChannels.messages), isFalse);
+        expect(updated.isSoundEnabled(NotificationChannels.alerts), isTrue);
+      },
+    );
+
+    test('copyWithVibration toggles one channel vibration', () {
+      final original = NotificationPreferences.defaults();
+      final updated = original.copyWithVibration(
+        NotificationChannels.nearby,
+        true,
+      );
+      expect(updated.isVibrationEnabled(NotificationChannels.nearby), isTrue);
+      expect(updated.isVibrationEnabled(NotificationChannels.messages), isTrue);
+    });
+
+    group('SharedPreferences round-trip', () {
+      setUp(() {
+        SharedPreferences.setMockInitialValues({});
+      });
+
+      test('save and reload reproduces same values', () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        final original = NotificationPreferences.defaults()
+            .copyWithChannel(NotificationChannels.alerts, false)
+            .copyWithSound(NotificationChannels.messages, false)
+            .copyWithVibration(NotificationChannels.nearby, true);
+
+        await original.save(prefs);
+        final loaded = await NotificationPreferences.load(prefs);
+
+        expect(loaded.isChannelEnabled(NotificationChannels.alerts), isFalse);
+        expect(loaded.isSoundEnabled(NotificationChannels.messages), isFalse);
+        expect(loaded.isVibrationEnabled(NotificationChannels.nearby), isTrue);
+        // Unchanged values preserved.
+        expect(loaded.isChannelEnabled(NotificationChannels.messages), isTrue);
+        expect(loaded.isSoundEnabled(NotificationChannels.alerts), isTrue);
+      });
+
+      test('load with no stored values returns defaults', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final loaded = await NotificationPreferences.load(prefs);
+
+        final defaults = NotificationPreferences.defaults();
+        for (final ch in NotificationChannels.all) {
+          expect(
+            loaded.isChannelEnabled(ch),
+            defaults.isChannelEnabled(ch),
+            reason: 'channel $ch',
+          );
+          expect(
+            loaded.isSoundEnabled(ch),
+            defaults.isSoundEnabled(ch),
+            reason: 'sound $ch',
+          );
+          expect(
+            loaded.isVibrationEnabled(ch),
+            defaults.isVibrationEnabled(ch),
+            reason: 'vibration $ch',
+          );
+        }
+      });
+    });
+  });
+}

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -171,38 +171,6 @@ void main() {
     });
   });
 
-  group('NotificationService — MessagingStyle builder', () {
-    late _Fixture f;
-
-    setUp(() async {
-      f = await _Fixture.create();
-    });
-
-    tearDown(() => f.dispose());
-
-    test('messages appear in order with correct sender mapping', () async {
-      f.injectInbound('WB5XYZ', 'Hello', msgId: '001');
-      await Future.delayed(const Duration(milliseconds: 50));
-      await f.messageService.sendMessage('WB5XYZ', 'Hi back');
-
-      final style = f.notificationService.buildMessagingStyleForTest('WB5XYZ');
-      expect(style.messages, hasLength(2));
-      // Inbound: person key = peer callsign (no name = no avatar bubble)
-      expect(style.messages!.first.text, 'Hello');
-      expect(style.messages!.first.person?.name, 'WB5XYZ');
-      // Outgoing: person = null (sent by "You")
-      expect(style.messages!.last.text, 'Hi back');
-      expect(style.messages!.last.person, isNull);
-    });
-
-    test('builder returns empty messages for unknown callsign', () {
-      final style = f.notificationService.buildMessagingStyleForTest(
-        'K0UNKNOWN',
-      );
-      expect(style.messages ?? [], isEmpty);
-    });
-  });
-
   group('NotificationService — inline reply routing', () {
     late _Fixture f;
 

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/models/notification_preferences.dart';
+import 'package:meridian_aprs/services/message_service.dart';
+import 'package:meridian_aprs/services/notification_service.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+import 'package:meridian_aprs/ui/widgets/in_app_banner_overlay.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+final _navigatorKey = GlobalKey<NavigatorState>();
+
+class _Fixture {
+  _Fixture._({
+    required this.messageService,
+    required this.notificationService,
+    required this.bannerController,
+    required this.stationService,
+  });
+
+  final MessageService messageService;
+  final NotificationService notificationService;
+  final InAppBannerController bannerController;
+  final StationService stationService;
+
+  static Future<_Fixture> create({
+    String callsign = 'W1AW',
+    int ssid = 9,
+    Map<String, Object> prefOverrides = const {},
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': callsign,
+      'user_ssid': ssid,
+      'message_id_counter': 0,
+      ...prefOverrides,
+    });
+
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(prefs);
+    final stationService = StationService();
+    final registry = ConnectionRegistry();
+    final txService = _SilentTxService(registry);
+    final messageService = MessageService(settings, txService, stationService);
+    final bannerController = InAppBannerController();
+
+    // Construct NotificationService WITHOUT calling initialize() so we avoid
+    // touching the flutter_local_notifications platform channel in tests.
+    final notificationService = NotificationService(
+      messageService: messageService,
+      prefs: prefs,
+      navigatorKey: _navigatorKey,
+      bannerController: bannerController,
+    );
+
+    // Manually seed preferences (skips the prefs load that initialize() does).
+    await NotificationPreferences.defaults().save(prefs);
+
+    // Manually wire the MessageService listener (normally done in initialize()).
+    messageService.addListener(notificationService.handleMessageServiceChange);
+
+    return _Fixture._(
+      messageService: messageService,
+      notificationService: notificationService,
+      bannerController: bannerController,
+      stationService: stationService,
+    );
+  }
+
+  void dispose() {
+    messageService.removeListener(
+      notificationService.handleMessageServiceChange,
+    );
+    notificationService.dispose();
+    messageService.dispose();
+  }
+
+  void injectInbound(String from, String text, {String msgId = '042'}) {
+    // Build an APRS message line addressed to our callsign (W1AW-9).
+    stationService.ingestLine('$from>APZMDN::W1AW-9   :$text{$msgId');
+  }
+}
+
+/// TxService that silently drops outgoing traffic (no real transport).
+class _SilentTxService extends TxService {
+  _SilentTxService(super.registry);
+
+  @override
+  Future<void> sendLine(String line, {ConnectionType? forceVia}) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NotificationService — banner dispatch', () {
+    late _Fixture f;
+
+    setUp(() async {
+      f = await _Fixture.create();
+    });
+
+    tearDown(() => f.dispose());
+
+    test(
+      'inbound message shows banner when messages channel is enabled',
+      () async {
+        f.injectInbound('WB5XYZ', 'Hello there');
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        expect(f.bannerController.current, isNotNull);
+        expect(f.bannerController.current!.callsign, 'WB5XYZ');
+        expect(f.bannerController.current!.text, 'Hello there');
+      },
+    );
+
+    test('banner is suppressed when messages channel is disabled', () async {
+      await f.notificationService.setChannelEnabled(
+        NotificationChannels.messages,
+        false,
+      );
+
+      f.injectInbound('WB5XYZ', 'Hello');
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.bannerController.current, isNull);
+    });
+
+    test('banner is suppressed when that callsign thread is active', () async {
+      f.notificationService.setActiveThread('WB5XYZ');
+
+      f.injectInbound('WB5XYZ', 'Hello');
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.bannerController.current, isNull);
+    });
+
+    test(
+      'banner shows when different callsign arrives than active thread',
+      () async {
+        f.notificationService.setActiveThread('WB5XYZ');
+
+        f.injectInbound('K6ABC', 'Hey', msgId: '099');
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        expect(f.bannerController.current, isNotNull);
+        expect(f.bannerController.current!.callsign, 'K6ABC');
+      },
+    );
+
+    test('duplicate message does not trigger a second banner', () async {
+      f.injectInbound('WB5XYZ', 'Hello', msgId: '001');
+      await Future.delayed(const Duration(milliseconds: 50));
+      f.bannerController.dismiss();
+
+      // Same ID → duplicate, MessageService dedupes it.
+      f.injectInbound('WB5XYZ', 'Hello', msgId: '001');
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.bannerController.current, isNull);
+    });
+  });
+
+  group('NotificationService — inline reply routing', () {
+    late _Fixture f;
+
+    setUp(() async {
+      f = await _Fixture.create();
+    });
+
+    tearDown(() => f.dispose());
+
+    test('reply action sends message to correct callsign', () async {
+      const response = NotificationResponse(
+        notificationResponseType:
+            NotificationResponseType.selectedNotificationAction,
+        actionId: 'reply',
+        input: 'This is my reply',
+        payload: 'WB5XYZ',
+        id: 1,
+      );
+
+      f.notificationService.handleNotificationResponse(response);
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final conv = f.messageService.conversationWith('WB5XYZ');
+      expect(conv, isNotNull);
+      final outgoing = conv!.messages.where((m) => m.isOutgoing).toList();
+      expect(outgoing, hasLength(1));
+      expect(outgoing.first.text, 'This is my reply');
+    });
+
+    test('reply with empty input is silently ignored', () async {
+      const response = NotificationResponse(
+        notificationResponseType:
+            NotificationResponseType.selectedNotificationAction,
+        actionId: 'reply',
+        input: '',
+        payload: 'WB5XYZ',
+        id: 1,
+      );
+
+      f.notificationService.handleNotificationResponse(response);
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.messageService.conversations, isEmpty);
+    });
+
+    test('reply with empty payload is silently ignored', () async {
+      const response = NotificationResponse(
+        notificationResponseType:
+            NotificationResponseType.selectedNotificationAction,
+        actionId: 'reply',
+        input: 'Hello',
+        payload: '',
+        id: 1,
+      );
+
+      f.notificationService.handleNotificationResponse(response);
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.messageService.conversations, isEmpty);
+    });
+  });
+
+  group('NotificationService — terminated-app reply outbox', () {
+    test('pending replies are drained and sent on initialize', () async {
+      SharedPreferences.setMockInitialValues({
+        'user_callsign': 'W1AW',
+        'user_ssid': 9,
+        'message_id_counter': 0,
+        'notification_reply_outbox': [
+          '{"callsign":"WB5XYZ","text":"Pending reply"}',
+          '{"callsign":"K6ABC","text":"Another reply"}',
+        ],
+      });
+
+      final prefs = await SharedPreferences.getInstance();
+      final settings = StationSettingsService(prefs);
+      final stationService = StationService();
+      final registry = ConnectionRegistry();
+      final txService = _SilentTxService(registry);
+      final messageService = MessageService(
+        settings,
+        txService,
+        stationService,
+      );
+      final bannerController = InAppBannerController();
+      final notificationService = NotificationService(
+        messageService: messageService,
+        prefs: prefs,
+        navigatorKey: _navigatorKey,
+        bannerController: bannerController,
+      );
+
+      await notificationService.drainReplyOutboxForTest();
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(messageService.conversationWith('WB5XYZ'), isNotNull);
+      expect(messageService.conversationWith('K6ABC'), isNotNull);
+
+      // Outbox is cleared after drain.
+      expect(prefs.getStringList('notification_reply_outbox'), isNull);
+
+      notificationService.dispose();
+      messageService.dispose();
+    });
+  });
+}

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -187,9 +187,9 @@ void main() {
 
       final style = f.notificationService.buildMessagingStyleForTest('WB5XYZ');
       expect(style.messages, hasLength(2));
-      // Inbound: person = peer callsign
+      // Inbound: person key = peer callsign (no name = no avatar bubble)
       expect(style.messages!.first.text, 'Hello');
-      expect(style.messages!.first.person?.name, 'WB5XYZ');
+      expect(style.messages!.first.person?.key, 'WB5XYZ');
       // Outgoing: person = null (sent by "You")
       expect(style.messages!.last.text, 'Hi back');
       expect(style.messages!.last.person, isNull);

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -189,7 +189,7 @@ void main() {
       expect(style.messages, hasLength(2));
       // Inbound: person key = peer callsign (no name = no avatar bubble)
       expect(style.messages!.first.text, 'Hello');
-      expect(style.messages!.first.person?.key, 'WB5XYZ');
+      expect(style.messages!.first.person?.name, 'WB5XYZ');
       // Outgoing: person = null (sent by "You")
       expect(style.messages!.last.text, 'Hi back');
       expect(style.messages!.last.person, isNull);

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -232,48 +232,4 @@ void main() {
       expect(f.messageService.conversations, isEmpty);
     });
   });
-
-  group('NotificationService — terminated-app reply outbox', () {
-    test('pending replies are drained and sent on initialize', () async {
-      SharedPreferences.setMockInitialValues({
-        'user_callsign': 'W1AW',
-        'user_ssid': 9,
-        'message_id_counter': 0,
-        'notification_reply_outbox': [
-          '{"callsign":"WB5XYZ","text":"Pending reply"}',
-          '{"callsign":"K6ABC","text":"Another reply"}',
-        ],
-      });
-
-      final prefs = await SharedPreferences.getInstance();
-      final settings = StationSettingsService(prefs);
-      final stationService = StationService();
-      final registry = ConnectionRegistry();
-      final txService = _SilentTxService(registry);
-      final messageService = MessageService(
-        settings,
-        txService,
-        stationService,
-      );
-      final bannerController = InAppBannerController();
-      final notificationService = NotificationService(
-        messageService: messageService,
-        prefs: prefs,
-        navigatorKey: _navigatorKey,
-        bannerController: bannerController,
-      );
-
-      await notificationService.drainReplyOutboxForTest();
-      await Future.delayed(const Duration(milliseconds: 50));
-
-      expect(messageService.conversationWith('WB5XYZ'), isNotNull);
-      expect(messageService.conversationWith('K6ABC'), isNotNull);
-
-      // Outbox is cleared after drain.
-      expect(prefs.getStringList('notification_reply_outbox'), isNull);
-
-      notificationService.dispose();
-      messageService.dispose();
-    });
-  });
 }

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -171,6 +171,38 @@ void main() {
     });
   });
 
+  group('NotificationService — MessagingStyle builder', () {
+    late _Fixture f;
+
+    setUp(() async {
+      f = await _Fixture.create();
+    });
+
+    tearDown(() => f.dispose());
+
+    test('messages appear in order with correct sender mapping', () async {
+      f.injectInbound('WB5XYZ', 'Hello', msgId: '001');
+      await Future.delayed(const Duration(milliseconds: 50));
+      await f.messageService.sendMessage('WB5XYZ', 'Hi back');
+
+      final style = f.notificationService.buildMessagingStyleForTest('WB5XYZ');
+      expect(style.messages, hasLength(2));
+      // Inbound: person = peer callsign
+      expect(style.messages!.first.text, 'Hello');
+      expect(style.messages!.first.person?.name, 'WB5XYZ');
+      // Outgoing: person = null (sent by "You")
+      expect(style.messages!.last.text, 'Hi back');
+      expect(style.messages!.last.person, isNull);
+    });
+
+    test('builder returns empty messages for unknown callsign', () {
+      final style = f.notificationService.buildMessagingStyleForTest(
+        'K0UNKNOWN',
+      );
+      expect(style.messages ?? [], isEmpty);
+    });
+  });
+
   group('NotificationService — inline reply routing', () {
     late _Fixture f;
 

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -230,6 +231,58 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 50));
 
       expect(f.messageService.conversations, isEmpty);
+    });
+  });
+
+  group('NotificationService — Android MethodChannel reply', () {
+    late _Fixture f;
+
+    setUp(() async {
+      f = await _Fixture.create();
+    });
+
+    tearDown(() => f.dispose());
+
+    test('handleReply sends message to correct callsign', () async {
+      await f.notificationService.handleNativeCallForTest(
+        const MethodCall('handleReply', {
+          'callsign': 'WB5XYZ',
+          'text': 'Android inline reply',
+          'notificationId': 42,
+        }),
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final conv = f.messageService.conversationWith('WB5XYZ');
+      expect(conv, isNotNull);
+      final outgoing = conv!.messages.where((m) => m.isOutgoing).toList();
+      expect(outgoing, hasLength(1));
+      expect(outgoing.first.text, 'Android inline reply');
+    });
+
+    test('handleMarkRead marks conversation as read', () async {
+      // Inject an inbound message so there is an unread conversation.
+      f.injectInbound('WB5XYZ', 'Are you there?');
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.messageService.conversationWith('WB5XYZ')?.unreadCount, 1);
+
+      await f.notificationService.handleNativeCallForTest(
+        const MethodCall('handleMarkRead', {'callsign': 'WB5XYZ'}),
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.messageService.conversationWith('WB5XYZ')?.unreadCount, 0);
+    });
+
+    test('navigateToThread is handled without throwing', () async {
+      // Navigation requires a real navigator; just verify no exception thrown.
+      await expectLater(
+        f.notificationService.handleNativeCallForTest(
+          const MethodCall('navigateToThread', {'callsign': 'WB5XYZ'}),
+        ),
+        completes,
+      );
     });
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <flutter_libserialport/flutter_libserialport_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
+#include <local_notifier/local_notifier_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -19,6 +20,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterLibserialportPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
+  LocalNotifierPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("LocalNotifierPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
   flutter_libserialport
   geolocator_windows
+  local_notifier
   permission_handler_windows
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary

- **`NotificationService`** — main-isolate dispatch to `flutter_local_notifications` (Android/iOS/macOS) and `local_notifier` (Windows/Linux); subscribes to `MessageService` and detects new inbound messages by diffing unread counts per callsign
- **Android native inline reply** — custom `MeridianNotificationActionReceiver` (BroadcastReceiver) + `FlutterEngineCache` enables reply and mark-as-read without opening the app; `MessagingStyle` conversation notifications with per-session history anchor; cold-start tap navigation via `MainActivity.getPendingNavigation` pull model
- **iOS inline reply** — `DarwinNotificationCategory` with `DarwinNotificationAction.text`; foreground delivery via `presentAlert: true`; cold-start navigation via `getNotificationAppLaunchDetails()`
- **`InAppBannerOverlay`** — slide-in banner at app root; full-width mobile, 320 px top-right desktop; auto-dismiss 4s; swipe-up dismiss; tap navigates to thread; suppressed when target thread is already open
- **`NotificationPreferences`** — per-channel enabled/sound/vibration, persisted to SharedPreferences; settings UI with per-channel toggles
- **APRS-IS opt-in** — removed unconditional auto-connect on launch; connection choice persisted so subsequent launches respect the user's last decision
- **Map "Not connected" chip** — repositioned top-left with error colors; `AnimatedCrossFade` prevents layout overlap with the time filter chip
- **Four notification channels** registered: `messages`, `alerts`, `nearby`, `system`
- **ADRs 035–038** added to `docs/DECISIONS.md`

## Test plan

- [x] Android: receive inbound message while backgrounded → system notification appears
- [x] Android: inline reply from notification → message delivered, spinner clears
- [x] Android: mark-as-read action → unread count clears, notification dismissed
- [ ] Android: tap notification (app backgrounded) → navigates to correct thread
- [ ] Android: tap notification (app terminated / cold start) → navigates to correct thread
- [ ] Android: notification history anchor — dismiss notification, receive new message → new notification starts fresh (no pre-dismissal history)
- [ ] iOS: receive inbound message while backgrounded → system notification appears
- [ ] iOS: inline reply from notification → message delivered
- [ ] iOS: tap notification → navigates to correct thread
- [ ] All platforms: in-app banner appears for message when on map screen
- [ ] All platforms: in-app banner suppressed when already in that callsign's thread
- [ ] All platforms: banner tap navigates to thread
- [ ] All platforms: banner auto-dismisses after ~4s; swipe-up dismisses early
- [ ] Settings: notification channel toggles persist across restart
- [x] APRS-IS: fresh install → no auto-connect on launch; connect manually → reconnects on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)