### PR TITLE
feat: v0.17 PR 1 — foundation for group messaging & bulletins

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -992,3 +992,161 @@ APRS operators frequently run multiple stations under one base callsign (e.g., `
 - `NotificationPreferences.notifyOtherSsids` (key `notif_notify_other_ssids`) gates cross-SSID system notifications.
 - New Settings → Messaging category (`lib/screens/settings/category/messaging_screen.dart`).
 - Spec: `docs/specs/base-callsign-message-matching.md`
+
+---
+
+## ADR-055: Addressee matcher precedence — Bulletin → Direct → Group (v0.17)
+
+**Date:** 2026-04-23
+**Status:** Accepted
+
+### Context
+
+v0.17 adds two new APRS message categories (group messages, bulletins) alongside the existing direct path from v0.5 and base-callsign matching from v0.14 (ADR-054). Every incoming `MessagePacket` must be classified into exactly one of {Direct, Group, Bulletin, None} before storage, display, or ACK generation. The classification determines whether an ACK is sent.
+
+The ordering of the classification rules is load-bearing — a seemingly cosmetic refactor (collapsing them into a single matcher list, or reordering for "clarity") can silently break ACK correctness in ways that don't surface until a user in a specific configuration experiences an "unreachable" operator.
+
+### Decision
+
+The addressee matcher applies three rules in a **fixed first-match-wins order**:
+
+1. **Bulletin** — addressee matches `^BLN[0-9A-Z]`
+2. **Direct** — addressee matches the operator's own callsign per ADR-054 (exact or cross-SSID)
+3. **Group** — addressee matches any enabled `GroupSubscription` per its `matchMode`
+
+Implementation details that are part of the contract:
+
+- The classifier function is named `classifyWithPrecedence()` — not `classify()` or a generic matcher loop. The name signals intent and surfaces the ordering rule at every call site.
+- A doc comment on the method states the rule and references this ADR. The library-level doc comment on `lib/core/callsign/addressee_matcher.dart` includes a "do not reorder / do not rename / do not collapse" warning.
+- The sealed `MessageClassification` type (`BulletinClassification` | `DirectClassification` | `GroupClassification` | `NoneClassification`) forces handlers to switch on the concrete variant — there is no boolean "isBulletin" that could be mishandled in isolation.
+- `DirectClassification` carries `isExactMatch` so the downstream ACK gate (exact match only, per ADR-054) is preserved.
+- Group precedence within rule 3 is first-subscription-wins in user-defined order, so the Settings "reorder" UX maps directly to matcher behavior.
+
+### Why this exact order
+
+- **Bulletin first.** Syntactically unambiguous — no legitimate callsign starts with `BLN[0-9A-Z]`. Prevents pathological groups (e.g., user creates a group named `B` with prefix match) from capturing bulletins.
+- **Direct before Group.** Guarantees messages addressed to the operator's own callsign classify as direct and get ACKed when exact. If Group came first, a permissive custom group (e.g., `W1` with prefix match when operator is `W1ABC`) would capture direct messages to `W1ABC-7`, skip the ACK, and the sender's retry loop would never terminate — the operator would appear unreachable despite receiving. This is a silent protocol violation with no obvious log signature.
+- **Group last.** User-configurable and potentially broad. More specific rules are handled first; group is the fallback for addressees that aren't bulletins and aren't for me.
+
+### Required test cases
+
+The following table is copied into `test/core/callsign/addressee_matcher_test.dart`. These cases must pass at all times — they protect the precedence rule from silent regression.
+
+| Case | Addressee | Setup | Expected |
+|---|---|---|---|
+| Bulletin beats pathological group | `BLN0` | Group `B` prefix | Bulletin |
+| Bulletin beats named-overlap group | `BLN1SRARC` | Group `SRARC` | Bulletin |
+| Direct beats group prefix conflict | `W1ABC-7` | Operator `W1ABC`; group `W1` prefix | Direct, ACKs |
+| Direct beats group exact conflict | `W1ABC` | Operator `W1ABC`; group `W1ABC` exact | Direct, ACKs |
+| Group when no direct/bulletin | `CQ` | Group `CQ` | Group, no ACK |
+| First subscription wins | `CQFOO` | Groups `CQ`, `CQFOO` both prefix | First in list |
+| Disabled subscriptions don't match | `CQ` | Group `CQ` disabled | None |
+| Exact mode rejects longer addressee | `CQRS` | Group `CQ` exact | None |
+| Prefix mode accepts longer | `CQRS` | Group `CQ` prefix | Group |
+
+### ACK policy
+
+| Classification | ACK? |
+|---|---|
+| Direct, exact match | Yes (ADR-054) |
+| Direct, cross-SSID | No (ADR-054) |
+| Group | Never |
+| Bulletin | Never |
+
+### If a future refactor wants to reorder these rules
+
+**Stop.** Re-read this ADR. Reordering is a protocol correctness change, not a style change. Any PR that touches the ordering must update this ADR and justify why the required test cases above remain correct under the new order. If the cases can't be preserved, the refactor is not a refactor — it is a behavior change that needs explicit product review.
+
+### Consequences
+
+- New `lib/core/callsign/addressee_matcher.dart` (the classifier) + `lib/core/callsign/message_classification.dart` (sealed result type) + `lib/core/callsign/operator_identity.dart` (identity snapshot value object).
+- `MessageService._onPacket` replaces its inline exact-vs-cross-SSID block with a single call to `AddresseeMatcher.classifyWithPrecedence` and switches on the sealed result.
+- Existing v0.14 ACK behavior preserved: exact-match direct ACKs; cross-SSID direct does not; group and bulletin never ACK.
+
+---
+
+## ADR-056: Group messaging architecture (v0.17)
+
+**Date:** 2026-04-23
+**Status:** Accepted
+
+### Context
+
+APRS group messages (`CQ`, `ALL`, `QST`, club-defined names like `SRARC`) are a protocol-level feature inherited from Yaesu/Kenwood radios and the APRS spec §14. They are one-to-many: a sender addresses any group name and every listener whose radio is configured to match that name receives the message. There is no server-side group mechanism — "subscription" is entirely a local receiver filter.
+
+Meridian implements the same model so it interoperates with Yaesu FT5D, Kenwood TH-D74, and modern software clients (APRSIS32, Xastir). Group messages are distinct from direct messages (different addressee shape) and distinct from bulletins (message-format DTI, ACK semantics differ).
+
+### Decision
+
+1. **Subscription model.** `GroupSubscription` is a local-only value object persisted to SharedPreferences. No network subscription step exists. Four built-ins are seeded on first run (`ALL`, `CQ`, `QST`, `YAESU`) — the Yaesu radio-firmware defaults plus two hobby conventions. Users may add custom groups (club names, event nets).
+
+2. **Wildcards = prefix match, not regex/glob.** APRS wire addressees are 9 characters, right-space-padded. Yaesu radios emit `ALL******` as a prefix match, so the matcher trims padding and applies `addressee.startsWith(name)`. Users can opt a group into `exact` mode for strict equality (no false positives), but `prefix` is the default because it matches the ecosystem.
+
+3. **Default reply modes are opinionated.**
+   - Built-ins `ALL`, `CQ`, `QST`, `YAESU` default to `replyMode = sender` — these are broadcast/discovery conventions where the right reply is 1:1 to whoever spoke up.
+   - Custom groups default to `replyMode = group` — clubs want chat-room semantics.
+   - The UI surfaces the reply-mode icon (`campaign` for sender, `forum` for group) on every group tile so the mental model is visible.
+
+4. **ACK policy: never.** Group messages are one-to-many; per APRS convention they are not acknowledged. Even when the wire carries a message-ID suffix, the matcher never emits an ACK for a `GroupClassification`. See ADR-055 for the full matrix.
+
+5. **Name validation: `[A-Z0-9]{1,9}`.** 9 characters is the wire addressee limit. Upper-cased on set; the settings editor normalizes input. No punctuation — the wire field is ASCII alphanumeric only.
+
+6. **Built-ins may be disabled, not deleted or renamed.** This preserves the "quiet by default" opt-in for `ALL` and `YAESU` while keeping the defaults discoverable. `isBuiltin: true` is set on the seeded rows and enforced by the service.
+
+7. **First-match-wins within user-defined order.** Groups `CQ` and `CQFOO` both in prefix mode for addressee `CQFOO` → whichever appears earlier in the subscription list wins. Settings provides a reorderable list so operators can place narrow before broad when they care.
+
+8. **Group conversations keyed in the existing `_conversations` map** under `#GROUP:<NAME>` prefix (no callsign starts with `#`, so no collision). Keeps the v0.14 persistence layer intact — no separate storage schema for PR 1. v0.15's drift migration will consolidate both direct and group threads into the same message table.
+
+9. **Own-SSID echo.** When the user sends a group message, the service also captures it as a received group message from the operator's own callsign — so it appears in the group channel view alongside replies. This is receive-side behavior only; send wiring completes in PR 4.
+
+### Consequences
+
+- New `lib/models/group_subscription.dart` — `GroupSubscription`, `MatchMode`, `ReplyMode`, `matches()` helper.
+- New `lib/services/group_subscription_service.dart` — CRUD + seeder (`group_subscriptions_v1` SharedPreferences key, `group_subscriptions_seeded_v1` idempotence flag).
+- `MessageEntry.category: MessageCategory` + `MessageEntry.groupName: String?` — legacy-safe JSON deserialization (missing keys default to `direct` + null).
+- `MessageCategory` enum in `lib/models/message_category.dart`.
+- Send path, adaptive compose, group channel view, reply-mode routing — PR 3 / PR 4 of v0.17.
+
+---
+
+## ADR-057: Bulletin transmission model — APRSIS32 fixed interval (v0.17, planned for PR 4)
+
+**Date:** 2026-04-23
+**Status:** Proposed (finalized in PR 4)
+
+### Context
+
+Two APRS bulletin transmission conventions exist in the wild:
+
+1. **WB4APR exponential decay** — send at 1m, 2m, 4m, 8m, …, up to some cap. Reduces channel load over time. Originally designed for AX.25 RF bulletin boards where bulletins lived for days.
+2. **APRSIS32 fixed-interval** — send at a user-chosen interval (typically 30 min) for a bounded lifetime (typically 24h). Simpler mental model, easier UX, matches what modern mobile-first APRS clients do.
+
+### Decision
+
+Use the APRSIS32 fixed-interval model with an initial pulse and a hard expiry:
+
+- `intervalSeconds` — 0 (one-shot) or 300 / 600 / 900 / 1800 / 3600
+- `expiresAt` — defaults to `createdAt + 24h`; user picks 2h / 6h / 12h / 24h / 48h
+- Scheduler fires an initial pulse on creation, then retransmits every `intervalSeconds` until expiry
+- Expired bulletins are disabled and fire a "repost?" notification
+- Edit body or addressee → reset `lastTransmittedAt = null`, `transmissionCount = 0`; initial pulse on next tick
+- Edit interval or expiry only → no reset
+- Retransmission history stored as aggregate counters (`transmissionCount`, `lastTransmittedAt`) — no per-receipt array (sufficient for aging + UI, scales to the drift migration without data loss).
+
+### Rationale
+
+- Operators do not need minute-level tuning of channel-load; the fixed interval is well-understood.
+- A bounded lifetime forces the operator to consciously re-post rather than letting stale bulletins linger.
+- The decay curve in WB4APR's model assumes a low-activity mailbox paradigm that doesn't match how modern clients consume bulletins (scrolling feed + notifications).
+- Fixed interval is easier to schedule in a background isolate alongside the beacon timer without dynamic recomputation.
+
+### ACK policy
+
+Bulletins are never ACKed. The `BulletinClassification` path in `MessageService` does not call `_transmitAck` under any circumstance.
+
+### Consequences (to be realized in PR 4)
+
+- `lib/services/bulletin_scheduler.dart` — 30s tick in main isolate, sibling to `BeaconingService`.
+- Background isolate (`meridian_connection_task.dart`) gains a parallel bulletin timer that reads `OutgoingBulletin` list from SharedPreferences on each fire (same pattern as the existing beacon-settings read).
+- `AprsEncoder.encodeBulletin(addressee, body)` — 9-char space-padded addressee, `:BLN0     :Body`, no wire ID.
+- RF path sourced from Advanced-mode "Bulletin path" setting (default `WIDE2-2`); APRS-IS has no path.

--- a/docs/specs/v0.17-groups-and-bulletins-spec.md
+++ b/docs/specs/v0.17-groups-and-bulletins-spec.md
@@ -1,0 +1,555 @@
+# v0.17 — Group Messaging & Bulletins
+
+**Status:** Spec (revision 2)
+**Milestone:** v0.17
+**Depends on:** v0.5 (messaging), v0.10 (area filter), v0.11 (notifications), v0.13 (filter UI, Advanced Mode), v0.14 (base-callsign matching)
+**Related ADRs (to be authored):** 055, 056, 057, 058, 059
+
+---
+
+## 1. Overview
+
+Meridian's messaging system today handles **direct** (1:1) messages, including cross-SSID matching for the operator's own base callsign (v0.14). This milestone extends messaging with two additional APRS message categories, both defined at the protocol level and fully interoperable with Yaesu, Kenwood, and modern software clients:
+
+- **Group messages** — messages addressed to a group name (`CQ`, `ALL`, `QST`, `SRARC`, etc.) rather than a callsign. Pure protocol-level: no server, no subscription mechanism on the network. "Subscription" is a local receiver filter.
+- **Bulletins** — broadcast messages addressed to `BLN0`–`BLN9` (general) or `BLNxNAME` (group bulletins). Periodic retransmission-based, never ACKed.
+
+Reference implementations we match:
+- **APRSIS32** for bulletin send model (fixed interval + 48h aging) and bulletin board semantics
+- **Yaesu FT5D / Kenwood TH-D74** for group addressee filter behavior
+- **aprs.fi** for bulletin global-view expectations
+
+---
+
+## 2. Scope
+
+### In scope
+- Receive, route, and display group messages with per-group wildcards
+- Send group messages with context-dependent reply mode (to sender vs. to group)
+- Receive and display bulletins, categorized by source and group, with age-out
+- Send bulletins (numbered `BLN#` and named `BLNxNAME`) with fixed-interval retransmission
+- Subscription management: built-in + custom groups + named bulletin groups
+- Settings integration in existing Messaging category
+- Notification integration per v0.11 infrastructure
+- APRS-IS filter expansion for bulletin scope
+- Advanced-mode-gated RF path settings for group messages and bulletins
+
+### Out of scope (deferred to FUTURE_FEATURES.md)
+- CQSRVR / ANSRVR server integration
+- APRSIS32-style sorted bulletin board
+- Group message full-text search
+- Bulletins as digipeater/relay feature
+- Per-bulletin path override (global only for v0.17)
+- Announcement messages distinct from bulletins
+
+---
+
+## 3. Key decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Addressee matcher precedence | **Bulletin → Direct → Group** (first match wins) | Load-bearing for ACK correctness; see ADR-055 |
+| Reply semantics | Per-group `reply_mode` (sender \| group) | Neither Yaesu/Kenwood nor software-client convention fits all uses |
+| Default reply — built-ins | `sender` for ALL/CQ/QST | Broadcast/discovery groups |
+| Default reply — custom | `group` | Clubs want chat-room semantics |
+| Wildcards | Prefix match on 9-char addressee | Matches Yaesu `ALL******` |
+| Bulletin transmit | Fixed interval + initial pulse + max lifetime | APRSIS32-standard |
+| Bulletin aging | 48h since last heard | Matches APRSIS32 |
+| General bulletin distance origin | **User station location** (required) | Map center too jittery |
+| Location unknown → general bulletins | **APRS-IS disabled**, banner shown; RF + named groups unaffected | No arbitrary fallback origin |
+| General bulletin scope (when known) | Area + 500 km default | Balances relevance with context |
+| Named bulletin scope | Global if subscribed | Club bulletins are non-geographic |
+| Own-SSID echo in group view | Yes | Continuity |
+| Onboarding | Settings-only | v0.12 stays focused |
+| Default subscriptions | CQ + QST enabled (notif off); ALL + YAESU disabled | Quiet defaults |
+| Bulletin send via APRS-IS | Allowed per-bulletin | Matches APRSIS32 |
+| RF path control | **Advanced-mode settings** for group and bulletin paths | Explicit user control |
+| Default group message path | Same as beacon path | User already configured sensibly |
+| Default bulletin path | `WIDE2-2` | Traditional APRS bulletin path |
+| Retransmission history | Aggregate counters + `last_heard_at` only | Sufficient for aging + UI |
+
+---
+
+## 4. UI Design
+
+### 4.1 Messaging tab restructure
+
+Segmented control at top switches between three views. No new bottom nav.
+
+- **Direct** — existing v0.14 conversation list (unchanged)
+- **Groups** — subscribed groups with unread counts and previews
+- **Bulletins** — chronological bulletin feed with source badges
+
+Android: M3 `SegmentedButton`. iOS: `CupertinoSlidingSegmentedControl`. Unread `Badge` per M3.
+
+### 4.2 Groups view
+
+Tiles show:
+- Reply-mode icon (📢 broadcast for `sender`, 💬 chat for `group`)
+- Group name
+- Unread badge
+- Last-message preview (sender + snippet + time)
+
+Icons: Material Symbols `campaign`/`forum`; Cupertino `megaphone`/`bubble.left.and.bubble.right`.
+
+Long-press menu: Mark all read, Notifications toggle, Edit, Mute 1h/8h/24h, Delete (custom only).
+
+### 4.3 Group channel view
+
+Single chronological feed (not threaded). Each bubble shows sender callsign prominently.
+
+Compose adapts to `reply_mode`:
+- **Group mode:** `[💬 Message to SRARC] [Send]`
+- **Sender mode:** `[📢 Reply to W1ABC-9 (last sender)] [Send]` + secondary "Send to group instead"
+
+Per-message action sheet: Reply directly to sender / Send to group / Copy / View sender station.
+
+### 4.4 Bulletins view
+
+Chronological feed with filter chips: [All / General / Groups / My bulletins].
+
+Each row: addressee · source callsign · `RF`|`IS` badge · last-heard time · body.
+
+**Location-unknown banner:** When station location is unknown and APRS-IS connected: "General bulletins from APRS-IS are hidden because your station location isn't set. [Set location →]". RF bulletins and named group bulletins still appear.
+
+Bulletin tap → detail: full text, source, first-heard + last-heard, total receipts, transports observed, "Message sender" action (opens direct thread). **No inline reply** — bulletins are one-way.
+
+### 4.5 Bulletin compose
+
+FAB in Bulletins view. Fields: Type (General/Group) → Line # (0–9 or A–Z) → Group name (if Group) → Body (67 chars) → Transmit interval (One-shot / 10 / 15 / 30 / 60 min) → Expires in (2h / 6h / 12h / 24h / 48h) → via RF / via APRS-IS.
+
+"My bulletins" section shows active outgoing bulletins with next-tx countdown, transmission count, expiry, Edit/Delete.
+
+### 4.6 Settings integration
+
+Within existing **Messaging** category (v0.13 reorg):
+
+**Groups**
+- Subscribed groups list (reorderable; built-ins lock-iconed on delete)
+- Add custom group (editor: name, match_mode, reply_mode, notify)
+- Per-group: enabled, notify, reply_mode, match_mode, edit/delete (custom only)
+- *Advanced mode only:* **Group message path** (default: "Same as beacon path")
+
+**Bulletins**
+- Show bulletins (master toggle; default on)
+- Notify on bulletins (default off)
+- Bulletin radius: [Map area / +100 km / +500 km / +1000 km / Global] (default +500 km)
+- Named bulletin group subscriptions (list)
+- Retention: [24h / 48h / 72h] (default 48h)
+- *Advanced mode only:* **Bulletin path** (default `WIDE2-2`)
+- *Advanced mode only:* Muted bulletin sources (callsign blocklist)
+
+Advanced-mode gating per AdvancedModeController (ADR-053). When off, path settings fall back to defaults and are hidden.
+
+---
+
+## 5. Data Model
+
+### 5.1 `GroupSubscription`
+
+```
+GroupSubscription {
+  id              : int (primary key)
+  name            : String         // 1-9 chars, uppercase alphanumeric
+  match_mode      : MatchMode      // prefix | exact (default: prefix)
+  enabled         : bool
+  notify          : bool
+  reply_mode      : ReplyMode      // sender | group
+  is_builtin      : bool           // built-ins: disable OK, delete/rename blocked
+  created_at      : DateTime
+  updated_at      : DateTime
+}
+```
+
+Default built-in rows seeded on first run:
+
+| name   | match_mode | enabled | notify | reply_mode |
+|--------|------------|---------|--------|------------|
+| ALL    | prefix     | false   | false  | sender     |
+| CQ     | prefix     | true    | false  | sender     |
+| QST    | prefix     | true    | false  | sender     |
+| YAESU  | prefix     | false   | false  | sender     |
+
+Name validation: 1–9 chars, `[A-Z0-9]` only, uppercase-normalized.
+
+### 5.2 `BulletinSubscription`
+
+```
+BulletinSubscription {
+  id          : int (primary key)
+  group_name  : String         // 1-5 chars, uppercase alphanumeric
+  notify      : bool
+  created_at  : DateTime
+}
+```
+
+No default rows. General bulletins `BLN0`-`BLN9` governed by radius, not subscriptions.
+
+### 5.3 `Bulletin`
+
+Separate from `MessageEntry` because retransmissions update (not duplicate) and aging is time-since-last-heard.
+
+```
+Bulletin {
+  id                  : int (primary key)
+  source_callsign     : String
+  addressee           : String         // e.g., "BLN0", "BLN1WX"
+  category            : BulletinCategory  // general | groupNamed
+  group_name          : String?        // "WX" for BLN1WX, null for BLN0-9
+  line_number         : String         // "0"-"9" or "A"-"Z"
+  body                : String         // up to 67 chars
+  first_heard_at      : DateTime
+  last_heard_at       : DateTime       // drives aging
+  heard_count         : int            // aggregate only — no per-receipt array
+  transports          : Set<TransportSource>  // {rf, aprsIs}
+  received_lat        : double?        // receiver pos at ingest (null for RF)
+  received_lon        : double?
+  is_read             : bool
+}
+```
+
+Unique constraint `(source_callsign, addressee)`.
+
+### 5.4 `OutgoingBulletin`
+
+```
+OutgoingBulletin {
+  id                   : int (primary key)
+  addressee            : String
+  body                 : String
+  interval_seconds     : int            // 0 = one-shot; else 300/600/900/1800/3600
+  expires_at           : DateTime
+  created_at           : DateTime
+  last_transmitted_at  : DateTime?
+  transmission_count   : int
+  via_rf               : bool
+  via_aprs_is          : bool
+  enabled              : bool
+}
+```
+
+Path comes from global "Bulletin path" (Advanced mode; default `WIDE2-2`). No per-bulletin path override in v0.17.
+
+### 5.5 Extensions to `MessageEntry`
+
+Add:
+```
+category     : MessageCategory   // direct | group | bulletin
+group_name   : String?           // matched subscription name, if category=group
+```
+
+Bulletins stored in `Bulletin` table, not `MessageEntry`.
+
+---
+
+## 6. Ingestion pipeline — addressee precedence
+
+**This section is architecturally load-bearing. See ADR-055.** Reordering these rules will cause protocol violations.
+
+### 6.1 Required precedence
+
+For every incoming APRS message-format packet, apply rules in this exact order, first-match-wins:
+
+1. **Bulletin** — addressee matches `^BLN[0-9A-Z]`
+2. **Direct (to me)** — addressee matches operator's callsign variants (v0.14 / ADR-054)
+3. **Group** — addressee matches any enabled `GroupSubscription` per its `match_mode`
+
+### 6.2 Why this exact order
+
+- **Bulletin first:** syntactically unambiguous — no legitimate callsign starts with `BLN[0-9A-Z]`. Prevents pathological groups (`BLN`, `B`) from capturing bulletins.
+- **Direct before Group:** guarantees messages to operator's own callsign classify as direct and get ACKed. If Group came first, a permissive custom group (e.g., `W1` with prefix match when operator is `W1ABC`) would capture direct messages, skip the ACK, and the sender's retry loop would never terminate — operator appears unreachable despite receiving.
+- **Group last:** user-configurable and potentially broad. More specific rules handled first; group is fallback.
+
+### 6.3 Classification algorithm
+
+```dart
+/// Classifies an incoming message addressee using strict precedence:
+/// Bulletin > Direct > Group. This ordering is load-bearing for ACK
+/// correctness — see ADR-055. Do not reorder without updating the ADR.
+MessageClassification classifyWithPrecedence(
+  String addressee,
+  OperatorIdentity identity,
+  List<GroupSubscription> enabledSubscriptions,
+) {
+  final normalized = addressee.trim().toUpperCase();
+
+  // 1. Bulletin — syntactic; cannot conflict with callsigns
+  if (_bulletinPattern.hasMatch(normalized)) {
+    return MessageClassification.bulletin(_parseBulletinAddressee(normalized));
+  }
+
+  // 2. Direct — ACK-required (v0.14 matching)
+  if (identity.matchesOwnCallsign(normalized)) {
+    return MessageClassification.direct();
+  }
+
+  // 3. Group — user-configurable; lowest precedence
+  for (final sub in enabledSubscriptions) {
+    if (sub.matches(normalized)) {
+      return MessageClassification.group(sub);
+    }
+  }
+
+  return MessageClassification.none();
+}
+```
+
+Method name and doc comment are part of the contract.
+
+### 6.4 ACK rules
+
+| Classification | ACK? |
+|---|---|
+| Direct | **Yes** (v0.14 rules) |
+| Group | **Never** |
+| Bulletin | **Never** |
+
+### 6.5 Bulletin handler
+
+```
+on_bulletin_classified(packet, info):
+  if info.category == general:        // BLN0-9
+    if packet.transport == aprsIs:
+      if user_station_location is null: drop
+      elif distance(packet.source, user_station) > radius_km: drop
+    // RF general bulletins: always kept
+  elif info.category == groupNamed:
+    if info.group_name not in BulletinSubscription: drop
+
+  upsert Bulletin where (source, addressee):
+    body = packet.body
+    last_heard_at = now()
+    heard_count += 1
+    transports |= packet.transport_source
+    is_read = false  // if body changed or first time
+
+  if changed and notifications enabled: fire notification
+```
+
+### 6.6 Own-SSID echo
+
+When user sends a group message, the message is also captured as a received group message (from own callsign) and appears in channel view.
+
+---
+
+## 7. APRS-IS Filter integration
+
+Extend existing v0.10/v0.13 filter:
+
+```
+existing:  a/<lat1>/<lon1>/<lat2>/<lon2>  t/m
+added:     g/BLN0 g/BLN1 ... g/BLN9
+added:     g/BLN*WX g/BLN*SRARC ...   (per BulletinSubscription)
+```
+
+APRS-IS doesn't natively express "within N km of my station." Client-side implementation:
+1. Request `t/m` + `g/BLN*` explicitly
+2. Filter bulletins by haversine distance from user station at ingest
+3. General bulletins beyond radius dropped; named group bulletins always kept
+4. Station position unknown → APRS-IS general bulletins dropped (banner per §4.4)
+
+Filter construction centralized in `AprsIsFilterBuilder`.
+
+---
+
+## 8. Bulletin transmission model
+
+APRSIS32-standard: fixed interval + initial pulse + max lifetime. See ADR-057.
+
+### 8.1 `BulletinScheduler`
+
+```
+// Foreground + background via MeridianConnectionService (v0.7) / MeridianConnectionTask (v0.9)
+every 30s tick:
+  for ob in enabled OutgoingBulletins:
+    if now > ob.expires_at:
+      ob.enabled = false
+      fire notification: "Bulletin expired. Repost?"
+      continue
+    if ob.interval_seconds == 0 and ob.transmission_count > 0:
+      continue  // one-shot, already sent
+    if ob.last_transmitted_at == null:
+      transmit(ob)  // initial pulse
+      continue
+    if now - ob.last_transmitted_at >= ob.interval_seconds:
+      transmit(ob)
+```
+
+### 8.2 Transmission
+
+- Route via TxService (Serial > BLE > APRS-IS per ADR-029)
+- Honor `via_rf` / `via_aprs_is` flags
+- **Path (RF only):** Advanced-mode "Bulletin path" (default `WIDE2-2`). APRS-IS has no path.
+- Packet format: `:BLN0     :Body text` (9-char padded addressee, colon, body)
+- Update `last_transmitted_at` and `transmission_count` on success
+
+### 8.3 Defaults
+
+- `interval_seconds`: 1800 (30 min)
+- `expires_at`: created_at + 24h
+- `via_rf`: true if any RF transport enabled
+- `via_aprs_is`: true if APRS-IS enabled
+
+### 8.4 Edit / Delete
+
+- Edit body or addressee → reset `last_transmitted_at = null`, `transmission_count = 0`; initial pulse on next tick
+- Edit interval/expiry only → no reset
+- Delete → row removed; no "cancel packet" exists in spec
+
+### 8.5 Outgoing group messages (RF path)
+
+Group messages via RF use Advanced-mode "Group message path" (default: same as beacon path). Fire-and-forget single transmissions — no scheduler.
+
+### 8.6 Background integration
+
+- **iOS:** existing v0.9 VoIP / `bluetooth-central`; scheduler runs in `MeridianConnectionTask` isolate alongside beacon timer
+- **Android:** existing v0.7 `MeridianConnectionService` foreground service; scheduler runs as sibling timer
+- **Desktop:** main isolate
+
+No new background service.
+
+---
+
+## 9. Notifications
+
+Extend v0.11 system:
+
+| Channel | Default | Body format |
+|---|---|---|
+| Group message (built-in: CQ, QST, etc.) | Off | `W1ABC-9 in CQ: <body>` |
+| Group message (custom) | **On** | `W1ABC-9 in SRARC: <body>` |
+| Bulletin (general) | Off | `Bulletin from K5WX-15: <body>` |
+| Bulletin (subscribed group) | **On** | `WX bulletin from K5WX-15: <body>` |
+| My bulletin expired | On | `Your bulletin BLN0 expired. Tap to repost.` |
+
+Android M3: notification channels. iOS: `UNUserNotificationCenter` categories.
+
+---
+
+## 10. Offline support check
+
+Meridian's principle: fully functional on RF only.
+
+| Feature | RF-only | APRS-IS-only | Notes |
+|---|---|---|---|
+| Receive group messages | ✓ | ✓ | Pure protocol-level |
+| Send group messages | ✓ | ✓ | Uses "Group message path" (RF); fire-and-forget |
+| Receive general bulletins | ✓ (no distance filter) | ✓ (distance filter applies) | RF always shown; APRS-IS filtered |
+| Receive named group bulletins | ✓ | ✓ | Subscription-based; no distance filter |
+| Send bulletins | ✓ | ✓ | Flags independent; uses "Bulletin path" on RF |
+| Subscription management | ✓ | ✓ | Local settings |
+| Bulletin scheduler | ✓ | ✓ | Routes via enabled transport(s) |
+| Bulletin aging | ✓ | ✓ | Based on `last_heard_at` |
+| Notifications | ✓ | ✓ | Local |
+
+**Station location unknown:** RF unaffected; APRS-IS general bulletins suppressed with banner; named groups unaffected.
+
+**No APRS-IS at all:** Everything except APRS-IS-specific ingest/transmit works normally.
+
+---
+
+## 11. Testing strategy
+
+### Unit tests (target: ~90 new)
+
+**Matcher precedence (critical — ADR-055). Required test cases:**
+
+| Case | Addressee | Setup | Expected |
+|---|---|---|---|
+| Bulletin beats pathological group | `BLN0` | Group `B` prefix | `bulletin` |
+| Bulletin beats named-overlap group | `BLN1SRARC` | Group `SRARC` | `bulletin` |
+| Direct beats group (prefix conflict) | `W1ABC-7` | Operator `W1ABC`; group `W1` prefix | `direct`, ACKs |
+| Direct beats group (exact conflict) | `W1ABC` | Operator `W1ABC`; group `W1ABC` exact | `direct`, ACKs |
+| Group matches when no direct/bulletin | `CQ` | Group `CQ` | `group`, no ACK |
+| First subscription match wins | `CQFOO` | Groups `CQ`, `CQFOO` (both prefix) | First in list order |
+| Disabled subscriptions don't match | `CQ` | Group `CQ` disabled | `none` |
+| Exact mode rejects longer addressee | `CQRS` | Group `CQ` exact | `none` |
+| Prefix mode accepts longer | `CQRS` | Group `CQ` prefix | `group` |
+
+**Bulletin scope filtering**
+- General within radius: kept
+- General outside radius: dropped
+- General, station location null, APRS-IS: dropped
+- General, station location null, RF: kept
+- Named group, subscribed: kept (any distance, any transport)
+- Named group, not subscribed: dropped
+- RF general: always kept regardless of distance
+
+**BulletinScheduler**
+- Initial pulse fires on creation
+- Second transmission after `interval_seconds`
+- One-shot sends exactly once
+- Expired bulletin stops and notifies
+- Edit body/addressee resets count and triggers new pulse
+- Edit interval/expiry only doesn't reset
+- Delete stops transmission
+- Disabled doesn't transmit
+
+**Defaults seeder**
+- Fresh install populates built-in rows
+- Existing install not disturbed (idempotent)
+
+### Widget tests
+- Segmented control switches views
+- Group tile renders correct icon per reply_mode
+- Group channel shows sender attribution on every bubble
+- Compose adapts to reply_mode
+- Bulletin detail has no reply affordance
+- Bulletin compose validates addressee
+- Location-unknown banner shows/hides correctly
+- Advanced-mode path settings hidden when off
+
+### Integration tests
+- E2E: receive group message → Groups tab → channel view → reply routes correctly per reply_mode
+- E2E: create bulletin → scheduler transmits → expires and notifies
+- APRS-IS filter string contains expected `g/` additions based on subscriptions
+
+---
+
+## 12. ADRs to author
+
+- **ADR-055:** Addressee matcher precedence (Bulletin → Direct → Group) — standalone ADR because load-bearing for ACK correctness. Includes required test cases from §11 as part of the ADR.
+- **ADR-056:** Group messaging architecture — subscription model, wildcard semantics, reply_mode defaults
+- **ADR-057:** Bulletin transmission model — fixed interval + aging; rationale for not implementing WB4APR exponential decay
+- **ADR-058:** Bulletin scope and APRS-IS filter extension — radius model, client-side distance filtering, station-location-required
+- **ADR-059:** Messaging tab restructure — segmented control, Direct/Groups/Bulletins split
+
+---
+
+## 13. Open items (answered in rev 2)
+
+| # | Item | Resolution |
+|---|---|---|
+| Q1 | Position-unknown bulletin handling | Disable APRS-IS general bulletins; show banner; RF + named groups unaffected |
+| Q2 | Retransmission history persistence | Aggregate counters + `last_heard_at` only; no per-receipt array |
+| Q3 | RF etiquette for sends | Replaced with Advanced-mode path settings (Bulletin path, Group message path) |
+| Q4 | v0.17 scope | Accepted; Claude Code flags early if split to v0.18 warranted |
+| Q5 | Group vs bulletin subscription separation | Keep separate entities; Settings shows near each other with explanatory note |
+
+---
+
+## 14. Implementation breakdown
+
+Suggested task ordering for Claude Code plan-mode:
+
+1. **Data model foundation** — new schemas + migrations; extend `MessageEntry`
+2. **Defaults seeder** — idempotent built-in group subscriptions
+3. **`AddresseeMatcher` precedence** — `classifyWithPrecedence()` with load-bearing comment
+4. **Ingestion integration** — wire matcher; bulletin upsert; scope filtering
+5. **Settings — Groups subsection**
+6. **Settings — Bulletins subsection**
+7. **Settings — Advanced-mode paths** (AdvancedModeController gating)
+8. **Messaging tab segmented control** — Direct unchanged
+9. **Groups list view**
+10. **Group channel view** — adaptive compose
+11. **Bulletin feed view** — source badges, filter chips, location-unknown banner
+12. **Bulletin detail view**
+13. **Bulletin compose**
+14. **`BulletinScheduler`**
+15. **Transport integration** — bulletin TxService routing; group message path
+16. **APRS-IS filter extension**
+17. **Notification channels**
+18. **ADRs 055–059**
+19. **Tests throughout** (not at end)
+
+Sequential, not parallel.

--- a/lib/core/callsign/addressee_matcher.dart
+++ b/lib/core/callsign/addressee_matcher.dart
@@ -1,0 +1,93 @@
+/// Addressee classifier for incoming APRS message packets.
+///
+/// Applies three rules in a fixed, load-bearing order:
+///
+///   1. **Bulletin** — syntactic match on `BLN[0-9A-Z]…`
+///   2. **Direct** — matches the operator's own callsign (any SSID, v0.14)
+///   3. **Group**   — matches any enabled [GroupSubscription]
+///
+/// The order is not a style preference. Reordering it causes protocol
+/// violations. If a message to `W1ABC-7` (operator `W1ABC`) classifies as a
+/// group before it classifies as direct, the code below will not ACK it —
+/// the sender's retry loop then never terminates and the operator appears
+/// unreachable despite receiving.
+///
+/// **Do not reorder. Do not collapse into a single matcher list. Do not
+/// rename to `classify()`.** The method name is part of the contract — it
+/// signals intent to future contributors. If a refactor looks cleaner by
+/// reordering these rules, stop and re-read ADR-055 before writing code.
+///
+/// See `docs/DECISIONS.md` ADR-055 for the full rationale, the required test
+/// cases in `test/core/callsign/addressee_matcher_test.dart`, and ADR-054 for
+/// the underlying direct-match rules (exact + cross-SSID, `-0` normalized).
+library;
+
+import '../../models/bulletin.dart';
+import '../../models/group_subscription.dart';
+import 'message_classification.dart';
+import 'operator_identity.dart';
+
+class AddresseeMatcher {
+  AddresseeMatcher._();
+
+  /// Matches `BLN` + line character (digit 0–9 or letter A–Z) as the first
+  /// four characters. Any addressee starting with this prefix is a bulletin
+  /// — no legitimate callsign has this shape, so the syntactic test is safe.
+  static final RegExp _bulletinPattern = RegExp(r'^BLN[0-9A-Z]');
+
+  /// Classifies an incoming message addressee using strict precedence:
+  /// Bulletin > Direct > Group. This ordering is load-bearing for ACK
+  /// correctness — see ADR-055. Do not reorder without updating the ADR.
+  ///
+  /// [addressee] is the raw wire field (trailing spaces permitted). [identity]
+  /// is the operator's current [OperatorIdentity] snapshot. [enabledSubscriptions]
+  /// is evaluated in list order; first-match-wins.
+  static MessageClassification classifyWithPrecedence(
+    String addressee,
+    OperatorIdentity identity,
+    List<GroupSubscription> enabledSubscriptions,
+  ) {
+    final normalized = addressee.trim().toUpperCase();
+
+    // 1. Bulletin — syntactic; cannot conflict with callsigns.
+    if (_bulletinPattern.hasMatch(normalized)) {
+      return BulletinClassification(_parseBulletinAddressee(normalized));
+    }
+
+    // 2. Direct — ACK-required (v0.14 rules).
+    if (identity.matchesOwnCallsign(normalized)) {
+      return DirectClassification(
+        isExactMatch: identity.matchesExactly(normalized),
+      );
+    }
+
+    // 3. Group — user-configurable; lowest precedence.
+    for (final sub in enabledSubscriptions) {
+      if (sub.matches(normalized)) {
+        return GroupClassification(sub);
+      }
+    }
+
+    return const NoneClassification();
+  }
+
+  /// Parses an already-validated bulletin addressee into structured fields.
+  ///
+  /// `BLN0`      → line=`"0"`, general
+  /// `BLN1WX`    → line=`"1"`, groupNamed, group=`"WX"`
+  /// `BLNASRARC` → line=`"A"`, groupNamed, group=`"SRARC"`
+  static BulletinAddresseeInfo _parseBulletinAddressee(String addressee) {
+    // Guaranteed: length >= 4, matches `^BLN[0-9A-Z]`.
+    final line = addressee.substring(3, 4);
+    final rest = addressee.length > 4 ? addressee.substring(4) : '';
+    final isGeneral = rest.isEmpty && RegExp(r'^[0-9]$').hasMatch(line);
+    return BulletinAddresseeInfo(
+      addressee: addressee,
+      lineNumber: line,
+      category: isGeneral
+          ? BulletinCategory.general
+          : BulletinCategory.groupNamed,
+      groupName: isGeneral ? null : rest,
+    );
+  }
+}

--- a/lib/core/callsign/message_classification.dart
+++ b/lib/core/callsign/message_classification.dart
@@ -1,0 +1,43 @@
+/// Result of [AddresseeMatcher.classifyWithPrecedence]. The classification
+/// determines UI routing, storage (Conversation vs. Bulletin), and — most
+/// importantly — whether an ACK should be sent.
+///
+/// Do not fold this into a boolean or flatten to a flag enum. The concrete
+/// subtypes carry information downstream handlers need (the matched
+/// subscription, the parsed bulletin info, the exact-vs-cross-SSID
+/// distinction for ACK eligibility).
+///
+/// See ADR-055.
+library;
+
+import '../../models/bulletin.dart';
+import '../../models/group_subscription.dart';
+
+sealed class MessageClassification {
+  const MessageClassification();
+}
+
+/// The addressee is a bulletin (`BLN[0-9A-Z]…`). Never ACKed.
+class BulletinClassification extends MessageClassification {
+  const BulletinClassification(this.info);
+  final BulletinAddresseeInfo info;
+}
+
+/// The addressee targets the operator's own callsign (any SSID form per
+/// ADR-054). [isExactMatch] governs ACK eligibility — exact matches get ACKed,
+/// cross-SSID matches never do.
+class DirectClassification extends MessageClassification {
+  const DirectClassification({required this.isExactMatch});
+  final bool isExactMatch;
+}
+
+/// The addressee matches an enabled [GroupSubscription]. Never ACKed.
+class GroupClassification extends MessageClassification {
+  const GroupClassification(this.subscription);
+  final GroupSubscription subscription;
+}
+
+/// The addressee did not match any rule. Drop the packet.
+class NoneClassification extends MessageClassification {
+  const NoneClassification();
+}

--- a/lib/core/callsign/operator_identity.dart
+++ b/lib/core/callsign/operator_identity.dart
@@ -1,0 +1,64 @@
+/// Immutable snapshot of the operator's identity for addressee classification.
+///
+/// Kept separate from `ConnectionCredentials` because the matcher does not need
+/// the passcode or licensed flag — only the callsign shape. Build via
+/// [StationSettingsService.operatorIdentity].
+library;
+
+import 'callsign_utils.dart';
+
+class OperatorIdentity {
+  OperatorIdentity({required String callsign, required this.ssid})
+    : callsign = callsign.toUpperCase(),
+      _fullAddressNormalized = normalizeCallsign(
+        ssid == 0 ? callsign.toUpperCase() : '${callsign.toUpperCase()}-$ssid',
+      ),
+      _baseCallsign = stripSsid(callsign.toUpperCase());
+
+  /// The bare callsign (no SSID), uppercased.
+  final String callsign;
+
+  /// Numeric SSID (0–15); letter SSIDs are not representable here because the
+  /// operator's own SSID is stored as an integer in settings.
+  final int ssid;
+
+  final String _fullAddressNormalized;
+  final String _baseCallsign;
+
+  /// True when [callsign] is empty — e.g., before onboarding completes.
+  bool get isEmpty => callsign.isEmpty;
+
+  /// Full AX.25-style address with `-0` stripped (matches APRS spec).
+  String get fullAddressNormalized => _fullAddressNormalized;
+
+  /// Base callsign without SSID.
+  String get baseCallsign => _baseCallsign;
+
+  /// True if [addressee] targets this operator's callsign in any SSID form
+  /// (exact-match or cross-SSID per ADR-054).
+  ///
+  /// Returns false when the identity is empty (pre-onboarding) so messages
+  /// don't classify as direct before the user has a callsign.
+  bool matchesOwnCallsign(String addressee) {
+    if (isEmpty) return false;
+    final normalized = normalizeCallsign(addressee);
+    if (normalized == _fullAddressNormalized) return true;
+    return stripSsid(normalized) == _baseCallsign;
+  }
+
+  /// True when the match is exact (same SSID). Only exact matches get ACKed;
+  /// cross-SSID matches are displayed but never ACKed (ADR-054).
+  bool matchesExactly(String addressee) {
+    if (isEmpty) return false;
+    return normalizeCallsign(addressee) == _fullAddressNormalized;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is OperatorIdentity &&
+      other.callsign == callsign &&
+      other.ssid == ssid;
+
+  @override
+  int get hashCode => Object.hash(callsign, ssid);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,9 @@ import 'screens/map_screen.dart';
 import 'screens/onboarding/onboarding_screen.dart';
 import 'services/background_service_manager.dart';
 import 'services/beaconing_service.dart';
+import 'services/bulletin_service.dart';
+import 'services/bulletin_subscription_service.dart';
+import 'services/group_subscription_service.dart';
 import 'services/ios_background_service.dart';
 import 'services/message_service.dart';
 import 'services/station_service.dart';
@@ -184,7 +187,25 @@ Future<void> main() async {
   );
   await beaconingService.loadPersistedSettings();
 
-  final messageService = MessageService(stationSettings, txService, service);
+  final groupSubscriptions = GroupSubscriptionService(prefs: prefs);
+  await groupSubscriptions.load();
+
+  final bulletinSubscriptions = BulletinSubscriptionService(prefs: prefs);
+  await bulletinSubscriptions.load();
+
+  final bulletinService = BulletinService(
+    subscriptions: bulletinSubscriptions,
+    prefs: prefs,
+  );
+  await bulletinService.load();
+
+  final messageService = MessageService(
+    stationSettings,
+    txService,
+    service,
+    groupSubscriptions: groupSubscriptions,
+    bulletins: bulletinService,
+  );
   await messageService.loadHistory();
 
   final bannerController = InAppBannerController();
@@ -261,6 +282,13 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider<TxService>.value(value: txService),
         ChangeNotifierProvider<BeaconingService>.value(value: beaconingService),
+        ChangeNotifierProvider<GroupSubscriptionService>.value(
+          value: groupSubscriptions,
+        ),
+        ChangeNotifierProvider<BulletinSubscriptionService>.value(
+          value: bulletinSubscriptions,
+        ),
+        ChangeNotifierProvider<BulletinService>.value(value: bulletinService),
         ChangeNotifierProvider<MessageService>.value(value: messageService),
         ChangeNotifierProvider<BackgroundServiceManager>.value(
           value: bgServiceManager,

--- a/lib/models/bulletin.dart
+++ b/lib/models/bulletin.dart
@@ -1,0 +1,173 @@
+/// A received APRS bulletin, stored separately from [MessageEntry] because
+/// retransmissions update (not duplicate) existing rows and aging is based on
+/// `lastHeardAt` rather than arrival sequence. See ADR-057.
+library;
+
+import '../core/packet/aprs_packet.dart';
+
+/// Which side of the addressee space the bulletin lives on.
+///
+/// [general] — `BLN0`–`BLN9`; delivery scope controlled by distance/radius.
+/// [groupNamed] — `BLNxNAME`; delivery scope controlled by subscriptions.
+enum BulletinCategory { general, groupNamed }
+
+/// Transport that delivered a given receipt of a bulletin. Reduced from
+/// [PacketSource] so the model stays free of connection-type distinctions the
+/// bulletin UI doesn't need (BLE vs serial TNC both count as RF).
+enum BulletinTransport { rf, aprsIs }
+
+extension BulletinTransportMapping on PacketSource {
+  BulletinTransport get asBulletinTransport => switch (this) {
+    PacketSource.aprsIs => BulletinTransport.aprsIs,
+    PacketSource.bleTnc ||
+    PacketSource.serialTnc ||
+    PacketSource.tnc => BulletinTransport.rf,
+  };
+}
+
+/// A received bulletin row. Unique on `(sourceCallsign, addressee)` —
+/// retransmissions of the same addressee from the same source update this
+/// row rather than append.
+class Bulletin {
+  Bulletin({
+    required this.id,
+    required this.sourceCallsign,
+    required this.addressee,
+    required this.category,
+    required this.lineNumber,
+    required this.body,
+    required this.firstHeardAt,
+    required this.lastHeardAt,
+    required this.heardCount,
+    required this.transports,
+    this.groupName,
+    this.receivedLat,
+    this.receivedLon,
+    this.isRead = false,
+  });
+
+  final int id;
+  final String sourceCallsign;
+
+  /// Full wire addressee, e.g. `BLN0`, `BLN1WX`. Already trimmed.
+  final String addressee;
+
+  final BulletinCategory category;
+
+  /// `"0"`–`"9"` for general, `"0"`–`"Z"` (alphanumeric) for group-named.
+  final String lineNumber;
+
+  /// `"WX"` for `BLN1WX`; null for `BLN0`–`BLN9`.
+  final String? groupName;
+
+  final String body;
+  final DateTime firstHeardAt;
+  final DateTime lastHeardAt;
+
+  /// Aggregate counter; not a per-receipt array (ADR-057).
+  final int heardCount;
+
+  /// Transports we have observed delivering this bulletin (may accumulate
+  /// over multiple retransmissions, e.g. both RF and APRS-IS).
+  final Set<BulletinTransport> transports;
+
+  /// Receiver's own position at the time of ingest. Null for RF receipts and
+  /// for APRS-IS receipts when the operator has no station location set.
+  final double? receivedLat;
+  final double? receivedLon;
+
+  final bool isRead;
+
+  Bulletin copyWith({
+    String? body,
+    DateTime? lastHeardAt,
+    int? heardCount,
+    Set<BulletinTransport>? transports,
+    double? receivedLat,
+    double? receivedLon,
+    bool? isRead,
+  }) => Bulletin(
+    id: id,
+    sourceCallsign: sourceCallsign,
+    addressee: addressee,
+    category: category,
+    lineNumber: lineNumber,
+    groupName: groupName,
+    body: body ?? this.body,
+    firstHeardAt: firstHeardAt,
+    lastHeardAt: lastHeardAt ?? this.lastHeardAt,
+    heardCount: heardCount ?? this.heardCount,
+    transports: transports ?? this.transports,
+    receivedLat: receivedLat ?? this.receivedLat,
+    receivedLon: receivedLon ?? this.receivedLon,
+    isRead: isRead ?? this.isRead,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'sourceCallsign': sourceCallsign,
+    'addressee': addressee,
+    'category': category.name,
+    'lineNumber': lineNumber,
+    'groupName': groupName,
+    'body': body,
+    'firstHeardAt': firstHeardAt.millisecondsSinceEpoch,
+    'lastHeardAt': lastHeardAt.millisecondsSinceEpoch,
+    'heardCount': heardCount,
+    'transports': transports.map((t) => t.name).toList(),
+    'receivedLat': receivedLat,
+    'receivedLon': receivedLon,
+    'isRead': isRead,
+  };
+
+  factory Bulletin.fromJson(Map<String, dynamic> json) => Bulletin(
+    id: json['id'] as int,
+    sourceCallsign: json['sourceCallsign'] as String,
+    addressee: json['addressee'] as String,
+    category: BulletinCategory.values.firstWhere(
+      (c) => c.name == (json['category'] as String?),
+      orElse: () => BulletinCategory.general,
+    ),
+    lineNumber: json['lineNumber'] as String,
+    groupName: json['groupName'] as String?,
+    body: json['body'] as String,
+    firstHeardAt: DateTime.fromMillisecondsSinceEpoch(
+      (json['firstHeardAt'] as int?) ?? 0,
+    ),
+    lastHeardAt: DateTime.fromMillisecondsSinceEpoch(
+      (json['lastHeardAt'] as int?) ?? 0,
+    ),
+    heardCount: (json['heardCount'] as int?) ?? 1,
+    transports: ((json['transports'] as List?) ?? [])
+        .whereType<String>()
+        .map(
+          (name) => BulletinTransport.values.firstWhere(
+            (t) => t.name == name,
+            orElse: () => BulletinTransport.rf,
+          ),
+        )
+        .toSet(),
+    receivedLat: (json['receivedLat'] as num?)?.toDouble(),
+    receivedLon: (json['receivedLon'] as num?)?.toDouble(),
+    isRead: (json['isRead'] as bool?) ?? false,
+  );
+}
+
+/// Structured view of a parsed bulletin addressee.
+///
+/// `BLN0`        → line=`"0"`, category=[BulletinCategory.general],      groupName=null
+/// `BLN1WX`      → line=`"1"`, category=[BulletinCategory.groupNamed],   groupName=`"WX"`
+/// `BLNASRARC`   → line=`"A"`, category=[BulletinCategory.groupNamed],   groupName=`"SRARC"`
+class BulletinAddresseeInfo {
+  const BulletinAddresseeInfo({
+    required this.addressee,
+    required this.lineNumber,
+    required this.category,
+    this.groupName,
+  });
+
+  final String addressee;
+  final String lineNumber;
+  final BulletinCategory category;
+  final String? groupName;
+}

--- a/lib/models/bulletin_subscription.dart
+++ b/lib/models/bulletin_subscription.dart
@@ -1,0 +1,54 @@
+/// Subscription to a named bulletin group (e.g. `BLNxWX`, `BLNxSRARC`).
+///
+/// Governs whether `BLNxNAME`-form bulletins for that group are kept on
+/// receive. General `BLN0`–`BLN9` bulletins are not governed by subscriptions
+/// — they use distance/radius logic instead. See ADR-058.
+library;
+
+class BulletinSubscription {
+  BulletinSubscription({
+    required this.id,
+    required String groupName,
+    this.notify = true,
+    DateTime? createdAt,
+  }) : groupName = groupName.toUpperCase(),
+       createdAt = createdAt ?? DateTime.now();
+
+  final int id;
+
+  /// 1–5 uppercase alphanumeric characters (maximum the APRS 9-char addressee
+  /// can carry after `BLN` + line number).
+  final String groupName;
+
+  final bool notify;
+  final DateTime createdAt;
+
+  static final RegExp namePattern = RegExp(r'^[A-Z0-9]{1,5}$');
+
+  static bool isValidName(String name) => namePattern.hasMatch(name);
+
+  BulletinSubscription copyWith({String? groupName, bool? notify}) =>
+      BulletinSubscription(
+        id: id,
+        groupName: groupName ?? this.groupName,
+        notify: notify ?? this.notify,
+        createdAt: createdAt,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'groupName': groupName,
+    'notify': notify,
+    'createdAt': createdAt.millisecondsSinceEpoch,
+  };
+
+  factory BulletinSubscription.fromJson(Map<String, dynamic> json) =>
+      BulletinSubscription(
+        id: json['id'] as int,
+        groupName: json['groupName'] as String,
+        notify: (json['notify'] as bool?) ?? true,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          (json['createdAt'] as int?) ?? 0,
+        ),
+      );
+}

--- a/lib/models/group_subscription.dart
+++ b/lib/models/group_subscription.dart
@@ -1,0 +1,130 @@
+/// Subscription to an APRS message group (e.g. `CQ`, `QST`, `ALL`, `SRARC`).
+///
+/// Groups are a pure client-side receiver filter — APRS has no server-side
+/// group mechanism, so "subscription" just means "include packets whose
+/// addressee matches this group's name in the Groups view."
+///
+/// See ADR-056.
+library;
+
+/// How the group's [name] is matched against an incoming addressee.
+///
+/// APRS wire addressees are 9 characters (space-padded). Yaesu radios emit
+/// `ALL******` (prefix-style) so [prefix] is the default; [exact] is available
+/// for clubs that want strict match.
+enum MatchMode { prefix, exact }
+
+/// Where a reply composed inside a group channel goes by default.
+///
+/// [sender] — reply addressed to the last-heard sender of the group message
+/// (discovery/announcement pattern; CQ, QST, ALL default to this).
+/// [group]  — reply broadcast to the group itself (club chat-room pattern;
+/// custom groups default to this).
+enum ReplyMode { sender, group }
+
+class GroupSubscription {
+  GroupSubscription({
+    required this.id,
+    required String name,
+    this.matchMode = MatchMode.prefix,
+    this.enabled = true,
+    this.notify = true,
+    this.replyMode = ReplyMode.group,
+    this.isBuiltin = false,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) : name = name.toUpperCase(),
+       createdAt = createdAt ?? DateTime.now(),
+       updatedAt = updatedAt ?? DateTime.now();
+
+  /// Stable local identifier. Assigned by [GroupSubscriptionService].
+  final int id;
+
+  /// 1–9 uppercase alphanumeric characters.
+  final String name;
+
+  final MatchMode matchMode;
+  final bool enabled;
+  final bool notify;
+  final ReplyMode replyMode;
+
+  /// True for the seeded built-ins (ALL, CQ, QST, YAESU). Built-ins can be
+  /// disabled and have their notify/replyMode edited, but cannot be renamed
+  /// or deleted.
+  final bool isBuiltin;
+
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  /// Returns true when [addressee] matches this subscription's [name] per
+  /// [matchMode]. Caller must pass an already-trimmed, uppercased addressee.
+  bool matches(String addressee) {
+    if (!enabled) return false;
+    switch (matchMode) {
+      case MatchMode.exact:
+        return addressee == name;
+      case MatchMode.prefix:
+        return addressee.startsWith(name);
+    }
+  }
+
+  /// RegExp for the allowed name shape (1–9 uppercase alphanumeric characters).
+  static final RegExp namePattern = RegExp(r'^[A-Z0-9]{1,9}$');
+
+  /// Returns true if [name] is a syntactically valid group name.
+  static bool isValidName(String name) => namePattern.hasMatch(name);
+
+  GroupSubscription copyWith({
+    String? name,
+    MatchMode? matchMode,
+    bool? enabled,
+    bool? notify,
+    ReplyMode? replyMode,
+    DateTime? updatedAt,
+  }) => GroupSubscription(
+    id: id,
+    name: name ?? this.name,
+    matchMode: matchMode ?? this.matchMode,
+    enabled: enabled ?? this.enabled,
+    notify: notify ?? this.notify,
+    replyMode: replyMode ?? this.replyMode,
+    isBuiltin: isBuiltin,
+    createdAt: createdAt,
+    updatedAt: updatedAt ?? DateTime.now(),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    'matchMode': matchMode.name,
+    'enabled': enabled,
+    'notify': notify,
+    'replyMode': replyMode.name,
+    'isBuiltin': isBuiltin,
+    'createdAt': createdAt.millisecondsSinceEpoch,
+    'updatedAt': updatedAt.millisecondsSinceEpoch,
+  };
+
+  factory GroupSubscription.fromJson(Map<String, dynamic> json) =>
+      GroupSubscription(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        matchMode: MatchMode.values.firstWhere(
+          (m) => m.name == (json['matchMode'] as String?),
+          orElse: () => MatchMode.prefix,
+        ),
+        enabled: (json['enabled'] as bool?) ?? true,
+        notify: (json['notify'] as bool?) ?? true,
+        replyMode: ReplyMode.values.firstWhere(
+          (m) => m.name == (json['replyMode'] as String?),
+          orElse: () => ReplyMode.group,
+        ),
+        isBuiltin: (json['isBuiltin'] as bool?) ?? false,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          (json['createdAt'] as int?) ?? 0,
+        ),
+        updatedAt: DateTime.fromMillisecondsSinceEpoch(
+          (json['updatedAt'] as int?) ?? 0,
+        ),
+      );
+}

--- a/lib/models/message_category.dart
+++ b/lib/models/message_category.dart
@@ -1,0 +1,13 @@
+/// Classification tag applied to every ingested APRS message packet by
+/// [AddresseeMatcher.classifyWithPrecedence]. See ADR-055.
+enum MessageCategory {
+  /// Addressed to the operator's own callsign (any SSID).
+  direct,
+
+  /// Matched an enabled [GroupSubscription].
+  group,
+
+  /// Bulletin (BLN0–BLN9 or BLNxNAME). Stored in the `Bulletin` table, not in
+  /// [MessageEntry] — carried here for completeness only.
+  bulletin,
+}

--- a/lib/models/outgoing_bulletin.dart
+++ b/lib/models/outgoing_bulletin.dart
@@ -1,0 +1,108 @@
+/// A bulletin the operator is transmitting. Scheduled on a fixed interval by
+/// [BulletinScheduler] until [expiresAt] or until disabled. See ADR-057.
+library;
+
+class OutgoingBulletin {
+  OutgoingBulletin({
+    required this.id,
+    required this.addressee,
+    required this.body,
+    required this.intervalSeconds,
+    required this.expiresAt,
+    required this.createdAt,
+    this.lastTransmittedAt,
+    this.transmissionCount = 0,
+    this.viaRf = true,
+    this.viaAprsIs = true,
+    this.enabled = true,
+  });
+
+  final int id;
+
+  /// Full wire addressee, e.g. `BLN0`, `BLN1WX`.
+  final String addressee;
+
+  /// Up to 67 chars.
+  final String body;
+
+  /// 0 = one-shot (sent once then sits idle until expiry). Otherwise the
+  /// expected spacing between transmissions: 300 / 600 / 900 / 1800 / 3600.
+  final int intervalSeconds;
+
+  final DateTime expiresAt;
+  final DateTime createdAt;
+  final DateTime? lastTransmittedAt;
+  final int transmissionCount;
+
+  final bool viaRf;
+  final bool viaAprsIs;
+
+  /// False after expiry (sweep disables) or after the user disables manually.
+  final bool enabled;
+
+  bool get isOneShot => intervalSeconds == 0;
+
+  OutgoingBulletin copyWith({
+    String? addressee,
+    String? body,
+    int? intervalSeconds,
+    DateTime? expiresAt,
+    DateTime? lastTransmittedAt,
+    bool clearLastTransmittedAt = false,
+    int? transmissionCount,
+    bool? viaRf,
+    bool? viaAprsIs,
+    bool? enabled,
+  }) => OutgoingBulletin(
+    id: id,
+    addressee: addressee ?? this.addressee,
+    body: body ?? this.body,
+    intervalSeconds: intervalSeconds ?? this.intervalSeconds,
+    expiresAt: expiresAt ?? this.expiresAt,
+    createdAt: createdAt,
+    lastTransmittedAt: clearLastTransmittedAt
+        ? null
+        : (lastTransmittedAt ?? this.lastTransmittedAt),
+    transmissionCount: transmissionCount ?? this.transmissionCount,
+    viaRf: viaRf ?? this.viaRf,
+    viaAprsIs: viaAprsIs ?? this.viaAprsIs,
+    enabled: enabled ?? this.enabled,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'addressee': addressee,
+    'body': body,
+    'intervalSeconds': intervalSeconds,
+    'expiresAt': expiresAt.millisecondsSinceEpoch,
+    'createdAt': createdAt.millisecondsSinceEpoch,
+    'lastTransmittedAt': lastTransmittedAt?.millisecondsSinceEpoch,
+    'transmissionCount': transmissionCount,
+    'viaRf': viaRf,
+    'viaAprsIs': viaAprsIs,
+    'enabled': enabled,
+  };
+
+  factory OutgoingBulletin.fromJson(Map<String, dynamic> json) =>
+      OutgoingBulletin(
+        id: json['id'] as int,
+        addressee: json['addressee'] as String,
+        body: json['body'] as String,
+        intervalSeconds: (json['intervalSeconds'] as int?) ?? 1800,
+        expiresAt: DateTime.fromMillisecondsSinceEpoch(
+          (json['expiresAt'] as int?) ?? 0,
+        ),
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          (json['createdAt'] as int?) ?? 0,
+        ),
+        lastTransmittedAt: (json['lastTransmittedAt'] as int?) == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(
+                json['lastTransmittedAt'] as int,
+              ),
+        transmissionCount: (json['transmissionCount'] as int?) ?? 0,
+        viaRf: (json['viaRf'] as bool?) ?? true,
+        viaAprsIs: (json['viaAprsIs'] as bool?) ?? true,
+        enabled: (json['enabled'] as bool?) ?? true,
+      );
+}

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -1,0 +1,192 @@
+/// Receive-side bulletin store.
+///
+/// Ingests classified bulletin packets from [MessageService] and upserts
+/// them into a `(sourceCallsign, addressee)`-keyed store. Retransmissions
+/// update the existing row: body replaces (marking unread if changed),
+/// `lastHeardAt` bumps, `heardCount` increments, `transports` union-merges.
+///
+/// For v0.17 PR 1 this service only applies the named-group subscription
+/// filter (unsubscribed `BLNxNAME` dropped). General `BLN0`–`BLN9` scope
+/// filtering (distance, station-location-null banner) lands in PR 5 along
+/// with the APRS-IS filter extension. See ADR-057, ADR-058.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../core/packet/aprs_packet.dart';
+import '../models/bulletin.dart';
+import 'bulletin_subscription_service.dart';
+
+/// Outcome of [BulletinService.ingest], exposed for test assertions.
+enum BulletinIngestOutcome {
+  /// New row inserted.
+  inserted,
+
+  /// Existing row updated in place (retransmission).
+  updated,
+
+  /// Dropped before upsert — named group not subscribed, or other future
+  /// scope filter (PR 5).
+  dropped,
+}
+
+class BulletinService extends ChangeNotifier {
+  BulletinService({
+    required BulletinSubscriptionService subscriptions,
+    SharedPreferences? prefs,
+  }) : _subscriptions = subscriptions,
+       _prefsOverride = prefs;
+
+  final BulletinSubscriptionService _subscriptions;
+  final SharedPreferences? _prefsOverride;
+
+  static const _keyBulletins = 'bulletins_v1';
+  static const _keyNextId = 'bulletins_next_id_v1';
+
+  // Keyed by "SOURCE|ADDRESSEE" for stable lookup.
+  final Map<String, Bulletin> _bulletins = {};
+  int _nextId = 1;
+
+  /// All stored bulletins, newest `lastHeardAt` first.
+  List<Bulletin> get bulletins {
+    final list = _bulletins.values.toList()
+      ..sort((a, b) => b.lastHeardAt.compareTo(a.lastHeardAt));
+    return list;
+  }
+
+  int get unreadCount => _bulletins.values.where((b) => !b.isRead).length;
+
+  Future<void> load() async {
+    final prefs = await _prefs();
+    _nextId = prefs.getInt(_keyNextId) ?? 1;
+    final raw = prefs.getString(_keyBulletins);
+    if (raw != null) {
+      try {
+        final list = (jsonDecode(raw) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(Bulletin.fromJson);
+        _bulletins.clear();
+        for (final b in list) {
+          _bulletins[_key(b.sourceCallsign, b.addressee)] = b;
+        }
+      } catch (e) {
+        debugPrint('BulletinService: failed to decode: $e');
+      }
+    }
+    notifyListeners();
+  }
+
+  /// Ingest a classified bulletin. Returns the outcome so callers/tests can
+  /// distinguish first-receipt from retransmission.
+  BulletinIngestOutcome ingest({
+    required BulletinAddresseeInfo info,
+    required String sourceCallsign,
+    required String body,
+    required PacketSource transport,
+    required DateTime receivedAt,
+    double? receivedLat,
+    double? receivedLon,
+  }) {
+    // Named-group subscription filter.
+    if (info.category == BulletinCategory.groupNamed) {
+      final group = info.groupName;
+      if (group == null ||
+          group.isEmpty ||
+          !_subscriptions.subscribedGroupNames.contains(group)) {
+        return BulletinIngestOutcome.dropped;
+      }
+    }
+
+    final source = sourceCallsign.trim().toUpperCase();
+    final key = _key(source, info.addressee);
+    final existing = _bulletins[key];
+    final BulletinIngestOutcome outcome;
+
+    if (existing == null) {
+      _bulletins[key] = Bulletin(
+        id: _nextId++,
+        sourceCallsign: source,
+        addressee: info.addressee,
+        category: info.category,
+        lineNumber: info.lineNumber,
+        groupName: info.groupName,
+        body: body,
+        firstHeardAt: receivedAt,
+        lastHeardAt: receivedAt,
+        heardCount: 1,
+        transports: {transport.asBulletinTransport},
+        receivedLat: receivedLat,
+        receivedLon: receivedLon,
+        isRead: false,
+      );
+      outcome = BulletinIngestOutcome.inserted;
+    } else {
+      final bodyChanged = existing.body != body;
+      final mergedTransports = {
+        ...existing.transports,
+        transport.asBulletinTransport,
+      };
+      _bulletins[key] = existing.copyWith(
+        body: bodyChanged ? body : existing.body,
+        lastHeardAt: receivedAt,
+        heardCount: existing.heardCount + 1,
+        transports: mergedTransports,
+        // If the body has changed, re-mark as unread (new information).
+        isRead: bodyChanged ? false : existing.isRead,
+      );
+      outcome = BulletinIngestOutcome.updated;
+    }
+
+    _persist(); // ignore: unawaited_futures
+    notifyListeners();
+    return outcome;
+  }
+
+  /// Mark a bulletin as read.
+  Future<void> markRead(int id) async {
+    String? matchKey;
+    for (final e in _bulletins.entries) {
+      if (e.value.id == id) {
+        matchKey = e.key;
+        break;
+      }
+    }
+    if (matchKey == null) return;
+    final current = _bulletins[matchKey]!;
+    if (current.isRead) return;
+    _bulletins[matchKey] = current.copyWith(isRead: true);
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Drop all bulletins whose `lastHeardAt` is older than [retention].
+  /// Call from a periodic sweeper (added in PR 5 along with the notification
+  /// pipeline).
+  Future<void> pruneOlderThan(Duration retention) async {
+    final cutoff = DateTime.now().subtract(retention);
+    final before = _bulletins.length;
+    _bulletins.removeWhere((_, b) => b.lastHeardAt.isBefore(cutoff));
+    if (_bulletins.length == before) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  String _key(String source, String addressee) =>
+      '${source.toUpperCase()}|${addressee.toUpperCase()}';
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  Future<void> _persist() async {
+    final prefs = await _prefs();
+    await prefs.setString(
+      _keyBulletins,
+      jsonEncode(_bulletins.values.map((b) => b.toJson()).toList()),
+    );
+    await prefs.setInt(_keyNextId, _nextId);
+  }
+}

--- a/lib/services/bulletin_subscription_service.dart
+++ b/lib/services/bulletin_subscription_service.dart
@@ -1,0 +1,104 @@
+/// Manages the operator's named-bulletin-group subscriptions (`BLNxWX`, etc.).
+///
+/// No defaults seeded — the operator explicitly subscribes to groups they
+/// want (per spec §5.2). General `BLN0`–`BLN9` bulletins are governed by
+/// distance/radius, not by subscriptions; that logic lives in [BulletinService].
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/bulletin_subscription.dart';
+
+class BulletinSubscriptionService extends ChangeNotifier {
+  BulletinSubscriptionService({SharedPreferences? prefs})
+    : _prefsOverride = prefs;
+
+  final SharedPreferences? _prefsOverride;
+
+  static const _keySubscriptions = 'bulletin_subscriptions_v1';
+  static const _keyNextId = 'bulletin_subscriptions_next_id_v1';
+
+  final List<BulletinSubscription> _subscriptions = [];
+  int _nextId = 1;
+
+  List<BulletinSubscription> get subscriptions =>
+      List.unmodifiable(_subscriptions);
+
+  /// The set of subscribed group names (uppercased). Used by
+  /// [BulletinService] to decide whether an incoming `BLNxNAME` is kept.
+  Set<String> get subscribedGroupNames =>
+      _subscriptions.map((s) => s.groupName).toSet();
+
+  Future<void> load() async {
+    final prefs = await _prefs();
+    _nextId = prefs.getInt(_keyNextId) ?? 1;
+    final raw = prefs.getString(_keySubscriptions);
+    if (raw != null) {
+      try {
+        final list = (jsonDecode(raw) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(BulletinSubscription.fromJson);
+        _subscriptions
+          ..clear()
+          ..addAll(list);
+      } catch (e) {
+        debugPrint('BulletinSubscriptionService: failed to decode: $e');
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<BulletinSubscription> add({
+    required String groupName,
+    bool notify = true,
+  }) async {
+    final normalized = groupName.trim().toUpperCase();
+    if (!BulletinSubscription.isValidName(normalized)) {
+      throw ArgumentError.value(groupName, 'groupName', 'invalid');
+    }
+    if (_subscriptions.any((s) => s.groupName == normalized)) {
+      throw ArgumentError.value(groupName, 'groupName', 'duplicate');
+    }
+    final sub = BulletinSubscription(
+      id: _nextId++,
+      groupName: normalized,
+      notify: notify,
+    );
+    _subscriptions.add(sub);
+    await _persist();
+    notifyListeners();
+    return sub;
+  }
+
+  Future<void> update(int id, {bool? notify}) async {
+    final idx = _subscriptions.indexWhere((s) => s.id == id);
+    if (idx < 0) return;
+    _subscriptions[idx] = _subscriptions[idx].copyWith(notify: notify);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> delete(int id) async {
+    final removed = _subscriptions.length;
+    _subscriptions.removeWhere((s) => s.id == id);
+    if (_subscriptions.length == removed) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  Future<void> _persist() async {
+    final prefs = await _prefs();
+    await prefs.setString(
+      _keySubscriptions,
+      jsonEncode(_subscriptions.map((s) => s.toJson()).toList()),
+    );
+    await prefs.setInt(_keyNextId, _nextId);
+  }
+}

--- a/lib/services/group_subscription_service.dart
+++ b/lib/services/group_subscription_service.dart
@@ -1,0 +1,225 @@
+/// Manages the operator's APRS group subscriptions.
+///
+/// Seeds the four built-ins on first run (per spec §5.1 / ADR-056):
+///   - `ALL`   disabled, notify off, reply `sender`  (broadcast discovery)
+///   - `CQ`    enabled,  notify off, reply `sender`  (contact-making)
+///   - `QST`   enabled,  notify off, reply `sender`  (broadcast discovery)
+///   - `YAESU` disabled, notify off, reply `sender`  (radio-firmware default)
+///
+/// All state persisted as a JSON blob in SharedPreferences. The drift/SQLite
+/// migration is v0.15 scope and will absorb this table.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/group_subscription.dart';
+
+class GroupSubscriptionService extends ChangeNotifier {
+  GroupSubscriptionService({SharedPreferences? prefs}) : _prefsOverride = prefs;
+
+  final SharedPreferences? _prefsOverride;
+
+  static const _keySubscriptions = 'group_subscriptions_v1';
+  static const _keyNextId = 'group_subscriptions_next_id_v1';
+  static const _keySeeded = 'group_subscriptions_seeded_v1';
+
+  final List<GroupSubscription> _subscriptions = [];
+  int _nextId = 1;
+
+  /// Unmodifiable read-only list in user-defined order.
+  ///
+  /// Downstream order-sensitive consumers (the matcher iterates in this order
+  /// — first match wins for the `Group` classification) observe whatever
+  /// sequence the user has configured in Settings.
+  List<GroupSubscription> get subscriptions =>
+      List.unmodifiable(_subscriptions);
+
+  /// Only the enabled entries, in order. Use this for the matcher.
+  List<GroupSubscription> get enabledSubscriptions =>
+      _subscriptions.where((s) => s.enabled).toList(growable: false);
+
+  /// Load persisted state + seed built-ins on first run. Idempotent.
+  Future<void> load() async {
+    final prefs = await _prefs();
+    _nextId = prefs.getInt(_keyNextId) ?? 1;
+    final raw = prefs.getString(_keySubscriptions);
+    if (raw != null) {
+      try {
+        final list = (jsonDecode(raw) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(GroupSubscription.fromJson);
+        _subscriptions
+          ..clear()
+          ..addAll(list);
+      } catch (e) {
+        debugPrint('GroupSubscriptionService: failed to decode: $e');
+      }
+    }
+    final seeded = prefs.getBool(_keySeeded) ?? false;
+    if (!seeded) {
+      await _seedBuiltins();
+      await prefs.setBool(_keySeeded, true);
+    }
+    notifyListeners();
+  }
+
+  Future<void> _seedBuiltins() async {
+    // Only seed names we don't already have (defensive — covers the unlikely
+    // case where a user manually created a row named `CQ` before we seeded).
+    final existingNames = _subscriptions.map((s) => s.name).toSet();
+    final defaults = <_BuiltinDefault>[
+      _BuiltinDefault('ALL', enabled: false),
+      _BuiltinDefault('CQ', enabled: true),
+      _BuiltinDefault('QST', enabled: true),
+      _BuiltinDefault('YAESU', enabled: false),
+    ];
+    for (final d in defaults) {
+      if (existingNames.contains(d.name)) continue;
+      _subscriptions.add(
+        GroupSubscription(
+          id: _nextId++,
+          name: d.name,
+          enabled: d.enabled,
+          notify: false,
+          replyMode: ReplyMode.sender,
+          isBuiltin: true,
+        ),
+      );
+    }
+    await _persist();
+  }
+
+  /// Add a custom subscription. Throws [ArgumentError] on invalid name or
+  /// duplicate (case-insensitive).
+  Future<GroupSubscription> add({
+    required String name,
+    MatchMode matchMode = MatchMode.prefix,
+    ReplyMode replyMode = ReplyMode.group,
+    bool notify = true,
+    bool enabled = true,
+  }) async {
+    final normalized = name.trim().toUpperCase();
+    if (!GroupSubscription.isValidName(normalized)) {
+      throw ArgumentError.value(name, 'name', 'invalid group name');
+    }
+    if (_subscriptions.any((s) => s.name == normalized)) {
+      throw ArgumentError.value(name, 'name', 'duplicate');
+    }
+    final sub = GroupSubscription(
+      id: _nextId++,
+      name: normalized,
+      matchMode: matchMode,
+      replyMode: replyMode,
+      notify: notify,
+      enabled: enabled,
+    );
+    _subscriptions.add(sub);
+    await _persist();
+    notifyListeners();
+    return sub;
+  }
+
+  /// Update an existing subscription. Built-ins may be updated (enabled,
+  /// notify, replyMode, matchMode) but their [name] and [isBuiltin] are
+  /// locked.
+  Future<void> update(
+    int id, {
+    MatchMode? matchMode,
+    bool? enabled,
+    bool? notify,
+    ReplyMode? replyMode,
+    String? name,
+  }) async {
+    final idx = _subscriptions.indexWhere((s) => s.id == id);
+    if (idx < 0) return;
+    final current = _subscriptions[idx];
+    String? nextName;
+    if (name != null) {
+      if (current.isBuiltin) {
+        throw StateError('Cannot rename built-in group ${current.name}');
+      }
+      final normalized = name.trim().toUpperCase();
+      if (!GroupSubscription.isValidName(normalized)) {
+        throw ArgumentError.value(name, 'name', 'invalid group name');
+      }
+      if (_subscriptions.any((s) => s.id != id && s.name == normalized)) {
+        throw ArgumentError.value(name, 'name', 'duplicate');
+      }
+      nextName = normalized;
+    }
+    _subscriptions[idx] = current.copyWith(
+      name: nextName,
+      matchMode: matchMode,
+      enabled: enabled,
+      notify: notify,
+      replyMode: replyMode,
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Delete a custom subscription. Built-ins cannot be deleted.
+  Future<void> delete(int id) async {
+    final idx = _subscriptions.indexWhere((s) => s.id == id);
+    if (idx < 0) return;
+    if (_subscriptions[idx].isBuiltin) {
+      throw StateError(
+        'Cannot delete built-in group ${_subscriptions[idx].name}',
+      );
+    }
+    _subscriptions.removeAt(idx);
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Reorder the full subscription list. [newOrder] must be a permutation
+  /// of the current ids.
+  Future<void> reorder(List<int> newOrder) async {
+    if (newOrder.length != _subscriptions.length) return;
+    final byId = {for (final s in _subscriptions) s.id: s};
+    final next = <GroupSubscription>[];
+    for (final id in newOrder) {
+      final s = byId[id];
+      if (s == null) return; // bail — mismatched id set
+      next.add(s);
+    }
+    _subscriptions
+      ..clear()
+      ..addAll(next);
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Find the subscription matching [addressee] (used by ingestion when a
+  /// group classification needs to resolve which subscription was hit —
+  /// the matcher already knows, but other callers may not).
+  GroupSubscription? findMatching(String addressee) {
+    final normalized = addressee.trim().toUpperCase();
+    for (final s in enabledSubscriptions) {
+      if (s.matches(normalized)) return s;
+    }
+    return null;
+  }
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+
+  Future<void> _persist() async {
+    final prefs = await _prefs();
+    await prefs.setString(
+      _keySubscriptions,
+      jsonEncode(_subscriptions.map((s) => s.toJson()).toList()),
+    );
+    await prefs.setInt(_keyNextId, _nextId);
+  }
+}
+
+class _BuiltinDefault {
+  _BuiltinDefault(this.name, {required this.enabled});
+  final String name;
+  final bool enabled;
+}

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -15,11 +15,17 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/callsign/addressee_matcher.dart';
 import '../core/callsign/callsign_utils.dart';
-import '../core/packet/aprs_packet.dart';
+import '../core/callsign/message_classification.dart';
 import '../core/packet/aprs_encoder.dart';
-import 'station_settings_service.dart';
+import '../core/packet/aprs_packet.dart';
+import '../models/group_subscription.dart';
+import '../models/message_category.dart';
+import 'bulletin_service.dart';
+import 'group_subscription_service.dart';
 import 'station_service.dart';
+import 'station_settings_service.dart';
 import 'tx_service.dart';
 
 /// Delivery state of an outgoing message.
@@ -34,6 +40,8 @@ class MessageEntry {
     required this.timestamp,
     required this.isOutgoing,
     this.addressee,
+    this.category = MessageCategory.direct,
+    this.groupName,
     this.status = MessageStatus.pending,
     this.retryCount = 0,
   });
@@ -50,6 +58,15 @@ class MessageEntry {
 
   /// Full callsign the message was addressed to (incoming only).
   final String? addressee;
+
+  /// Classification category from [AddresseeMatcher.classifyWithPrecedence].
+  /// Defaults to [MessageCategory.direct] for legacy-safe deserialization —
+  /// older entries without this key were all direct messages (v0.14-era).
+  final MessageCategory category;
+
+  /// The matched group subscription name when [category] is
+  /// [MessageCategory.group]; null otherwise.
+  final String? groupName;
 
   MessageStatus status;
   int retryCount;
@@ -81,12 +98,21 @@ class Conversation {
 }
 
 class MessageService extends ChangeNotifier {
-  MessageService(this._settings, this._tx, StationService stations) {
+  MessageService(
+    this._settings,
+    this._tx,
+    StationService stations, {
+    required GroupSubscriptionService groupSubscriptions,
+    required BulletinService bulletins,
+  }) : _groupSubscriptions = groupSubscriptions,
+       _bulletins = bulletins {
     _incomingSub = stations.packetStream.listen(_onPacket);
   }
 
   final StationSettingsService _settings;
   final TxService _tx;
+  final GroupSubscriptionService _groupSubscriptions;
+  final BulletinService _bulletins;
 
   static const _keyCounter = 'message_id_counter';
   static const _keyPeers = 'msg_peers';
@@ -311,26 +337,70 @@ class MessageService extends ChangeNotifier {
 
   void _onPacket(AprsPacket packet) {
     if (packet is! MessagePacket) return;
-    final myAddress = myFullAddress;
-    final addresseeNorm = normalizeCallsign(packet.addressee.toUpperCase());
 
-    final isExactMatch = addresseeNorm == myAddress;
-    final isCrossSsidMatch =
-        !isExactMatch && stripSsid(addresseeNorm) == stripSsid(myAddress);
-
-    if (!isExactMatch && !isCrossSsidMatch) {
-      debugPrint(
-        'MessageService: dropped packet — addressee="${packet.addressee.toUpperCase()}" '
-        'myAddress="$myAddress"',
-      );
-      return;
-    }
+    // Classify the addressee via the load-bearing precedence order (ADR-055):
+    // Bulletin → Direct → Group. Do not inline or reorder this call.
+    final classification = AddresseeMatcher.classifyWithPrecedence(
+      packet.addressee,
+      _settings.operatorIdentity,
+      _groupSubscriptions.enabledSubscriptions,
+    );
 
     final source = packet.source.trim().toUpperCase();
     final text = packet.message;
     final wireId = packet.messageId;
 
-    // ACK/REJ: process only for exact-match addressee.
+    switch (classification) {
+      case BulletinClassification(:final info):
+        // Bulletins are never ACKed and never flow into Conversation threads.
+        _bulletins.ingest(
+          info: info,
+          sourceCallsign: source,
+          body: text,
+          transport: packet.transportSource,
+          receivedAt: packet.receivedAt,
+        );
+        return;
+
+      case DirectClassification(:final isExactMatch):
+        _handleDirect(
+          packet: packet,
+          source: source,
+          text: text,
+          wireId: wireId,
+          isExactMatch: isExactMatch,
+        );
+        return;
+
+      case GroupClassification(:final subscription):
+        _handleGroup(
+          packet: packet,
+          source: source,
+          text: text,
+          wireId: wireId,
+          subscription: subscription,
+        );
+        return;
+
+      case NoneClassification():
+        debugPrint(
+          'MessageService: dropped packet — addressee="${packet.addressee.toUpperCase()}" '
+          'myAddress="$myFullAddress"',
+        );
+        return;
+    }
+  }
+
+  void _handleDirect({
+    required MessagePacket packet,
+    required String source,
+    required String text,
+    required String? wireId,
+    required bool isExactMatch,
+  }) {
+    // ACK/REJ routing mirrors v0.14: only ACKs to our exact SSID resolve the
+    // outgoing retry loop. Cross-SSID ACKs are logged but never applied to
+    // our message table.
     if (packet.isAck) {
       debugPrint('MessageService: inbound ACK from=$source id=$wireId');
       if (isExactMatch) _handleAck(source, wireId ?? '');
@@ -341,7 +411,6 @@ class MessageService extends ChangeNotifier {
       return;
     }
 
-    // Inbound message — deduplicate.
     final dedupeKey = '$source:${wireId ?? text}';
     if (_seenInbound.contains(dedupeKey)) return;
     _seenInbound.add(dedupeKey);
@@ -353,6 +422,7 @@ class MessageService extends ChangeNotifier {
       timestamp: packet.receivedAt,
       isOutgoing: false,
       addressee: packet.addressee.trim(),
+      category: MessageCategory.direct,
     );
 
     final conv = _getOrCreateConversation(source);
@@ -360,7 +430,7 @@ class MessageService extends ChangeNotifier {
     conv.lastActivity = packet.receivedAt;
     conv.unreadCount++;
 
-    // Send ACK immediately — exact match only. Never ACK cross-SSID messages.
+    // ACK exact match only. Never ACK cross-SSID, group, or bulletin.
     if (isExactMatch && wireId != null && wireId.isNotEmpty) {
       _transmitAck(source, wireId); // ignore: unawaited_futures
     }
@@ -368,6 +438,52 @@ class MessageService extends ChangeNotifier {
     notifyListeners();
     _persist(); // ignore: unawaited_futures
   }
+
+  void _handleGroup({
+    required MessagePacket packet,
+    required String source,
+    required String text,
+    required String? wireId,
+    required GroupSubscription subscription,
+  }) {
+    // Group messages are never ACKed — even if the wire carries a message-ID.
+    // Discard ACK/REJ payloads addressed to a group (nonsense protocol-wise,
+    // but we defensively ignore them to avoid corrupting any threading).
+    if (packet.isAck || packet.isRej) return;
+
+    // Dedupe on source+id+groupName — a retransmission within the same
+    // conversation shouldn't double-post.
+    final dedupeKey = 'group:${subscription.name}:$source:${wireId ?? text}';
+    if (_seenInbound.contains(dedupeKey)) return;
+    _seenInbound.add(dedupeKey);
+
+    // PR 3 adds the Groups tab UI. For now, receive-side storage uses the
+    // group name as the conversation key so all incoming messages for a
+    // group land in a single thread the UI can pick up later.
+    final entry = MessageEntry(
+      localId: dedupeKey,
+      wireId: wireId,
+      text: text,
+      timestamp: packet.receivedAt,
+      isOutgoing: false,
+      addressee: packet.addressee.trim(),
+      category: MessageCategory.group,
+      groupName: subscription.name,
+    );
+
+    final conv = _getOrCreateConversation(_groupConvKey(subscription.name));
+    conv.messages.add(entry);
+    conv.lastActivity = packet.receivedAt;
+    conv.unreadCount++;
+
+    notifyListeners();
+    _persist(); // ignore: unawaited_futures
+  }
+
+  /// Conversation-key prefix for group threads. Keeps group conversations in
+  /// the same `_conversations` map as direct threads without colliding with
+  /// real callsigns (no callsign starts with `#`).
+  static String _groupConvKey(String groupName) => '#GROUP:$groupName';
 
   void _handleAck(String peer, String ackId) {
     final ackKey = '$peer:$ackId';
@@ -547,6 +663,8 @@ class MessageService extends ChangeNotifier {
     'timestamp': e.timestamp.millisecondsSinceEpoch,
     'isOutgoing': e.isOutgoing,
     'addressee': e.addressee,
+    'category': e.category.name,
+    'groupName': e.groupName,
     'status': e.status.name,
     'retryCount': e.retryCount,
   };
@@ -578,6 +696,15 @@ class MessageService extends ChangeNotifier {
     if (status == MessageStatus.pending || status == MessageStatus.retrying) {
       status = MessageStatus.failed;
     }
+    // Legacy-safe: entries saved before v0.17 lack `category`/`groupName`.
+    // They are all direct messages (cross-SSID handled via `addressee`).
+    final categoryName = json['category'] as String?;
+    final category = categoryName == null
+        ? MessageCategory.direct
+        : MessageCategory.values.firstWhere(
+            (c) => c.name == categoryName,
+            orElse: () => MessageCategory.direct,
+          );
     return MessageEntry(
       localId: json['localId'] as String,
       wireId: json['wireId'] as String?,
@@ -585,6 +712,8 @@ class MessageService extends ChangeNotifier {
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
       isOutgoing: (json['isOutgoing'] as bool?) ?? false,
       addressee: json['addressee'] as String?,
+      category: category,
+      groupName: json['groupName'] as String?,
       status: status,
       retryCount: (json['retryCount'] as int?) ?? 0,
     );

--- a/lib/services/station_settings_service.dart
+++ b/lib/services/station_settings_service.dart
@@ -15,6 +15,7 @@ library;
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/callsign/operator_identity.dart';
 import '../core/connection/aprs_is_filter_config.dart';
 import '../core/connection/connection_credentials.dart';
 import '../core/credentials/credential_key.dart';
@@ -116,6 +117,14 @@ class StationSettingsService extends ChangeNotifier {
     passcode: _passcode,
     isLicensed: _isLicensed,
   );
+
+  /// Identity snapshot for the addressee matcher (ADR-055).
+  ///
+  /// Composes the callsign + SSID fields into the form the matcher needs. Does
+  /// not include passcode or licensing state — those belong to
+  /// [ConnectionCredentials] only.
+  OperatorIdentity get operatorIdentity =>
+      OperatorIdentity(callsign: _callsign, ssid: _ssid);
 
   /// Prime async-backed fields (currently just [passcode]) from their
   /// underlying stores. Call once at startup — and from onboarding — before

--- a/test/core/callsign/addressee_matcher_test.dart
+++ b/test/core/callsign/addressee_matcher_test.dart
@@ -1,0 +1,209 @@
+/// Precedence tests for the addressee matcher. These tests protect the
+/// load-bearing ordering rule — if any of them regress, ACKs can be skipped
+/// or sent to the wrong target. Do not change precedence without updating
+/// ADR-055.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/core/callsign/addressee_matcher.dart';
+import 'package:meridian_aprs/core/callsign/message_classification.dart';
+import 'package:meridian_aprs/core/callsign/operator_identity.dart';
+import 'package:meridian_aprs/models/bulletin.dart';
+import 'package:meridian_aprs/models/group_subscription.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+OperatorIdentity _operator(String callsign, [int ssid = 0]) =>
+    OperatorIdentity(callsign: callsign, ssid: ssid);
+
+GroupSubscription _group(
+  int id,
+  String name, {
+  MatchMode matchMode = MatchMode.prefix,
+  bool enabled = true,
+}) => GroupSubscription(
+  id: id,
+  name: name,
+  matchMode: matchMode,
+  enabled: enabled,
+  notify: false,
+  replyMode: ReplyMode.sender,
+);
+
+MessageClassification _classify(
+  String addressee,
+  OperatorIdentity identity,
+  List<GroupSubscription> subs,
+) => AddresseeMatcher.classifyWithPrecedence(addressee, identity, subs);
+
+// ---------------------------------------------------------------------------
+// Spec §11 required tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ADR-055 precedence: Bulletin → Direct → Group', () {
+    test('bulletin beats pathological group with B prefix', () {
+      // Group `B` prefix would match `BLN0` if we let it — but bulletins
+      // are classified first, so `BLN0` is a bulletin.
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'B')];
+      final result = _classify('BLN0', identity, subs);
+      expect(result, isA<BulletinClassification>());
+      final info = (result as BulletinClassification).info;
+      expect(info.category, BulletinCategory.general);
+      expect(info.lineNumber, '0');
+      expect(info.groupName, isNull);
+    });
+
+    test('bulletin beats named-overlap group (BLN1SRARC + SRARC group)', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'SRARC')];
+      final result = _classify('BLN1SRARC', identity, subs);
+      expect(result, isA<BulletinClassification>());
+      final info = (result as BulletinClassification).info;
+      expect(info.category, BulletinCategory.groupNamed);
+      expect(info.lineNumber, '1');
+      expect(info.groupName, 'SRARC');
+    });
+
+    test('direct beats group prefix conflict (W1ABC-7 + group W1 prefix)', () {
+      // This is the load-bearing case — if group came first, W1 prefix would
+      // capture a direct message, skip the ACK, sender's retry never
+      // terminates, operator appears unreachable.
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'W1')];
+      final result = _classify('W1ABC-7', identity, subs);
+      expect(result, isA<DirectClassification>());
+      expect((result as DirectClassification).isExactMatch, isTrue);
+    });
+
+    test('direct beats group exact conflict (W1ABC + group W1ABC exact)', () {
+      final identity = _operator('W1ABC', 0);
+      final subs = [_group(1, 'W1ABC', matchMode: MatchMode.exact)];
+      final result = _classify('W1ABC', identity, subs);
+      expect(result, isA<DirectClassification>());
+      expect((result as DirectClassification).isExactMatch, isTrue);
+    });
+
+    test('group matches when no direct/bulletin (addressee CQ, group CQ)', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ')];
+      final result = _classify('CQ', identity, subs);
+      expect(result, isA<GroupClassification>());
+      expect((result as GroupClassification).subscription.name, 'CQ');
+    });
+
+    test('first subscription match wins (CQFOO with CQ then CQFOO subs)', () {
+      // Both groups are prefix-mode. CQ comes first in the list, so it wins.
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ'), _group(2, 'CQFOO')];
+      final result = _classify('CQFOO', identity, subs);
+      expect(result, isA<GroupClassification>());
+      expect((result as GroupClassification).subscription.name, 'CQ');
+    });
+
+    test('disabled subscriptions do not match', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ', enabled: false)];
+      // Matcher callers pre-filter by `.enabledSubscriptions`, so disabled
+      // subs never reach the matcher. Both the full-list and enabled-only
+      // paths should classify as none.
+      final noneFromFull = _classify('CQ', identity, subs);
+      final noneFromFiltered = _classify(
+        'CQ',
+        identity,
+        subs.where((s) => s.enabled).toList(),
+      );
+      expect(noneFromFull, isA<NoneClassification>());
+      expect(noneFromFiltered, isA<NoneClassification>());
+    });
+
+    test('exact mode rejects longer addressee (CQRS with group CQ exact)', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ', matchMode: MatchMode.exact)];
+      final result = _classify('CQRS', identity, subs);
+      expect(result, isA<NoneClassification>());
+    });
+
+    test('prefix mode accepts longer (CQRS with group CQ prefix)', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ')];
+      final result = _classify('CQRS', identity, subs);
+      expect(result, isA<GroupClassification>());
+      expect((result as GroupClassification).subscription.name, 'CQ');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases beyond spec §11
+  // -------------------------------------------------------------------------
+
+  group('edge cases', () {
+    test('empty operator (pre-onboarding) falls through direct', () {
+      final identity = _operator('', 0);
+      final subs = [_group(1, 'CQ')];
+      final result = _classify('CQ', identity, subs);
+      // Should still hit the group rule since direct requires a real
+      // callsign, and shouldn't throw.
+      expect(result, isA<GroupClassification>());
+    });
+
+    test('empty operator + direct-looking addressee → none', () {
+      final identity = _operator('', 0);
+      final result = _classify('W1ABC', identity, []);
+      expect(result, isA<NoneClassification>());
+    });
+
+    test(
+      'cross-SSID direct: W1ABC-9 to operator W1ABC-7 is direct, not exact',
+      () {
+        final identity = _operator('W1ABC', 7);
+        final result = _classify('W1ABC-9', identity, []);
+        expect(result, isA<DirectClassification>());
+        expect((result as DirectClassification).isExactMatch, isFalse);
+      },
+    );
+
+    test('-0 normalization: W1ABC-0 to operator W1ABC is exact match', () {
+      final identity = _operator('W1ABC', 0);
+      final result = _classify('W1ABC-0', identity, []);
+      expect(result, isA<DirectClassification>());
+      expect((result as DirectClassification).isExactMatch, isTrue);
+    });
+
+    test('nothing matches → none', () {
+      final identity = _operator('W1ABC', 7);
+      final subs = [_group(1, 'CQ')];
+      final result = _classify('KB1XYZ', identity, subs);
+      expect(result, isA<NoneClassification>());
+    });
+
+    test('padded 9-char addressee is trimmed', () {
+      // Wire-form addressees are 9-char space-padded; the matcher trims.
+      final identity = _operator('W1ABC', 7);
+      final result = _classify('W1ABC-7  ', identity, []);
+      expect(result, isA<DirectClassification>());
+    });
+
+    test('general bulletin with digit line parses correctly (BLN9)', () {
+      final result = _classify('BLN9', _operator('W1ABC', 7), []);
+      expect(result, isA<BulletinClassification>());
+      final info = (result as BulletinClassification).info;
+      expect(info.category, BulletinCategory.general);
+      expect(info.lineNumber, '9');
+      expect(info.groupName, isNull);
+    });
+
+    test('named bulletin with letter line parses correctly (BLNASRARC)', () {
+      final result = _classify('BLNASRARC', _operator('W1ABC', 7), []);
+      expect(result, isA<BulletinClassification>());
+      final info = (result as BulletinClassification).info;
+      expect(info.category, BulletinCategory.groupNamed);
+      expect(info.lineNumber, 'A');
+      expect(info.groupName, 'SRARC');
+    });
+  });
+}

--- a/test/services/bulletin_service_test.dart
+++ b/test/services/bulletin_service_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/models/bulletin.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<(BulletinService, BulletinSubscriptionService)> makeServices({
+    List<String> subscribedGroups = const [],
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final subs = BulletinSubscriptionService(prefs: prefs);
+    await subs.load();
+    for (final g in subscribedGroups) {
+      await subs.add(groupName: g, notify: false);
+    }
+    final bulletins = BulletinService(subscriptions: subs, prefs: prefs);
+    await bulletins.load();
+    return (bulletins, subs);
+  }
+
+  BulletinAddresseeInfo generalInfo(String line) => BulletinAddresseeInfo(
+    addressee: 'BLN$line',
+    lineNumber: line,
+    category: BulletinCategory.general,
+  );
+
+  BulletinAddresseeInfo namedInfo(String line, String groupName) =>
+      BulletinAddresseeInfo(
+        addressee: 'BLN$line$groupName',
+        lineNumber: line,
+        category: BulletinCategory.groupNamed,
+        groupName: groupName,
+      );
+
+  // ---------------------------------------------------------------------------
+
+  group('general bulletin ingest', () {
+    test('first receipt inserts with heardCount=1', () async {
+      final (svc, _) = await makeServices();
+      final outcome = svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Severe weather alert',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      expect(outcome, BulletinIngestOutcome.inserted);
+      expect(svc.bulletins, hasLength(1));
+      final b = svc.bulletins.first;
+      expect(b.heardCount, 1);
+      expect(b.transports, {BulletinTransport.aprsIs});
+      expect(b.isRead, isFalse);
+    });
+
+    test(
+      'retransmission updates: bumps count, lastHeardAt, merges transports',
+      () async {
+        final (svc, _) = await makeServices();
+        svc.ingest(
+          info: generalInfo('0'),
+          sourceCallsign: 'K5WX-15',
+          body: 'Alert',
+          transport: PacketSource.aprsIs,
+          receivedAt: DateTime(2026, 4, 23, 12, 0),
+        );
+        final outcome = svc.ingest(
+          info: generalInfo('0'),
+          sourceCallsign: 'K5WX-15',
+          body: 'Alert',
+          transport: PacketSource.serialTnc,
+          receivedAt: DateTime(2026, 4, 23, 12, 5),
+        );
+        expect(outcome, BulletinIngestOutcome.updated);
+        expect(svc.bulletins, hasLength(1));
+        final b = svc.bulletins.first;
+        expect(b.heardCount, 2);
+        expect(b.lastHeardAt, DateTime(2026, 4, 23, 12, 5));
+        expect(b.transports, {BulletinTransport.aprsIs, BulletinTransport.rf});
+      },
+    );
+
+    test('body change re-marks as unread', () async {
+      final (svc, _) = await makeServices();
+      svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Old text',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      await svc.markRead(svc.bulletins.first.id);
+      expect(svc.bulletins.first.isRead, isTrue);
+
+      svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'New text',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 10),
+      );
+      expect(svc.bulletins.first.body, 'New text');
+      expect(svc.bulletins.first.isRead, isFalse);
+    });
+
+    test('body unchanged does not re-mark as unread', () async {
+      final (svc, _) = await makeServices();
+      svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Same',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      await svc.markRead(svc.bulletins.first.id);
+      svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Same',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 5),
+      );
+      expect(svc.bulletins.first.isRead, isTrue);
+    });
+  });
+
+  group('named-group subscription filter', () {
+    test('unsubscribed group is dropped', () async {
+      final (svc, _) = await makeServices();
+      final outcome = svc.ingest(
+        info: namedInfo('1', 'WX'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Radar update',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      expect(outcome, BulletinIngestOutcome.dropped);
+      expect(svc.bulletins, isEmpty);
+    });
+
+    test('subscribed group is kept', () async {
+      final (svc, _) = await makeServices(subscribedGroups: ['WX']);
+      final outcome = svc.ingest(
+        info: namedInfo('1', 'WX'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Radar update',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      expect(outcome, BulletinIngestOutcome.inserted);
+      expect(svc.bulletins, hasLength(1));
+      expect(svc.bulletins.first.groupName, 'WX');
+    });
+  });
+
+  group('persistence + retention', () {
+    test('bulletins round-trip through SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final subs = BulletinSubscriptionService(prefs: prefs);
+      await subs.load();
+      final first = BulletinService(subscriptions: subs, prefs: prefs);
+      await first.load();
+
+      first.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-15',
+        body: 'Alert',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      // Let persistence flush.
+      await Future<void>.delayed(Duration.zero);
+
+      final reloaded = BulletinService(subscriptions: subs, prefs: prefs);
+      await reloaded.load();
+      expect(reloaded.bulletins, hasLength(1));
+      expect(reloaded.bulletins.first.body, 'Alert');
+    });
+
+    test('pruneOlderThan drops aged-out rows', () async {
+      final (svc, _) = await makeServices();
+      final old = DateTime.now().subtract(const Duration(hours: 72));
+      final fresh = DateTime.now().subtract(const Duration(hours: 2));
+      svc.ingest(
+        info: generalInfo('0'),
+        sourceCallsign: 'K5WX-1',
+        body: 'Old',
+        transport: PacketSource.aprsIs,
+        receivedAt: old,
+      );
+      svc.ingest(
+        info: generalInfo('1'),
+        sourceCallsign: 'K5WX-2',
+        body: 'Fresh',
+        transport: PacketSource.aprsIs,
+        receivedAt: fresh,
+      );
+      await svc.pruneOlderThan(const Duration(hours: 48));
+      expect(svc.bulletins, hasLength(1));
+      expect(svc.bulletins.first.body, 'Fresh');
+    });
+  });
+}

--- a/test/services/group_subscription_service_test.dart
+++ b/test/services/group_subscription_service_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/models/group_subscription.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('seeder (ADR-056 built-ins)', () {
+    test('fresh install seeds ALL, CQ, QST, YAESU', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+
+      final names = service.subscriptions.map((s) => s.name).toList();
+      expect(names, containsAll(['ALL', 'CQ', 'QST', 'YAESU']));
+
+      final byName = {for (final s in service.subscriptions) s.name: s};
+      expect(byName['CQ']!.enabled, isTrue);
+      expect(byName['QST']!.enabled, isTrue);
+      expect(byName['ALL']!.enabled, isFalse);
+      expect(byName['YAESU']!.enabled, isFalse);
+
+      // All built-ins default to reply-to-sender + notify off.
+      for (final name in ['ALL', 'CQ', 'QST', 'YAESU']) {
+        expect(byName[name]!.replyMode, ReplyMode.sender);
+        expect(byName[name]!.notify, isFalse);
+        expect(byName[name]!.isBuiltin, isTrue);
+      }
+    });
+
+    test(
+      'seeder is idempotent — second load does not duplicate or reset',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        final first = GroupSubscriptionService(prefs: prefs);
+        await first.load();
+        // User toggles ALL on; this must survive re-load.
+        final allId = first.subscriptions.firstWhere((s) => s.name == 'ALL').id;
+        await first.update(allId, enabled: true);
+
+        final second = GroupSubscriptionService(prefs: prefs);
+        await second.load();
+        final secondAll = second.subscriptions.firstWhere(
+          (s) => s.name == 'ALL',
+        );
+        expect(secondAll.enabled, isTrue);
+        // Still only 4 built-ins (no duplicate seed).
+        final builtins = second.subscriptions
+            .where((s) => s.isBuiltin)
+            .toList();
+        expect(builtins.length, 4);
+      },
+    );
+  });
+
+  group('custom groups', () {
+    test('add + delete round-trips through SharedPreferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+
+      final srarc = await service.add(name: 'SRARC');
+      expect(srarc.name, 'SRARC');
+      expect(srarc.isBuiltin, isFalse);
+      // Custom default is reply-to-group.
+      expect(srarc.replyMode, ReplyMode.group);
+
+      // Persist across service instance.
+      final reloaded = GroupSubscriptionService(prefs: prefs);
+      await reloaded.load();
+      expect(reloaded.subscriptions.any((s) => s.name == 'SRARC'), isTrue);
+
+      // Delete.
+      await reloaded.delete(srarc.id);
+      final after = GroupSubscriptionService(prefs: prefs);
+      await after.load();
+      expect(after.subscriptions.any((s) => s.name == 'SRARC'), isFalse);
+    });
+
+    test('rejects invalid name', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+      expect(() => service.add(name: 'too-long-name'), throwsArgumentError);
+      expect(() => service.add(name: 'BAD!'), throwsArgumentError);
+      expect(() => service.add(name: ''), throwsArgumentError);
+    });
+
+    test('rejects duplicate name (case-insensitive)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+      await service.add(name: 'CLUB');
+      expect(() => service.add(name: 'club'), throwsArgumentError);
+    });
+
+    test('cannot delete or rename built-ins', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+      final cq = service.subscriptions.firstWhere((s) => s.name == 'CQ');
+      expect(() => service.delete(cq.id), throwsStateError);
+      expect(() => service.update(cq.id, name: 'CQCQCQ'), throwsStateError);
+    });
+  });
+
+  group('reorder', () {
+    test('reorder preserves content and is observable', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = GroupSubscriptionService(prefs: prefs);
+      await service.load();
+
+      final ids = service.subscriptions.map((s) => s.id).toList();
+      final reversed = ids.reversed.toList();
+      await service.reorder(reversed);
+
+      expect(service.subscriptions.map((s) => s.id).toList(), reversed);
+    });
+  });
+}

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -1,0 +1,239 @@
+/// Integration tests covering `MessageService` routing by classification
+/// category (direct / group / bulletin). Complements the unit tests in
+/// `addressee_matcher_test.dart` by confirming the service honors the
+/// matcher's decision — ACKs go out for direct exact-match only, bulletins
+/// land in the bulletin store, groups don't ACK. See ADR-055.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/callsign/callsign_utils.dart';
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/models/message_category.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
+import 'package:meridian_aprs/services/message_service.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class _Fixture {
+  _Fixture._({
+    required this.service,
+    required this.stationService,
+    required this.sentLines,
+    required this.groupSubscriptions,
+    required this.bulletinSubscriptions,
+    required this.bulletins,
+  });
+
+  final MessageService service;
+  final StationService stationService;
+  final List<String> sentLines;
+  final GroupSubscriptionService groupSubscriptions;
+  final BulletinSubscriptionService bulletinSubscriptions;
+  final BulletinService bulletins;
+
+  static Future<_Fixture> create({
+    String callsign = 'W1ABC',
+    int ssid = 7,
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': callsign,
+      'user_ssid': ssid,
+      'message_id_counter': 0,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    final stationService = StationService();
+    final registry = ConnectionRegistry();
+    final sentLines = <String>[];
+    final txService = _RecordingTxService(registry, settings, sentLines);
+
+    final groupSubs = GroupSubscriptionService(prefs: prefs);
+    await groupSubs.load();
+
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+
+    final service = MessageService(
+      settings,
+      txService,
+      stationService,
+      groupSubscriptions: groupSubs,
+      bulletins: bulletins,
+    );
+
+    return _Fixture._(
+      service: service,
+      stationService: stationService,
+      sentLines: sentLines,
+      groupSubscriptions: groupSubs,
+      bulletinSubscriptions: bulletinSubs,
+      bulletins: bulletins,
+    );
+  }
+}
+
+class _RecordingTxService extends TxService {
+  _RecordingTxService(super.registry, super.settings, this._log);
+  final List<String> _log;
+
+  @override
+  Future<void> sendLine(String line, {ConnectionType? forceVia}) async =>
+      _log.add(line);
+}
+
+// Helper: shove an APRS-IS message line through the ingest pipeline.
+void _ingestLine(_Fixture f, String line) {
+  f.stationService.ingestLine(line, source: PacketSource.aprsIs);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('direct classification', () {
+    test('exact-match direct message is stored and ACKed', () async {
+      final f = await _Fixture.create();
+      _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::W1ABC-7  :Hello{042');
+      // Allow the stream listener microtask to fire.
+      await Future<void>.delayed(Duration.zero);
+
+      final conv = f.service.conversationWith('K2ABC');
+      expect(conv, isNotNull);
+      expect(conv!.messages.first.text, 'Hello');
+      expect(conv.messages.first.category, MessageCategory.direct);
+
+      // ACK was transmitted to K2ABC for msg id 042.
+      expect(f.sentLines.any((l) => l.contains(':K2ABC')), isTrue);
+      expect(f.sentLines.any((l) => l.contains('ack042')), isTrue);
+    });
+
+    test('cross-SSID direct is stored but not ACKed (ADR-054)', () async {
+      final f = await _Fixture.create();
+      // Addressed to W1ABC-9 — operator is W1ABC-7 — cross-SSID match.
+      _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::W1ABC-9  :Hello{042');
+      await Future<void>.delayed(Duration.zero);
+
+      final conv = f.service.conversationWith('K2ABC');
+      expect(conv, isNotNull);
+      expect(conv!.messages.first.isCrossSsid(f.service.myFullAddress), isTrue);
+      // No ACK line emitted.
+      expect(f.sentLines.where((l) => l.contains('ack042')), isEmpty);
+    });
+  });
+
+  group('bulletin classification', () {
+    test(
+      'general bulletin (BLN0) lands in BulletinService, not Conversation',
+      () async {
+        final f = await _Fixture.create();
+        _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN0     :Severe wx alert');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(f.bulletins.bulletins, hasLength(1));
+        final b = f.bulletins.bulletins.first;
+        expect(b.sourceCallsign, 'K5WX-15');
+        expect(b.addressee, 'BLN0');
+        expect(b.body, 'Severe wx alert');
+        expect(b.heardCount, 1);
+
+        // No conversation thread was created.
+        expect(
+          f.service.allConversations.any((c) => c.peerCallsign == 'K5WX-15'),
+          isFalse,
+        );
+        // No ACK (bulletins are never ACKed).
+        expect(f.sentLines, isEmpty);
+      },
+    );
+
+    test('named bulletin with no subscription is dropped', () async {
+      final f = await _Fixture.create();
+      _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN1WX   :Radar');
+      await Future<void>.delayed(Duration.zero);
+      expect(f.bulletins.bulletins, isEmpty);
+    });
+
+    test('named bulletin with matching subscription is kept', () async {
+      final f = await _Fixture.create();
+      await f.bulletinSubscriptions.add(groupName: 'WX', notify: false);
+      _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN1WX   :Radar');
+      await Future<void>.delayed(Duration.zero);
+      expect(f.bulletins.bulletins, hasLength(1));
+      expect(f.bulletins.bulletins.first.groupName, 'WX');
+    });
+  });
+
+  group('group classification', () {
+    test('CQ message lands in a group conversation and is not ACKed', () async {
+      final f = await _Fixture.create();
+      // CQ is enabled by default in the seeded built-ins.
+      _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::CQ       :CQ CQ CQ');
+      await Future<void>.delayed(Duration.zero);
+
+      // Group thread keyed by `#GROUP:CQ`. Internal key is not public API
+      // but we can verify via allConversations that a thread was created.
+      final matched = f.service.allConversations
+          .where((c) => c.peerCallsign.contains('CQ'))
+          .toList();
+      expect(matched, isNotEmpty);
+      expect(matched.first.messages.first.category, MessageCategory.group);
+      expect(matched.first.messages.first.groupName, 'CQ');
+
+      // No ACK even though the wire carries a messageId (groups never ACK).
+      expect(f.sentLines, isEmpty);
+    });
+
+    test('disabled group subscription does not match', () async {
+      final f = await _Fixture.create();
+      // Disable CQ.
+      final cq = f.groupSubscriptions.subscriptions.firstWhere(
+        (s) => s.name == 'CQ',
+      );
+      await f.groupSubscriptions.update(cq.id, enabled: false);
+
+      _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::CQ       :CQ CQ CQ');
+      await Future<void>.delayed(Duration.zero);
+
+      // No conversation, no bulletin, no ACK.
+      expect(
+        f.service.allConversations.any((c) => c.peerCallsign.contains('CQ')),
+        isFalse,
+      );
+      expect(f.bulletins.bulletins, isEmpty);
+      expect(f.sentLines, isEmpty);
+    });
+  });
+
+  group('callsign normalization', () {
+    test('stripSsid and normalizeCallsign still behave correctly', () {
+      // Sanity: the matcher's direct rule relies on these primitives.
+      expect(stripSsid('W1ABC-9'), 'W1ABC');
+      expect(normalizeCallsign('W1ABC-0'), 'W1ABC');
+      expect(normalizeCallsign('W1ABC'), 'W1ABC');
+    });
+  });
+}

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
 import 'package:meridian_aprs/services/message_service.dart';
 import 'package:meridian_aprs/services/station_service.dart';
 import 'package:meridian_aprs/services/station_settings_service.dart';
@@ -25,11 +28,17 @@ class _Fixture {
     required this.service,
     required this.stationService,
     required this.sentLines,
+    required this.groupSubscriptions,
+    required this.bulletinSubscriptions,
+    required this.bulletins,
   });
 
   final MessageService service;
   final StationService stationService;
   final List<String> sentLines;
+  final GroupSubscriptionService groupSubscriptions;
+  final BulletinSubscriptionService bulletinSubscriptions;
+  final BulletinService bulletins;
 
   static Future<_Fixture> create({
     String callsign = 'W1AW',
@@ -50,11 +59,29 @@ class _Fixture {
     final registry = ConnectionRegistry();
     final sentLines = <String>[];
     final txService = _RecordingTxService(registry, settings, sentLines);
-    final messageService = MessageService(settings, txService, stationService);
+    final groupSubs = GroupSubscriptionService(prefs: prefs);
+    await groupSubs.load();
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+    final messageService = MessageService(
+      settings,
+      txService,
+      stationService,
+      groupSubscriptions: groupSubs,
+      bulletins: bulletins,
+    );
     return _Fixture._(
       service: messageService,
       stationService: stationService,
       sentLines: sentLines,
+      groupSubscriptions: groupSubs,
+      bulletinSubscriptions: bulletinSubs,
+      bulletins: bulletins,
     );
   }
 }
@@ -451,7 +478,22 @@ void main() {
         final registry = ConnectionRegistry();
         final sentLines = <String>[];
         final txService = _RecordingTxService(registry, settings, sentLines);
-        final service = MessageService(settings, txService, stationService);
+        final groupSubs = GroupSubscriptionService(prefs: prefs);
+        await groupSubs.load();
+        final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+        await bulletinSubs.load();
+        final bulletins = BulletinService(
+          subscriptions: bulletinSubs,
+          prefs: prefs,
+        );
+        await bulletins.load();
+        final service = MessageService(
+          settings,
+          txService,
+          stationService,
+          groupSubscriptions: groupSubs,
+          bulletins: bulletins,
+        );
         await service.loadHistory();
 
         final conv = service.conversationWith('KB1XYZ');

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -6,6 +6,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meridian_aprs/core/connection/connection_registry.dart';
 import 'package:meridian_aprs/models/notification_preferences.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
 import 'package:meridian_aprs/services/message_service.dart';
 import 'package:meridian_aprs/services/notification_service.dart';
 import 'package:meridian_aprs/services/station_service.dart';
@@ -54,7 +57,22 @@ class _Fixture {
     final stationService = StationService();
     final registry = ConnectionRegistry();
     final txService = _SilentTxService(registry, settings);
-    final messageService = MessageService(settings, txService, stationService);
+    final groupSubs = GroupSubscriptionService(prefs: prefs);
+    await groupSubs.load();
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+    final messageService = MessageService(
+      settings,
+      txService,
+      stationService,
+      groupSubscriptions: groupSubs,
+      bulletins: bulletins,
+    );
     final bannerController = InAppBannerController();
 
     // Construct NotificationService WITHOUT calling initialize() so we avoid

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,6 +7,9 @@ import 'package:meridian_aprs/theme/theme_controller.dart';
 import 'package:meridian_aprs/screens/map_screen.dart';
 import 'package:meridian_aprs/services/background_service_manager.dart';
 import 'package:meridian_aprs/services/beaconing_service.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
 import 'package:meridian_aprs/services/message_service.dart';
 import 'package:meridian_aprs/services/station_service.dart';
 import 'package:meridian_aprs/services/station_settings_service.dart';
@@ -39,7 +42,22 @@ void main() {
     );
     final txService = TxService(registry, stationSettings);
     final beaconingService = BeaconingService(stationSettings, txService);
-    final messageService = MessageService(stationSettings, txService, service);
+    final groupSubs = GroupSubscriptionService(prefs: prefs);
+    await groupSubs.load();
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+    final messageService = MessageService(
+      stationSettings,
+      txService,
+      service,
+      groupSubscriptions: groupSubs,
+      bulletins: bulletins,
+    );
     final bgServiceManager = BackgroundServiceManager(
       registry: registry,
       beaconing: beaconingService,


### PR DESCRIPTION
## Summary
- Adds the receive-side plumbing for v0.17 (Group Messaging & Bulletins)
- New `AddresseeMatcher.classifyWithPrecedence()` applies load-bearing Bulletin → Direct → Group precedence; v0.14 ACK behavior preserved for exact-SSID direct only
- Four new data models (`GroupSubscription`, `BulletinSubscription`, `Bulletin`, `OutgoingBulletin`) + `MessageCategory` enum + `OperatorIdentity` value object
- Three new services: `GroupSubscriptionService` (with ADR-056 built-in seeder — ALL off, CQ on, QST on, YAESU off), `BulletinSubscriptionService`, `BulletinService` (upsert + transport merge + body-change-unread)
- `MessageEntry` gains `category` + `groupName` with legacy-safe JSON deserialization
- ADR-055 (standalone, load-bearing — includes spec §11 test table + explicit "do not reorder" guardrail) and ADR-056 added to `docs/DECISIONS.md`; ADR-057 proposed

## Scope
Receive plumbing only — no UI changes visible yet. Settings UI is PR 2; Messaging tab restructure + Groups/Bulletins views is PR 3; send path (scheduler, compose, adaptive reply) is PR 4; APRS-IS filter extension + notifications + docs is PR 5.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 512 passing (470 existing + 42 new)
- [x] Spec §11 precedence cases in `test/core/callsign/addressee_matcher_test.dart` — all 9 + edge cases (empty operator, cross-SSID, -0 normalization, padded addressee)
- [x] Seeder idempotence + CRUD for `GroupSubscriptionService`
- [x] Bulletin upsert: first-receipt insert, retransmission update, transport merge, body-change-unread, subscription filter, retention prune
- [x] Classification integration: direct exact ACKs, cross-SSID doesn't ACK, BLN0 lands in BulletinService, CQ lands in group conversation without ACK
- [x] Manual — direct message send/receive/ACK round-trip still works on main branch behavior