### PR TITLE
feat: v0.17 PR 2 — Settings UI for Groups + Bulletins + Advanced paths

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1078,12 +1078,12 @@ Meridian implements the same model so it interoperates with Yaesu FT5D, Kenwood 
 
 ### Decision
 
-1. **Subscription model.** `GroupSubscription` is a local-only value object persisted to SharedPreferences. No network subscription step exists. Four built-ins are seeded on first run (`ALL`, `CQ`, `QST`, `YAESU`) — the Yaesu radio-firmware defaults plus two hobby conventions. Users may add custom groups (club names, event nets).
+1. **Subscription model.** `GroupSubscription` is a local-only value object persisted to SharedPreferences. No network subscription step exists. Three protocol-neutral built-ins are seeded on first run (`ALL`, `CQ`, `QST`) — all enabled-or-not per the defaults table below. Vendor-specific group names (e.g. `YAESU`, `KENWOOD`) are intentionally *not* seeded: Meridian is not a vendor-specific product, and users who want them can add them via Settings in two taps. Users may add any custom group (club names, event nets, vendor names).
 
 2. **Wildcards = prefix match, not regex/glob.** APRS wire addressees are 9 characters, right-space-padded. Yaesu radios emit `ALL******` as a prefix match, so the matcher trims padding and applies `addressee.startsWith(name)`. Users can opt a group into `exact` mode for strict equality (no false positives), but `prefix` is the default because it matches the ecosystem.
 
 3. **Default reply modes are opinionated.**
-   - Built-ins `ALL`, `CQ`, `QST`, `YAESU` default to `replyMode = sender` — these are broadcast/discovery conventions where the right reply is 1:1 to whoever spoke up.
+   - Built-ins `ALL`, `CQ`, `QST` default to `replyMode = sender` — these are broadcast/discovery conventions where the right reply is 1:1 to whoever spoke up.
    - Custom groups default to `replyMode = group` — clubs want chat-room semantics.
    - The UI surfaces the reply-mode icon (`campaign` for sender, `forum` for group) on every group tile so the mental model is visible.
 
@@ -1091,7 +1091,7 @@ Meridian implements the same model so it interoperates with Yaesu FT5D, Kenwood 
 
 5. **Name validation: `[A-Z0-9]{1,9}`.** 9 characters is the wire addressee limit. Upper-cased on set; the settings editor normalizes input. No punctuation — the wire field is ASCII alphanumeric only.
 
-6. **Built-ins may be disabled, not deleted or renamed.** This preserves the "quiet by default" opt-in for `ALL` and `YAESU` while keeping the defaults discoverable. `isBuiltin: true` is set on the seeded rows and enforced by the service.
+6. **Built-ins may be disabled, not deleted or renamed.** This preserves the "quiet by default" opt-in for `ALL` while keeping the defaults discoverable. `isBuiltin: true` is set on the seeded rows and enforced by the service.
 
 7. **First-match-wins within user-defined order.** Groups `CQ` and `CQFOO` both in prefix mode for addressee `CQFOO` → whichever appears earlier in the subscription list wins. Settings provides a reorderable list so operators can place narrow before broad when they care.
 

--- a/docs/specs/v0.17-groups-and-bulletins-spec.md
+++ b/docs/specs/v0.17-groups-and-bulletins-spec.md
@@ -61,7 +61,7 @@ Reference implementations we match:
 | Named bulletin scope | Global if subscribed | Club bulletins are non-geographic |
 | Own-SSID echo in group view | Yes | Continuity |
 | Onboarding | Settings-only | v0.12 stays focused |
-| Default subscriptions | CQ + QST enabled (notif off); ALL + YAESU disabled | Quiet defaults |
+| Default subscriptions | CQ + QST enabled (notif off); ALL disabled. Vendor names (YAESU/KENWOOD) not seeded — user adds if desired. | Quiet, vendor-neutral defaults |
 | Bulletin send via APRS-IS | Allowed per-bulletin | Matches APRSIS32 |
 | RF path control | **Advanced-mode settings** for group and bulletin paths | Explicit user control |
 | Default group message path | Same as beacon path | User already configured sensibly |
@@ -163,12 +163,13 @@ GroupSubscription {
 
 Default built-in rows seeded on first run:
 
-| name   | match_mode | enabled | notify | reply_mode |
-|--------|------------|---------|--------|------------|
-| ALL    | prefix     | false   | false  | sender     |
-| CQ     | prefix     | true    | false  | sender     |
-| QST    | prefix     | true    | false  | sender     |
-| YAESU  | prefix     | false   | false  | sender     |
+| name | match_mode | enabled | notify | reply_mode |
+|------|------------|---------|--------|------------|
+| ALL  | prefix     | false   | false  | sender     |
+| CQ   | prefix     | true    | false  | sender     |
+| QST  | prefix     | true    | false  | sender     |
+
+Vendor-specific group names (`YAESU`, `KENWOOD`, etc.) are **not** seeded as built-ins. Meridian is a vendor-neutral client; users who run a Yaesu or Kenwood radio and want the vendor's broadcast addressee should add it via Settings → Messaging → Add custom group (two taps).
 
 Name validation: 1–9 chars, `[A-Z0-9]` only, uppercase-normalized.
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,6 +35,7 @@ import 'services/bulletin_subscription_service.dart';
 import 'services/group_subscription_service.dart';
 import 'services/ios_background_service.dart';
 import 'services/message_service.dart';
+import 'services/messaging_settings_service.dart';
 import 'services/station_service.dart';
 import 'services/station_settings_service.dart';
 import 'services/tx_service.dart';
@@ -199,6 +200,9 @@ Future<void> main() async {
   );
   await bulletinService.load();
 
+  final messagingSettings = MessagingSettingsService(prefs: prefs);
+  await messagingSettings.load();
+
   final messageService = MessageService(
     stationSettings,
     txService,
@@ -289,6 +293,9 @@ Future<void> main() async {
           value: bulletinSubscriptions,
         ),
         ChangeNotifierProvider<BulletinService>.value(value: bulletinService),
+        ChangeNotifierProvider<MessagingSettingsService>.value(
+          value: messagingSettings,
+        ),
         ChangeNotifierProvider<MessageService>.value(value: messageService),
         ChangeNotifierProvider<BackgroundServiceManager>.value(
           value: bgServiceManager,

--- a/lib/models/notification_preferences.dart
+++ b/lib/models/notification_preferences.dart
@@ -20,6 +20,8 @@ class NotificationPreferences {
     required this.soundEnabled,
     required this.vibrationEnabled,
     this.notifyOtherSsids = false,
+    this.notifyGroups = true,
+    this.notifyBulletins = false,
   });
 
   /// Global opt-in flag — false means no notifications are dispatched even if
@@ -37,7 +39,20 @@ class NotificationPreferences {
   /// to false — opt-in only.
   final bool notifyOtherSsids;
 
+  /// Master toggle for group-message notifications (v0.17). Per-group
+  /// `notify` on [GroupSubscription] further gates individual groups.
+  /// Defaults to true so users see a group they intentionally subscribed
+  /// to, without an extra Settings visit.
+  final bool notifyGroups;
+
+  /// Master toggle for bulletin notifications (v0.17). Per-group
+  /// `notify` on [BulletinSubscription] further gates individual named
+  /// groups. Defaults to false — bulletins are broadcast-noisy by nature.
+  final bool notifyBulletins;
+
   static const _keyNotifyOtherSsids = 'notif_notify_other_ssids';
+  static const _keyNotifyGroups = 'notif_notify_groups';
+  static const _keyNotifyBulletins = 'notif_notify_bulletins';
 
   // Default sound/vibration: on for messages+alerts, off for nearby+system.
   static const _defaultSound = {
@@ -88,12 +103,16 @@ class NotificationPreferences {
           (_defaultVibration[ch] ?? false);
     }
     final notifyOtherSsids = prefs.getBool(_keyNotifyOtherSsids) ?? false;
+    final notifyGroups = prefs.getBool(_keyNotifyGroups) ?? true;
+    final notifyBulletins = prefs.getBool(_keyNotifyBulletins) ?? false;
     return NotificationPreferences(
       optedIn: optedIn,
       channelEnabled: channelEnabled,
       soundEnabled: soundEnabled,
       vibrationEnabled: vibrationEnabled,
       notifyOtherSsids: notifyOtherSsids,
+      notifyGroups: notifyGroups,
+      notifyBulletins: notifyBulletins,
     );
   }
 
@@ -109,6 +128,8 @@ class NotificationPreferences {
       await prefs.setBool('notif_vibration_${e.key}', e.value);
     }
     await prefs.setBool(_keyNotifyOtherSsids, notifyOtherSsids);
+    await prefs.setBool(_keyNotifyGroups, notifyGroups);
+    await prefs.setBool(_keyNotifyBulletins, notifyBulletins);
   }
 
   NotificationPreferences copyWithOptedIn(bool value) =>
@@ -118,6 +139,8 @@ class NotificationPreferences {
         soundEnabled: Map.of(soundEnabled),
         vibrationEnabled: Map.of(vibrationEnabled),
         notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: notifyGroups,
+        notifyBulletins: notifyBulletins,
       );
 
   NotificationPreferences copyWithChannel(String id, bool enabled) =>
@@ -127,6 +150,8 @@ class NotificationPreferences {
         soundEnabled: Map.of(soundEnabled),
         vibrationEnabled: Map.of(vibrationEnabled),
         notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: notifyGroups,
+        notifyBulletins: notifyBulletins,
       );
 
   NotificationPreferences copyWithSound(String id, bool enabled) =>
@@ -136,6 +161,8 @@ class NotificationPreferences {
         soundEnabled: Map.of(soundEnabled)..[id] = enabled,
         vibrationEnabled: Map.of(vibrationEnabled),
         notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: notifyGroups,
+        notifyBulletins: notifyBulletins,
       );
 
   NotificationPreferences copyWithVibration(String id, bool enabled) =>
@@ -145,6 +172,8 @@ class NotificationPreferences {
         soundEnabled: Map.of(soundEnabled),
         vibrationEnabled: Map.of(vibrationEnabled)..[id] = enabled,
         notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: notifyGroups,
+        notifyBulletins: notifyBulletins,
       );
 
   NotificationPreferences copyWithNotifyOtherSsids(bool v) =>
@@ -154,5 +183,29 @@ class NotificationPreferences {
         soundEnabled: Map.of(soundEnabled),
         vibrationEnabled: Map.of(vibrationEnabled),
         notifyOtherSsids: v,
+        notifyGroups: notifyGroups,
+        notifyBulletins: notifyBulletins,
+      );
+
+  NotificationPreferences copyWithNotifyGroups(bool v) =>
+      NotificationPreferences(
+        optedIn: optedIn,
+        channelEnabled: Map.of(channelEnabled),
+        soundEnabled: Map.of(soundEnabled),
+        vibrationEnabled: Map.of(vibrationEnabled),
+        notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: v,
+        notifyBulletins: notifyBulletins,
+      );
+
+  NotificationPreferences copyWithNotifyBulletins(bool v) =>
+      NotificationPreferences(
+        optedIn: optedIn,
+        channelEnabled: Map.of(channelEnabled),
+        soundEnabled: Map.of(soundEnabled),
+        vibrationEnabled: Map.of(vibrationEnabled),
+        notifyOtherSsids: notifyOtherSsids,
+        notifyGroups: notifyGroups,
+        notifyBulletins: v,
       );
 }

--- a/lib/screens/settings/category/messaging_screen.dart
+++ b/lib/screens/settings/category/messaging_screen.dart
@@ -1,12 +1,20 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/callsign/callsign_utils.dart';
+import '../../../models/bulletin_subscription.dart';
+import '../../../models/group_subscription.dart';
+import '../../../services/bulletin_service.dart';
+import '../../../services/bulletin_subscription_service.dart';
+import '../../../services/group_subscription_service.dart';
 import '../../../services/message_service.dart';
+import '../../../services/messaging_settings_service.dart';
 import '../../../services/notification_service.dart';
 import '../../../services/station_settings_service.dart';
+import '../advanced_mode_controller.dart';
 import '../widgets/section_header.dart';
 
 class MessagingSettingsContent extends StatelessWidget {
@@ -17,6 +25,11 @@ class MessagingSettingsContent extends StatelessWidget {
     final messageService = context.watch<MessageService>();
     final notifService = context.watch<NotificationService>();
     final station = context.watch<StationSettingsService>();
+    final groups = context.watch<GroupSubscriptionService>();
+    final bulletinSubs = context.watch<BulletinSubscriptionService>();
+    final bulletins = context.watch<BulletinService>();
+    final messagingSettings = context.watch<MessagingSettingsService>();
+    final advanced = context.watch<AdvancedModeController>();
 
     final baseCall = stripSsid(station.fullAddress);
     final fullCall = station.fullAddress.isEmpty
@@ -26,6 +39,9 @@ class MessagingSettingsContent extends StatelessWidget {
 
     return ListView(
       children: [
+        // -----------------------------------------------------------------
+        // Cross-SSID messages (v0.14)
+        // -----------------------------------------------------------------
         const SectionHeader('Cross-SSID Messages'),
         SwitchListTile.adaptive(
           title: const Text('Show messages to other SSIDs of my callsign'),
@@ -50,8 +66,709 @@ class MessagingSettingsContent extends StatelessWidget {
               onChanged: (v) => notifService.setNotifyOtherSsids(v),
             ),
           ),
+
+        // -----------------------------------------------------------------
+        // Groups
+        // -----------------------------------------------------------------
+        const SectionHeader('Groups'),
+        SwitchListTile.adaptive(
+          title: const Text('Notify on group messages'),
+          subtitle: const Text(
+            'Master toggle — individual groups below can also be muted.',
+          ),
+          value: prefs.notifyGroups,
+          onChanged: (v) => notifService.setNotifyGroups(v),
+        ),
+        _GroupsList(groups: groups),
+        ListTile(
+          leading: const Icon(Symbols.add),
+          title: const Text('Add custom group'),
+          subtitle: const Text('e.g. club net name or event'),
+          onTap: () => _showGroupEditor(context, groups, existing: null),
+        ),
+        if (advanced.isEnabled)
+          _AdvancedGroupPathTile(settings: messagingSettings),
+
+        // -----------------------------------------------------------------
+        // Bulletins
+        // -----------------------------------------------------------------
+        const SectionHeader('Bulletins'),
+        SwitchListTile.adaptive(
+          title: const Text('Show bulletins'),
+          subtitle: const Text(
+            'Display received bulletins on the Bulletins tab.',
+          ),
+          value: bulletins.showBulletins,
+          onChanged: (v) => bulletins.setShowBulletins(v),
+        ),
+        SwitchListTile.adaptive(
+          title: const Text('Notify on bulletins'),
+          subtitle: const Text(
+            'Master toggle — subscribed named groups below can also be muted.',
+          ),
+          value: prefs.notifyBulletins,
+          onChanged: (v) => notifService.setNotifyBulletins(v),
+        ),
+        _BulletinRadiusTile(bulletins: bulletins),
+        _BulletinRetentionTile(bulletins: bulletins),
+        const SectionHeader('Named bulletin groups'),
+        _BulletinSubscriptionsList(subscriptions: bulletinSubs),
+        ListTile(
+          leading: const Icon(Symbols.add),
+          title: const Text('Add named group subscription'),
+          subtitle: const Text('e.g. WX, SRARC — up to 5 chars'),
+          onTap: () => _showBulletinSubscriptionAdder(context, bulletinSubs),
+        ),
+        if (advanced.isEnabled)
+          _AdvancedBulletinPathTile(settings: messagingSettings),
+        if (advanced.isEnabled)
+          _MutedBulletinSourcesTile(settings: messagingSettings),
         const SizedBox(height: 16),
       ],
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Groups list
+// ---------------------------------------------------------------------------
+
+class _GroupsList extends StatelessWidget {
+  const _GroupsList({required this.groups});
+  final GroupSubscriptionService groups;
+
+  @override
+  Widget build(BuildContext context) {
+    final subs = groups.subscriptions;
+    if (subs.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Text('No groups yet.'),
+      );
+    }
+    // ReorderableListView requires a bounded height; use shrinkWrap inside
+    // the outer scrolling ListView.
+    return ReorderableListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      buildDefaultDragHandles: true,
+      itemCount: subs.length,
+      itemBuilder: (ctx, idx) {
+        final sub = subs[idx];
+        return _GroupListItem(key: ValueKey(sub.id), sub: sub, groups: groups);
+      },
+      onReorder: (oldIndex, newIndex) {
+        if (newIndex > oldIndex) newIndex -= 1;
+        final ids = subs.map((s) => s.id).toList();
+        final moved = ids.removeAt(oldIndex);
+        ids.insert(newIndex, moved);
+        groups.reorder(ids);
+      },
+    );
+  }
+}
+
+class _GroupListItem extends StatelessWidget {
+  const _GroupListItem({super.key, required this.sub, required this.groups});
+  final GroupSubscription sub;
+  final GroupSubscriptionService groups;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = sub.replyMode == ReplyMode.sender
+        ? Symbols.campaign
+        : Symbols.forum;
+    final subtitle = [
+      sub.matchMode == MatchMode.exact ? 'exact match' : 'prefix match',
+      sub.replyMode == ReplyMode.sender ? 'reply to sender' : 'reply to group',
+      if (sub.isBuiltin) 'built-in',
+    ].join(' · ');
+
+    return ListTile(
+      leading: Icon(icon, color: sub.enabled ? null : Colors.grey),
+      title: Row(
+        children: [
+          Expanded(child: Text(sub.name)),
+          if (sub.isBuiltin) const Icon(Symbols.lock, size: 16),
+        ],
+      ),
+      subtitle: Text(subtitle),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Symbols.edit),
+            tooltip: 'Edit',
+            onPressed: () => _showGroupEditor(context, groups, existing: sub),
+          ),
+          Switch.adaptive(
+            value: sub.enabled,
+            onChanged: (v) => groups.update(sub.id, enabled: v),
+          ),
+        ],
+      ),
+      onTap: () => _showGroupEditor(context, groups, existing: sub),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group editor dialog
+// ---------------------------------------------------------------------------
+
+Future<void> _showGroupEditor(
+  BuildContext context,
+  GroupSubscriptionService groups, {
+  required GroupSubscription? existing,
+}) async {
+  final result = await showDialog<_GroupEditorResult>(
+    context: context,
+    builder: (ctx) => _GroupEditorDialog(existing: existing),
+  );
+  if (result == null) return;
+  if (result.delete && existing != null) {
+    try {
+      await groups.delete(existing.id);
+    } on StateError {
+      // Built-ins can't be deleted — UI shouldn't have offered the option.
+    }
+    return;
+  }
+  try {
+    if (existing == null) {
+      await groups.add(
+        name: result.name,
+        matchMode: result.matchMode,
+        replyMode: result.replyMode,
+        notify: result.notify,
+        enabled: result.enabled,
+      );
+    } else {
+      await groups.update(
+        existing.id,
+        name: existing.isBuiltin ? null : result.name,
+        matchMode: result.matchMode,
+        replyMode: result.replyMode,
+        notify: result.notify,
+        enabled: result.enabled,
+      );
+    }
+  } on ArgumentError catch (e) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Invalid: ${e.message}')));
+    }
+  }
+}
+
+class _GroupEditorResult {
+  _GroupEditorResult({
+    required this.name,
+    required this.matchMode,
+    required this.replyMode,
+    required this.notify,
+    required this.enabled,
+    this.delete = false,
+  });
+  final String name;
+  final MatchMode matchMode;
+  final ReplyMode replyMode;
+  final bool notify;
+  final bool enabled;
+  final bool delete;
+}
+
+class _GroupEditorDialog extends StatefulWidget {
+  const _GroupEditorDialog({required this.existing});
+  final GroupSubscription? existing;
+
+  @override
+  State<_GroupEditorDialog> createState() => _GroupEditorDialogState();
+}
+
+class _GroupEditorDialogState extends State<_GroupEditorDialog> {
+  late final TextEditingController _name;
+  late MatchMode _matchMode;
+  late ReplyMode _replyMode;
+  late bool _notify;
+  late bool _enabled;
+
+  bool get _isEdit => widget.existing != null;
+  bool get _isBuiltin => widget.existing?.isBuiltin ?? false;
+
+  @override
+  void initState() {
+    super.initState();
+    _name = TextEditingController(text: widget.existing?.name ?? '');
+    _matchMode = widget.existing?.matchMode ?? MatchMode.prefix;
+    _replyMode = widget.existing?.replyMode ?? ReplyMode.group;
+    _notify = widget.existing?.notify ?? true;
+    _enabled = widget.existing?.enabled ?? true;
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(_isEdit ? 'Edit group' : 'Add group'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _name,
+              enabled: !_isBuiltin,
+              textCapitalization: TextCapitalization.characters,
+              maxLength: 9,
+              decoration: InputDecoration(
+                labelText: 'Name',
+                hintText: 'e.g. CQ, SRARC',
+                helperText: _isBuiltin
+                    ? 'Built-in groups cannot be renamed'
+                    : '1–9 uppercase letters / digits',
+              ),
+              autofocus: !_isEdit,
+            ),
+            const SizedBox(height: 12),
+            const Text('Match mode'),
+            SegmentedButton<MatchMode>(
+              segments: const [
+                ButtonSegment(value: MatchMode.prefix, label: Text('Prefix')),
+                ButtonSegment(value: MatchMode.exact, label: Text('Exact')),
+              ],
+              selected: {_matchMode},
+              onSelectionChanged: (s) => setState(() => _matchMode = s.first),
+            ),
+            const SizedBox(height: 12),
+            const Text('Default reply'),
+            SegmentedButton<ReplyMode>(
+              segments: const [
+                ButtonSegment(
+                  value: ReplyMode.sender,
+                  icon: Icon(Symbols.campaign),
+                  label: Text('To sender'),
+                ),
+                ButtonSegment(
+                  value: ReplyMode.group,
+                  icon: Icon(Symbols.forum),
+                  label: Text('To group'),
+                ),
+              ],
+              selected: {_replyMode},
+              onSelectionChanged: (s) => setState(() => _replyMode = s.first),
+            ),
+            const SizedBox(height: 12),
+            SwitchListTile.adaptive(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Enabled'),
+              value: _enabled,
+              onChanged: (v) => setState(() => _enabled = v),
+            ),
+            SwitchListTile.adaptive(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Notify'),
+              value: _notify,
+              onChanged: (v) => setState(() => _notify = v),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        if (_isEdit && !_isBuiltin)
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(
+                _GroupEditorResult(
+                  name: widget.existing!.name,
+                  matchMode: _matchMode,
+                  replyMode: _replyMode,
+                  notify: _notify,
+                  enabled: _enabled,
+                  delete: true,
+                ),
+              );
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Delete'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final name = _name.text.trim().toUpperCase();
+            if (!_isBuiltin && !GroupSubscription.isValidName(name)) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Invalid group name')),
+              );
+              return;
+            }
+            Navigator.of(context).pop(
+              _GroupEditorResult(
+                name: name,
+                matchMode: _matchMode,
+                replyMode: _replyMode,
+                notify: _notify,
+                enabled: _enabled,
+              ),
+            );
+          },
+          child: Text(_isEdit ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bulletin radius / retention tiles
+// ---------------------------------------------------------------------------
+
+class _BulletinRadiusTile extends StatelessWidget {
+  const _BulletinRadiusTile({required this.bulletins});
+  final BulletinService bulletins;
+
+  String _labelFor(int km) => switch (km) {
+    0 => 'Map area only',
+    -1 => 'Global',
+    _ => '+$km km',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Symbols.radar),
+      title: const Text('Bulletin radius'),
+      subtitle: Text(_labelFor(bulletins.radiusKm)),
+      trailing: const Icon(Symbols.chevron_right),
+      onTap: () async {
+        final selected = await showDialog<int>(
+          context: context,
+          builder: (ctx) => SimpleDialog(
+            title: const Text('Bulletin radius'),
+            children: [
+              for (final km in BulletinService.radiusOptionsKm)
+                ListTile(
+                  leading: Icon(
+                    km == bulletins.radiusKm
+                        ? Symbols.radio_button_checked
+                        : Symbols.radio_button_unchecked,
+                  ),
+                  title: Text(_labelFor(km)),
+                  onTap: () => Navigator.of(ctx).pop(km),
+                ),
+            ],
+          ),
+        );
+        if (selected != null) await bulletins.setRadiusKm(selected);
+      },
+    );
+  }
+}
+
+class _BulletinRetentionTile extends StatelessWidget {
+  const _BulletinRetentionTile({required this.bulletins});
+  final BulletinService bulletins;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Symbols.schedule),
+      title: const Text('Retention'),
+      subtitle: Text('${bulletins.retentionHours}h'),
+      trailing: const Icon(Symbols.chevron_right),
+      onTap: () async {
+        final selected = await showDialog<int>(
+          context: context,
+          builder: (ctx) => SimpleDialog(
+            title: const Text('Bulletin retention'),
+            children: [
+              for (final h in BulletinService.retentionOptionsHours)
+                ListTile(
+                  leading: Icon(
+                    h == bulletins.retentionHours
+                        ? Symbols.radio_button_checked
+                        : Symbols.radio_button_unchecked,
+                  ),
+                  title: Text('${h}h'),
+                  onTap: () => Navigator.of(ctx).pop(h),
+                ),
+            ],
+          ),
+        );
+        if (selected != null) await bulletins.setRetentionHours(selected);
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bulletin subscriptions
+// ---------------------------------------------------------------------------
+
+class _BulletinSubscriptionsList extends StatelessWidget {
+  const _BulletinSubscriptionsList({required this.subscriptions});
+  final BulletinSubscriptionService subscriptions;
+
+  @override
+  Widget build(BuildContext context) {
+    final list = subscriptions.subscriptions;
+    if (list.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Text(
+          'No named-group subscriptions. Add one below to receive '
+          'bulletins like BLN1WX or BLN2SRARC.',
+        ),
+      );
+    }
+    return Column(
+      children: [
+        for (final sub in list)
+          ListTile(
+            leading: const Icon(Symbols.campaign),
+            title: Text(sub.groupName),
+            subtitle: Text(sub.notify ? 'Notifications on' : 'Silent'),
+            trailing: IconButton(
+              icon: const Icon(Symbols.delete),
+              onPressed: () => subscriptions.delete(sub.id),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+Future<void> _showBulletinSubscriptionAdder(
+  BuildContext context,
+  BulletinSubscriptionService subs,
+) async {
+  final controller = TextEditingController();
+  final result = await showDialog<String>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Add named-group subscription'),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        textCapitalization: TextCapitalization.characters,
+        maxLength: 5,
+        decoration: const InputDecoration(
+          labelText: 'Group name',
+          hintText: 'e.g. WX, SRARC',
+          helperText: '1–5 uppercase letters / digits',
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
+          child: const Text('Add'),
+        ),
+      ],
+    ),
+  );
+  if (result == null || result.isEmpty) return;
+  final normalized = result.toUpperCase();
+  if (!BulletinSubscription.isValidName(normalized)) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Invalid name — 1–5 alphanumeric chars')),
+      );
+    }
+    return;
+  }
+  try {
+    await subs.add(groupName: normalized);
+  } on ArgumentError catch (e) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Invalid: ${e.message}')));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Advanced-mode tiles
+// ---------------------------------------------------------------------------
+
+class _AdvancedGroupPathTile extends StatelessWidget {
+  const _AdvancedGroupPathTile({required this.settings});
+  final MessagingSettingsService settings;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = settings.groupMessagePath.isEmpty
+        ? 'Uses beacon path (${MessagingSettingsService.resolvedDefaultGroupMessagePath})'
+        : settings.groupMessagePath;
+    return ListTile(
+      leading: const Icon(Symbols.route),
+      title: const Text('Group message path'),
+      subtitle: Text(value),
+      trailing: const Icon(Symbols.edit),
+      onTap: () => _showPathEditor(
+        context,
+        title: 'Group message path',
+        initial: settings.groupMessagePath,
+        hint: 'Leave empty to use beacon path',
+        onSave: settings.setGroupMessagePath,
+        allowEmpty: true,
+      ),
+    );
+  }
+}
+
+class _AdvancedBulletinPathTile extends StatelessWidget {
+  const _AdvancedBulletinPathTile({required this.settings});
+  final MessagingSettingsService settings;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Symbols.route),
+      title: const Text('Bulletin path'),
+      subtitle: Text(settings.bulletinPath),
+      trailing: const Icon(Symbols.edit),
+      onTap: () => _showPathEditor(
+        context,
+        title: 'Bulletin path',
+        initial: settings.bulletinPath,
+        hint: 'Default: ${MessagingSettingsService.defaultBulletinPath}',
+        onSave: settings.setBulletinPath,
+        allowEmpty: false,
+      ),
+    );
+  }
+}
+
+Future<void> _showPathEditor(
+  BuildContext context, {
+  required String title,
+  required String initial,
+  required String hint,
+  required Future<void> Function(String) onSave,
+  required bool allowEmpty,
+}) async {
+  final controller = TextEditingController(text: initial);
+  final result = await showDialog<String?>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        decoration: InputDecoration(
+          labelText: 'Digipeater path',
+          hintText: hint,
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(controller.text),
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+  if (result == null) return;
+  if (!allowEmpty && result.trim().isEmpty) return;
+  try {
+    await onSave(result);
+  } on ArgumentError catch (e) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Invalid: ${e.message}')));
+    }
+  }
+}
+
+class _MutedBulletinSourcesTile extends StatelessWidget {
+  const _MutedBulletinSourcesTile({required this.settings});
+  final MessagingSettingsService settings;
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = settings.mutedBulletinSources.toList()..sort();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ListTile(
+          leading: const Icon(Symbols.notifications_off),
+          title: const Text('Muted bulletin sources'),
+          subtitle: Text(
+            muted.isEmpty
+                ? 'No callsigns muted'
+                : '${muted.length} callsign${muted.length == 1 ? '' : 's'} muted',
+          ),
+          trailing: IconButton(
+            icon: const Icon(Symbols.add),
+            onPressed: () => _showAddMutedSource(context, settings),
+          ),
+        ),
+        for (final callsign in muted)
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: ListTile(
+              dense: true,
+              title: Text(callsign),
+              trailing: IconButton(
+                icon: const Icon(Symbols.close),
+                onPressed: () => settings.removeMutedBulletinSource(callsign),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+Future<void> _showAddMutedSource(
+  BuildContext context,
+  MessagingSettingsService settings,
+) async {
+  final controller = TextEditingController();
+  final result = await showDialog<String>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Mute bulletin source'),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        textCapitalization: TextCapitalization.characters,
+        decoration: const InputDecoration(
+          labelText: 'Callsign (with or without SSID)',
+          hintText: 'e.g. K5WX-15',
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
+          child: const Text('Mute'),
+        ),
+      ],
+    ),
+  );
+  if (result == null || result.isEmpty) return;
+  await settings.addMutedBulletinSource(result);
 }

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -46,10 +46,37 @@ class BulletinService extends ChangeNotifier {
 
   static const _keyBulletins = 'bulletins_v1';
   static const _keyNextId = 'bulletins_next_id_v1';
+  static const _keyShowBulletins = 'bulletins_show';
+  static const _keyRadiusKm = 'bulletins_radius_km';
+  static const _keyRetentionHours = 'bulletins_retention_hours';
+
+  /// Allowed radius options (km). `0` is a sentinel for "Map area only" (no
+  /// client-side distance filter — the APRS-IS area filter handles it).
+  /// The `-1` sentinel means "Global" (no distance filter at all).
+  static const List<int> radiusOptionsKm = [0, 100, 500, 1000, -1];
+
+  /// Allowed retention options (hours). Default is 48h (APRSIS32 convention).
+  static const List<int> retentionOptionsHours = [24, 48, 72];
 
   // Keyed by "SOURCE|ADDRESSEE" for stable lookup.
   final Map<String, Bulletin> _bulletins = {};
   int _nextId = 1;
+
+  bool _showBulletins = true;
+  int _radiusKm = 500;
+  int _retentionHours = 48;
+
+  /// Master toggle for bulletin display. When false, the Bulletins tab hides
+  /// all received rows (ingest keeps storing — ADR-054 capture-always parity).
+  bool get showBulletins => _showBulletins;
+
+  /// Distance-filter radius in km for APRS-IS-received general bulletins.
+  /// `0` = "map area only" (area filter alone); `-1` = "global" (no filter).
+  /// Actual distance-filtering logic lands in PR 5 along with the filter
+  /// builder; this getter only stores the user preference for now.
+  int get radiusKm => _radiusKm;
+
+  int get retentionHours => _retentionHours;
 
   /// All stored bulletins, newest `lastHeardAt` first.
   List<Bulletin> get bulletins {
@@ -63,6 +90,9 @@ class BulletinService extends ChangeNotifier {
   Future<void> load() async {
     final prefs = await _prefs();
     _nextId = prefs.getInt(_keyNextId) ?? 1;
+    _showBulletins = prefs.getBool(_keyShowBulletins) ?? true;
+    _radiusKm = prefs.getInt(_keyRadiusKm) ?? 500;
+    _retentionHours = prefs.getInt(_keyRetentionHours) ?? 48;
     final raw = prefs.getString(_keyBulletins);
     if (raw != null) {
       try {
@@ -160,6 +190,40 @@ class BulletinService extends ChangeNotifier {
     if (current.isRead) return;
     _bulletins[matchKey] = current.copyWith(isRead: true);
     await _persist();
+    notifyListeners();
+  }
+
+  Future<void> setShowBulletins(bool v) async {
+    if (_showBulletins == v) return;
+    _showBulletins = v;
+    final prefs = await _prefs();
+    await prefs.setBool(_keyShowBulletins, v);
+    notifyListeners();
+  }
+
+  Future<void> setRadiusKm(int v) async {
+    if (_radiusKm == v) return;
+    if (!radiusOptionsKm.contains(v)) {
+      throw ArgumentError.value(v, 'radiusKm', 'not a supported radius');
+    }
+    _radiusKm = v;
+    final prefs = await _prefs();
+    await prefs.setInt(_keyRadiusKm, v);
+    notifyListeners();
+  }
+
+  Future<void> setRetentionHours(int v) async {
+    if (_retentionHours == v) return;
+    if (!retentionOptionsHours.contains(v)) {
+      throw ArgumentError.value(
+        v,
+        'retentionHours',
+        'not a supported retention',
+      );
+    }
+    _retentionHours = v;
+    final prefs = await _prefs();
+    await prefs.setInt(_keyRetentionHours, v);
     notifyListeners();
   }
 

--- a/lib/services/group_subscription_service.dart
+++ b/lib/services/group_subscription_service.dart
@@ -1,10 +1,13 @@
 /// Manages the operator's APRS group subscriptions.
 ///
-/// Seeds the four built-ins on first run (per spec §5.1 / ADR-056):
-///   - `ALL`   disabled, notify off, reply `sender`  (broadcast discovery)
-///   - `CQ`    enabled,  notify off, reply `sender`  (contact-making)
-///   - `QST`   enabled,  notify off, reply `sender`  (broadcast discovery)
-///   - `YAESU` disabled, notify off, reply `sender`  (radio-firmware default)
+/// Seeds three protocol-neutral built-ins on first run (per ADR-056):
+///   - `ALL` disabled, notify off, reply `sender`  (broadcast discovery)
+///   - `CQ`  enabled,  notify off, reply `sender`  (contact-making)
+///   - `QST` enabled,  notify off, reply `sender`  (broadcast discovery)
+///
+/// Radio-vendor group names (e.g. `YAESU`) are intentionally omitted —
+/// Meridian is not a vendor-specific product. Users can add any custom
+/// group they want via Settings → Messaging → Groups.
 ///
 /// All state persisted as a JSON blob in SharedPreferences. The drift/SQLite
 /// migration is v0.15 scope and will absorb this table.
@@ -75,7 +78,6 @@ class GroupSubscriptionService extends ChangeNotifier {
       _BuiltinDefault('ALL', enabled: false),
       _BuiltinDefault('CQ', enabled: true),
       _BuiltinDefault('QST', enabled: true),
-      _BuiltinDefault('YAESU', enabled: false),
     ];
     for (final d in defaults) {
       if (existingNames.contains(d.name)) continue;

--- a/lib/services/messaging_settings_service.dart
+++ b/lib/services/messaging_settings_service.dart
@@ -1,0 +1,131 @@
+/// Advanced-mode path and blocklist settings for v0.17 messaging.
+///
+/// Owns three preferences that only appear in the Settings UI when Advanced
+/// Mode is enabled (ADR-053):
+///
+///   - `groupMessagePath` — RF digipeater path for outgoing group messages.
+///     Default is empty, which means "use the same path the beacon encoder
+///     uses" (today hardcoded to `WIDE1-1,WIDE2-1` in [Ax25Encoder]).
+///   - `bulletinPath` — RF digipeater path for outgoing bulletins. Default
+///     `WIDE2-2` per traditional APRS bulletin convention.
+///   - `mutedBulletinSources` — callsigns whose bulletins are suppressed on
+///     the Bulletins tab regardless of scope.
+///
+/// Consumed by PR 4's send path (`BulletinScheduler`, group send). PR 2
+/// wires UI + persistence only.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MessagingSettingsService extends ChangeNotifier {
+  MessagingSettingsService({SharedPreferences? prefs}) : _prefsOverride = prefs;
+
+  final SharedPreferences? _prefsOverride;
+
+  static const _keyGroupMessagePath = 'messaging_group_message_path';
+  static const _keyBulletinPath = 'messaging_bulletin_path';
+  static const _keyMutedBulletinSources = 'messaging_muted_bulletin_sources';
+
+  /// Default bulletin path per spec §3.
+  static const defaultBulletinPath = 'WIDE2-2';
+
+  /// Resolved text for the "uses beacon path" default when [groupMessagePath]
+  /// is empty. Today this is hardcoded in [Ax25Encoder.buildAprsFrame]; when a
+  /// configurable beacon path is introduced this string becomes dynamic.
+  static const resolvedDefaultGroupMessagePath = 'WIDE1-1,WIDE2-1';
+
+  String _groupMessagePath = '';
+  String _bulletinPath = defaultBulletinPath;
+  Set<String> _mutedBulletinSources = {};
+
+  /// Empty string means "same as beacon path" — see
+  /// [resolvedDefaultGroupMessagePath].
+  String get groupMessagePath => _groupMessagePath;
+
+  String get bulletinPath => _bulletinPath;
+
+  Set<String> get mutedBulletinSources =>
+      Set.unmodifiable(_mutedBulletinSources);
+
+  /// Effective path string used by the TX layer for group messages.
+  String get effectiveGroupMessagePath => _groupMessagePath.isEmpty
+      ? resolvedDefaultGroupMessagePath
+      : _groupMessagePath;
+
+  Future<void> load() async {
+    final prefs = await _prefs();
+    _groupMessagePath = prefs.getString(_keyGroupMessagePath) ?? '';
+    _bulletinPath = prefs.getString(_keyBulletinPath) ?? defaultBulletinPath;
+    final raw = prefs.getString(_keyMutedBulletinSources);
+    if (raw != null) {
+      try {
+        _mutedBulletinSources =
+            ((jsonDecode(raw) as List<dynamic>).cast<String>())
+                .map((c) => c.toUpperCase())
+                .toSet();
+      } catch (_) {
+        _mutedBulletinSources = {};
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<void> setGroupMessagePath(String value) async {
+    final v = value.trim();
+    if (_groupMessagePath == v) return;
+    _groupMessagePath = v;
+    final prefs = await _prefs();
+    if (v.isEmpty) {
+      await prefs.remove(_keyGroupMessagePath);
+    } else {
+      await prefs.setString(_keyGroupMessagePath, v);
+    }
+    notifyListeners();
+  }
+
+  Future<void> setBulletinPath(String value) async {
+    final v = value.trim();
+    if (v.isEmpty) {
+      // Reject empty — bulletins must have a path. Revert to default instead
+      // of silently failing (caller should pass explicit default to reset).
+      throw ArgumentError.value(value, 'bulletinPath', 'must not be empty');
+    }
+    if (_bulletinPath == v) return;
+    _bulletinPath = v;
+    final prefs = await _prefs();
+    await prefs.setString(_keyBulletinPath, v);
+    notifyListeners();
+  }
+
+  Future<void> addMutedBulletinSource(String callsign) async {
+    final normalized = callsign.trim().toUpperCase();
+    if (normalized.isEmpty) return;
+    if (_mutedBulletinSources.contains(normalized)) return;
+    _mutedBulletinSources = {..._mutedBulletinSources, normalized};
+    await _persistMutedSources();
+    notifyListeners();
+  }
+
+  Future<void> removeMutedBulletinSource(String callsign) async {
+    final normalized = callsign.trim().toUpperCase();
+    if (!_mutedBulletinSources.contains(normalized)) return;
+    _mutedBulletinSources = {..._mutedBulletinSources}..remove(normalized);
+    await _persistMutedSources();
+    notifyListeners();
+  }
+
+  Future<void> _persistMutedSources() async {
+    final prefs = await _prefs();
+    await prefs.setString(
+      _keyMutedBulletinSources,
+      jsonEncode(_mutedBulletinSources.toList()),
+    );
+  }
+
+  Future<SharedPreferences> _prefs() async =>
+      _prefsOverride ?? await SharedPreferences.getInstance();
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -364,6 +364,18 @@ class NotificationService extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> setNotifyGroups(bool v) async {
+    _notifPrefs = _notifPrefs.copyWithNotifyGroups(v);
+    await _notifPrefs.save(_prefs);
+    notifyListeners();
+  }
+
+  Future<void> setNotifyBulletins(bool v) async {
+    _notifPrefs = _notifPrefs.copyWithNotifyBulletins(v);
+    await _notifPrefs.save(_prefs);
+    notifyListeners();
+  }
+
   // ---------------------------------------------------------------------------
   // MessageService listener
   // ---------------------------------------------------------------------------

--- a/test/models/notification_preferences_test.dart
+++ b/test/models/notification_preferences_test.dart
@@ -85,6 +85,39 @@ void main() {
         expect(loaded.isSoundEnabled(NotificationChannels.alerts), isTrue);
       });
 
+      test('v0.17 defaults: notifyGroups=true, notifyBulletins=false', () {
+        final prefs = NotificationPreferences.defaults();
+        expect(prefs.notifyGroups, isTrue);
+        expect(prefs.notifyBulletins, isFalse);
+      });
+
+      test('copyWithNotifyGroups isolates the field', () {
+        final original = NotificationPreferences.defaults();
+        final toggled = original.copyWithNotifyGroups(false);
+        expect(toggled.notifyGroups, isFalse);
+        expect(toggled.notifyBulletins, original.notifyBulletins);
+        expect(toggled.notifyOtherSsids, original.notifyOtherSsids);
+      });
+
+      test('copyWithNotifyBulletins isolates the field', () {
+        final original = NotificationPreferences.defaults();
+        final toggled = original.copyWithNotifyBulletins(true);
+        expect(toggled.notifyBulletins, isTrue);
+        expect(toggled.notifyGroups, original.notifyGroups);
+      });
+
+      test('notifyGroups/notifyBulletins round-trip', () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final original = NotificationPreferences.defaults()
+            .copyWithNotifyGroups(false)
+            .copyWithNotifyBulletins(true);
+        await original.save(prefs);
+        final loaded = await NotificationPreferences.load(prefs);
+        expect(loaded.notifyGroups, isFalse);
+        expect(loaded.notifyBulletins, isTrue);
+      });
+
       test('load with no stored values returns defaults', () async {
         SharedPreferences.setMockInitialValues({});
         final prefs = await SharedPreferences.getInstance();

--- a/test/services/bulletin_service_test.dart
+++ b/test/services/bulletin_service_test.dart
@@ -158,6 +158,47 @@ void main() {
     });
   });
 
+  group('receive-scope prefs (v0.17 PR 2)', () {
+    test(
+      'defaults: showBulletins=true, radiusKm=500, retentionHours=48',
+      () async {
+        final (svc, _) = await makeServices();
+        expect(svc.showBulletins, isTrue);
+        expect(svc.radiusKm, 500);
+        expect(svc.retentionHours, 48);
+      },
+    );
+
+    test('setRadiusKm rejects unsupported values', () async {
+      final (svc, _) = await makeServices();
+      expect(() => svc.setRadiusKm(250), throwsArgumentError);
+      expect(() => svc.setRadiusKm(-2), throwsArgumentError);
+    });
+
+    test('setRetentionHours rejects unsupported values', () async {
+      final (svc, _) = await makeServices();
+      expect(() => svc.setRetentionHours(36), throwsArgumentError);
+    });
+
+    test('prefs round-trip across instances', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final subs = BulletinSubscriptionService(prefs: prefs);
+      await subs.load();
+      final first = BulletinService(subscriptions: subs, prefs: prefs);
+      await first.load();
+      await first.setShowBulletins(false);
+      await first.setRadiusKm(1000);
+      await first.setRetentionHours(72);
+
+      final reloaded = BulletinService(subscriptions: subs, prefs: prefs);
+      await reloaded.load();
+      expect(reloaded.showBulletins, isFalse);
+      expect(reloaded.radiusKm, 1000);
+      expect(reloaded.retentionHours, 72);
+    });
+  });
+
   group('persistence + retention', () {
     test('bulletins round-trip through SharedPreferences', () async {
       SharedPreferences.setMockInitialValues({});

--- a/test/services/group_subscription_service_test.dart
+++ b/test/services/group_subscription_service_test.dart
@@ -8,28 +8,33 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('seeder (ADR-056 built-ins)', () {
-    test('fresh install seeds ALL, CQ, QST, YAESU', () async {
-      SharedPreferences.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
-      final service = GroupSubscriptionService(prefs: prefs);
-      await service.load();
+    test(
+      'fresh install seeds ALL, CQ, QST (no vendor-specific names)',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = GroupSubscriptionService(prefs: prefs);
+        await service.load();
 
-      final names = service.subscriptions.map((s) => s.name).toList();
-      expect(names, containsAll(['ALL', 'CQ', 'QST', 'YAESU']));
+        final names = service.subscriptions.map((s) => s.name).toList();
+        expect(names, containsAll(['ALL', 'CQ', 'QST']));
+        // Vendor names must not be seeded by default.
+        expect(names, isNot(contains('YAESU')));
+        expect(names, isNot(contains('KENWOOD')));
 
-      final byName = {for (final s in service.subscriptions) s.name: s};
-      expect(byName['CQ']!.enabled, isTrue);
-      expect(byName['QST']!.enabled, isTrue);
-      expect(byName['ALL']!.enabled, isFalse);
-      expect(byName['YAESU']!.enabled, isFalse);
+        final byName = {for (final s in service.subscriptions) s.name: s};
+        expect(byName['CQ']!.enabled, isTrue);
+        expect(byName['QST']!.enabled, isTrue);
+        expect(byName['ALL']!.enabled, isFalse);
 
-      // All built-ins default to reply-to-sender + notify off.
-      for (final name in ['ALL', 'CQ', 'QST', 'YAESU']) {
-        expect(byName[name]!.replyMode, ReplyMode.sender);
-        expect(byName[name]!.notify, isFalse);
-        expect(byName[name]!.isBuiltin, isTrue);
-      }
-    });
+        // All built-ins default to reply-to-sender + notify off.
+        for (final name in ['ALL', 'CQ', 'QST']) {
+          expect(byName[name]!.replyMode, ReplyMode.sender);
+          expect(byName[name]!.notify, isFalse);
+          expect(byName[name]!.isBuiltin, isTrue);
+        }
+      },
+    );
 
     test(
       'seeder is idempotent — second load does not duplicate or reset',
@@ -49,11 +54,11 @@ void main() {
           (s) => s.name == 'ALL',
         );
         expect(secondAll.enabled, isTrue);
-        // Still only 4 built-ins (no duplicate seed).
+        // Still only 3 built-ins (no duplicate seed).
         final builtins = second.subscriptions
             .where((s) => s.isBuiltin)
             .toList();
-        expect(builtins.length, 4);
+        expect(builtins.length, 3);
       },
     );
   });

--- a/test/services/messaging_settings_service_test.dart
+++ b/test/services/messaging_settings_service_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/services/messaging_settings_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('defaults', () {
+    test('empty group message path means "same as beacon path"', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      expect(svc.groupMessagePath, isEmpty);
+      expect(
+        svc.effectiveGroupMessagePath,
+        MessagingSettingsService.resolvedDefaultGroupMessagePath,
+      );
+    });
+
+    test('default bulletin path is WIDE2-2', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      expect(svc.bulletinPath, 'WIDE2-2');
+    });
+
+    test('default muted sources is empty', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      expect(svc.mutedBulletinSources, isEmpty);
+    });
+  });
+
+  group('persistence', () {
+    test('group message path round-trips', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final first = MessagingSettingsService(prefs: prefs);
+      await first.load();
+      await first.setGroupMessagePath('WIDE1-1');
+
+      final second = MessagingSettingsService(prefs: prefs);
+      await second.load();
+      expect(second.groupMessagePath, 'WIDE1-1');
+      expect(second.effectiveGroupMessagePath, 'WIDE1-1');
+    });
+
+    test('setting group message path to empty clears the pref', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      await svc.setGroupMessagePath('WIDE1-1');
+      await svc.setGroupMessagePath('');
+      expect(svc.groupMessagePath, isEmpty);
+      expect(
+        svc.effectiveGroupMessagePath,
+        MessagingSettingsService.resolvedDefaultGroupMessagePath,
+      );
+    });
+
+    test('bulletin path rejects empty', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      expect(() => svc.setBulletinPath(''), throwsArgumentError);
+      expect(() => svc.setBulletinPath('   '), throwsArgumentError);
+      expect(svc.bulletinPath, 'WIDE2-2');
+    });
+
+    test('muted sources add/remove + uppercase normalization', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final svc = MessagingSettingsService(prefs: prefs);
+      await svc.load();
+      await svc.addMutedBulletinSource('k5wx-15');
+      expect(svc.mutedBulletinSources, contains('K5WX-15'));
+
+      // Add again — should be idempotent.
+      await svc.addMutedBulletinSource('K5WX-15');
+      expect(svc.mutedBulletinSources.length, 1);
+
+      await svc.removeMutedBulletinSource('K5WX-15');
+      expect(svc.mutedBulletinSources, isEmpty);
+    });
+
+    test('muted sources persist across service instances', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final first = MessagingSettingsService(prefs: prefs);
+      await first.load();
+      await first.addMutedBulletinSource('N0CALL-7');
+
+      final second = MessagingSettingsService(prefs: prefs);
+      await second.load();
+      expect(second.mutedBulletinSources, contains('N0CALL-7'));
+    });
+  });
+}

--- a/test/widget/settings/messaging_screen_test.dart
+++ b/test/widget/settings/messaging_screen_test.dart
@@ -1,0 +1,249 @@
+/// Widget tests for `MessagingSettingsContent`. Covers the v0.17 PR 2
+/// additions — Groups subsection, Bulletins subsection, Advanced-mode path
+/// fields — plus the pre-existing v0.14 Cross-SSID section to confirm no
+/// regression.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/models/notification_preferences.dart';
+import 'package:meridian_aprs/screens/settings/advanced_mode_controller.dart';
+import 'package:meridian_aprs/screens/settings/category/messaging_screen.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
+import 'package:meridian_aprs/services/message_service.dart';
+import 'package:meridian_aprs/services/messaging_settings_service.dart';
+import 'package:meridian_aprs/services/notification_service.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+import 'package:meridian_aprs/ui/widgets/in_app_banner_overlay.dart';
+
+import '../../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+class _Harness {
+  _Harness._({
+    required this.groups,
+    required this.bulletinSubs,
+    required this.bulletins,
+    required this.messagingSettings,
+    required this.advanced,
+    required this.widget,
+  });
+
+  final GroupSubscriptionService groups;
+  final BulletinSubscriptionService bulletinSubs;
+  final BulletinService bulletins;
+  final MessagingSettingsService messagingSettings;
+  final AdvancedModeController advanced;
+  final Widget widget;
+
+  static Future<_Harness> create() async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1ABC',
+      'user_ssid': 7,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    final registry = ConnectionRegistry();
+    final stationService = StationService();
+    final tx = TxService(registry, settings);
+
+    final groups = GroupSubscriptionService(prefs: prefs);
+    await groups.load();
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+    final messagingSettings = MessagingSettingsService(prefs: prefs);
+    await messagingSettings.load();
+    final advanced = await AdvancedModeController.create();
+
+    final messageService = MessageService(
+      settings,
+      tx,
+      stationService,
+      groupSubscriptions: groups,
+      bulletins: bulletins,
+    );
+    final notifService = NotificationService(
+      messageService: messageService,
+      prefs: prefs,
+      navigatorKey: GlobalKey<NavigatorState>(),
+      bannerController: InAppBannerController(),
+    );
+    // Seed notif prefs without touching platform channels.
+    await NotificationPreferences.defaults(optedIn: true).save(prefs);
+
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<StationSettingsService>.value(
+              value: settings,
+            ),
+            ChangeNotifierProvider<MessageService>.value(value: messageService),
+            ChangeNotifierProvider<NotificationService>.value(
+              value: notifService,
+            ),
+            ChangeNotifierProvider<GroupSubscriptionService>.value(
+              value: groups,
+            ),
+            ChangeNotifierProvider<BulletinSubscriptionService>.value(
+              value: bulletinSubs,
+            ),
+            ChangeNotifierProvider<BulletinService>.value(value: bulletins),
+            ChangeNotifierProvider<MessagingSettingsService>.value(
+              value: messagingSettings,
+            ),
+            ChangeNotifierProvider<AdvancedModeController>.value(
+              value: advanced,
+            ),
+          ],
+          child: const MessagingSettingsContent(),
+        ),
+      ),
+    );
+
+    return _Harness._(
+      groups: groups,
+      bulletinSubs: bulletinSubs,
+      bulletins: bulletins,
+      messagingSettings: messagingSettings,
+      advanced: advanced,
+      widget: widget,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // SectionHeader uppercases its title on render.
+
+  testWidgets('renders all three section headers', (tester) async {
+    final h = await _Harness.create();
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+    // Top of list — Cross-SSID Messages — is always visible.
+    expect(find.text('CROSS-SSID MESSAGES'), findsOneWidget);
+    // Groups + Bulletins may be below the fold in the test viewport;
+    // scroll through the list to confirm they render.
+    await tester.scrollUntilVisible(
+      find.text('GROUPS'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('GROUPS'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.text('BULLETINS'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('BULLETINS'), findsOneWidget);
+  });
+
+  testWidgets('built-in groups appear in the list', (tester) async {
+    final h = await _Harness.create();
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+    // Scroll until CQ is visible. Default seeded set includes CQ + QST.
+    await tester.scrollUntilVisible(
+      find.text('CQ'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('CQ'), findsOneWidget);
+    expect(find.text('QST'), findsOneWidget);
+  });
+
+  testWidgets('Advanced-mode path fields hidden when advanced mode is off', (
+    tester,
+  ) async {
+    final h = await _Harness.create();
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+    // Scroll to the bottom in case the section existed — then assert none.
+    await tester.drag(
+      find.byType(Scrollable).first,
+      const Offset(0, -3000),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Group message path'), findsNothing);
+    expect(find.text('Bulletin path'), findsNothing);
+    expect(find.text('Muted bulletin sources'), findsNothing);
+  });
+
+  testWidgets('Advanced-mode path fields appear when toggled on', (
+    tester,
+  ) async {
+    final h = await _Harness.create();
+    await h.advanced.setEnabled(true);
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Bulletin path'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Bulletin path'), findsOneWidget);
+    expect(find.text('Muted bulletin sources'), findsOneWidget);
+    // Group message path is rendered above in the Groups section.
+    await tester.scrollUntilVisible(
+      find.text('Group message path'),
+      -300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.text('Group message path'), findsOneWidget);
+  });
+
+  testWidgets('Show bulletins toggle wires through service', (tester) async {
+    final h = await _Harness.create();
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+
+    expect(h.bulletins.showBulletins, isTrue);
+    await tester.scrollUntilVisible(
+      find.text('Show bulletins'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.text('Show bulletins'));
+    await tester.pumpAndSettle();
+    expect(h.bulletins.showBulletins, isFalse);
+  });
+
+  testWidgets('named bulletin subscription empty state copy renders', (
+    tester,
+  ) async {
+    final h = await _Harness.create();
+    await tester.pumpWidget(h.widget);
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.textContaining('No named-group subscriptions'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.textContaining('No named-group subscriptions'), findsOneWidget);
+  });
+}

--- a/test/widget/settings/messaging_screen_test.dart
+++ b/test/widget/settings/messaging_screen_test.dart
@@ -183,10 +183,7 @@ void main() {
     await tester.pumpWidget(h.widget);
     await tester.pumpAndSettle();
     // Scroll to the bottom in case the section existed — then assert none.
-    await tester.drag(
-      find.byType(Scrollable).first,
-      const Offset(0, -3000),
-    );
+    await tester.drag(find.byType(Scrollable).first, const Offset(0, -3000));
     await tester.pumpAndSettle();
     expect(find.text('Group message path'), findsNothing);
     expect(find.text('Bulletin path'), findsNothing);


### PR DESCRIPTION
## Summary
- Extends Settings → Messaging with three new inline subsections (**Groups**, **Bulletins**, Advanced-mode paths) built on the PR 1 data layer.
- Groups: master notify toggle, reorderable subscription list (built-ins lock-iconed), per-group edit dialog (name, match mode, reply mode, notify), add-custom-group flow, delete (custom only).
- Bulletins: Show toggle, Notify toggle, Radius dropdown (Map area / +100km / +500km / +1000km / Global), Retention dropdown (24h / 48h / 72h), named-group subscriptions list with add dialog.
- Advanced-mode only (ADR-053 gating): Group message path (empty = resolved beacon path `WIDE1-1,WIDE2-1`), Bulletin path (default `WIDE2-2`), Muted bulletin sources blocklist. Hidden and falls back to defaults when Advanced Mode is off.
- Vendor-neutrality chore: dropped `YAESU` from the seeded built-ins. Seeder now produces `ALL`, `CQ`, `QST` only. ADR-056 + spec §5.1 updated to document the choice. Users can still add any vendor name as a custom group in two taps.

## Service-layer additions
- `BulletinService`: `showBulletins` / `radiusKm` / `retentionHours` prefs with supported-value validation. Distance-filter logic still lives in PR 5.
- `MessagingSettingsService` (new): owns the three Advanced-mode prefs. `effectiveGroupMessagePath` getter resolves the "same as beacon path" sentinel. Consumed by PR 4's send path.
- `NotificationPreferences`: `notifyGroups` (default on) and `notifyBulletins` (default off) with `copyWith*` + round-trip persistence. Dispatch wiring lands in PR 5.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 534 passing (512 existing + 22 new)
- [x] Widget: section headers render; built-in groups appear; Advanced-mode fields hidden when off, visible when on; Show-bulletins toggle wires through; named-group empty-state copy renders
- [x] Service: `MessagingSettingsService` defaults + round-trip + muted sources; `BulletinService` new prefs validation + round-trip; `NotificationPreferences` new-field round-trip + copyWith isolation
- [x] Seeder: no `YAESU` or `KENWOOD` in defaults; `ALL` disabled, `CQ`/`QST` enabled; idempotent
- [x] Manual (user-tested): settings → Messaging shows three sections; built-ins persist toggles across restart; Advanced Mode on/off hides/shows path fields; add custom group `SRARC` flow works; add named-group subscription `WX` works