### PR TITLE
feat: v0.17 PR 3 — Messaging tab restructure (Direct / Groups / Bulletins)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1187,3 +1187,54 @@ Rationale:
 - BLE TNC background sessions continue to function — they rode under `dataSync` before ADR-052 and still do now.
 - ADR-052 is superseded. Audit finding F-META-003 (#44) is reopened for the underlying concern (is `dataSync` semantically correct for BLE TNC?) but the crash is resolved.
 - Manifest comment references this ADR so future contributors don't re-add `connectedDevice` without the dynamic plugin path.
+
+---
+
+## ADR-059: Messaging tab restructure — segmented Direct / Groups / Bulletins (v0.17)
+
+**Date:** 2026-04-24
+**Status:** Accepted
+
+### Context
+
+v0.17 adds two new top-level message surfaces (Groups and Bulletins) alongside the existing Direct thread list. All three share the same conceptual home — the "Messages" destination — but they diverge on UX semantics: Direct is 1:1 with ACK chrome, Groups is a broadcast chat room with reply-mode adaptation, Bulletins is a read-only feed with age-out. We needed to decide how the user switches between them.
+
+Options considered:
+
+1. **New top-level bottom-nav destinations.** Adds two icons to the mobile scaffold. Rejected — the bottom nav already holds Map / Packets / Messages / Connection / Settings, and adding two more crowds it past the Material-recommended limit (5) and would require a second "More" sheet on smaller devices.
+2. **Separate subscreens pushed from Direct.** User enters Messages → taps a button → lands on Groups. Rejected — makes Groups and Bulletins feel like subordinate features rather than peers, and the back-button gesture would become the primary "switch tab" affordance.
+3. **Segmented control at the top of the Messages screen.** Three peers, platform-adaptive, one tap to switch. Accepted.
+
+### Decision
+
+- **Segmented control** at the top of `MessagesScreen` with three values: Direct / Groups / Bulletins. Direct is the default.
+- **Platform adaptivity:** Material 3 `SegmentedButton` on Android + desktop; `CupertinoSlidingSegmentedControl` on iOS. Both are platform-native idioms for 3-option toggles.
+- **Unread badges** on the Direct and Groups segments (Material side only — Cupertino's sliding control doesn't support per-segment trailing content; iOS users see unread counts in the tab content itself).
+- **Compose FAB** is gated to the Direct tab. Group send UI lives on the Group channel screen; Bulletin compose gets its own FAB on the Bulletins tab in PR 4.
+- **Direct tab preserves v0.14 behavior byte-for-byte.** The existing conversation-grouping logic, ACK retry surface, cross-SSID filter, and compose sheet are all unchanged — only the ambient chrome (segmented control) is new.
+- **Groups tab** lists `GroupSubscription` entries in user-defined order (matcher-semantics mirror: first match wins). Tapping a tile opens `GroupChannelScreen`. Empty state routes the user to Settings → Messaging → Groups.
+- **Group channel screen** is a separate screen (not a reuse of `MessageThreadScreen`) because the bubble shape (sender callsign on every message), the absence of ACK/retry chrome, and the adaptive compose bar differ materially from direct threads.
+- **Bulletins tab** is a flat feed with filter chips (All / General / Groups / My bulletins) and a location-unknown banner. Tapping a row opens `BulletinDetailScreen`, which is explicitly read-only — no compose affordance.
+
+### Why a separate `GroupChannelScreen` instead of reusing `MessageThreadScreen`
+
+- The group channel renders sender attribution on every bubble (`MessageEntry.fromCallsign`), while direct threads rely on "all messages in this thread are from the peer" and never need per-message sender labels.
+- Direct threads carry ACK/retry status indicators on outgoing bubbles. Group messages have no ACK chrome (ADR-055 forbids ACKing groups), so the same bubble widget would need a toggle to suppress status — unneeded complexity.
+- Direct compose is a single text field + send. Group compose must adapt to `replyMode` (sender vs. group) with a secondary action in sender mode. The compose bar branch point is non-trivial.
+- Reuse would force both screens to carry the other's edge cases in its codepaths. Separate screens are cleaner and independently testable.
+
+### Data-model addition: `MessageEntry.fromCallsign`
+
+Group conversations are keyed by `#GROUP:<NAME>`, so the sender cannot be recovered from the parent `Conversation.peerCallsign`. We added `fromCallsign: String?` to `MessageEntry`, populated by both the direct and group incoming handlers. Null for outgoing entries and for v0.14-era legacy-deserialized entries — direct threads can still infer sender from the parent conversation key when `fromCallsign` is null.
+
+### `allConversations` scope change
+
+`MessageService.allConversations` now excludes group threads. Callers that need them use the new `groupConversations` accessor. The only existing caller of `allConversations` is `NotificationService`, which was designed for direct-message dispatch and should not accidentally fan out notifications to group threads (group notification dispatch lands in PR 5 via its own pipeline). The test suite was updated in lockstep.
+
+### Consequences
+
+- New screens: `lib/screens/group_channel_screen.dart`, `lib/screens/groups_tab.dart`, `lib/screens/bulletins_tab.dart`, `lib/screens/bulletin_detail_screen.dart`.
+- `lib/screens/messages_screen.dart` rewritten from `StatelessWidget` to `StatefulWidget` with a `_tab` field; the Direct body path is lifted out unchanged.
+- `MessageService` gains `groupConversations`, `groupNameOf`, `conversationForGroup`, `totalGroupUnread` and the `fromCallsign` field on `MessageEntry`.
+- Widget tests in `test/widget/messages/messages_screen_test.dart` cover segmented-control rendering, Bulletins-tab gating, location-banner visibility, and adaptive-compose states.
+- Bulletin distance-filter logic and notification dispatch for groups/bulletins still live in PR 5. The PR 3 location-unknown banner implements the user-visible behavior (hide general APRS-IS bulletins when no station location is set) directly in `BulletinsTab` so the banner copy is truthful from day one.

--- a/lib/screens/bulletin_detail_screen.dart
+++ b/lib/screens/bulletin_detail_screen.dart
@@ -1,0 +1,192 @@
+/// Read-only detail view for a single bulletin (spec §4.4).
+///
+/// No inline reply — bulletins are one-way. Offers a "Message sender"
+/// action that opens a direct conversation with the source callsign.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../models/bulletin.dart';
+import '../services/bulletin_service.dart';
+import '../ui/utils/platform_route.dart';
+import 'message_thread_screen.dart';
+
+class BulletinDetailScreen extends StatelessWidget {
+  const BulletinDetailScreen({super.key, required this.bulletinId});
+
+  final int bulletinId;
+
+  Bulletin? _lookup(BulletinService service) {
+    for (final b in service.bulletins) {
+      if (b.id == bulletinId) return b;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bulletins = context.watch<BulletinService>();
+    final bulletin = _lookup(bulletins);
+    final theme = Theme.of(context);
+
+    if (bulletin == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Bulletin')),
+        body: const Center(
+          child: Text('This bulletin is no longer available.'),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(bulletin.addressee),
+        actions: [
+          IconButton(
+            icon: const Icon(Symbols.mail),
+            tooltip: 'Message sender',
+            onPressed: () {
+              Navigator.push(
+                context,
+                buildPlatformRoute(
+                  (_) => MessageThreadScreen(
+                    peerCallsign: bulletin.sourceCallsign,
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Row(
+            children: [
+              Icon(Symbols.campaign, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(bulletin.addressee, style: theme.textTheme.titleLarge),
+              const Spacer(),
+              for (final t in bulletin.transports)
+                Padding(
+                  padding: const EdgeInsets.only(left: 6),
+                  child: _TransportBadge(transport: t),
+                ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'From ${bulletin.sourceCallsign}',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 20),
+          SelectableText(bulletin.body, style: theme.textTheme.bodyLarge),
+          const SizedBox(height: 24),
+          const Divider(),
+          _InfoRow(
+            icon: Symbols.schedule,
+            label: 'First heard',
+            value: _formatAbsolute(bulletin.firstHeardAt),
+          ),
+          _InfoRow(
+            icon: Symbols.update,
+            label: 'Last heard',
+            value: _formatAbsolute(bulletin.lastHeardAt),
+          ),
+          _InfoRow(
+            icon: Symbols.numbers,
+            label: 'Total receipts',
+            value: bulletin.heardCount.toString(),
+          ),
+          _InfoRow(
+            icon: Symbols.category,
+            label: 'Category',
+            value: switch (bulletin.category) {
+              BulletinCategory.general => 'General (BLN0–BLN9)',
+              BulletinCategory.groupNamed =>
+                'Named group (${bulletin.groupName ?? '—'})',
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatAbsolute(DateTime dt) {
+    final y = dt.year.toString().padLeft(4, '0');
+    final m = dt.month.toString().padLeft(2, '0');
+    final d = dt.day.toString().padLeft(2, '0');
+    final hh = dt.hour.toString().padLeft(2, '0');
+    final mm = dt.minute.toString().padLeft(2, '0');
+    return '$y-$m-$d $hh:$mm';
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: 12),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          Text(value, style: theme.textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}
+
+class _TransportBadge extends StatelessWidget {
+  const _TransportBadge({required this.transport});
+  final BulletinTransport transport;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = transport == BulletinTransport.rf ? 'RF' : 'IS';
+    final color = transport == BulletinTransport.rf
+        ? theme.colorScheme.tertiaryContainer
+        : theme.colorScheme.secondaryContainer;
+    final onColor = transport == BulletinTransport.rf
+        ? theme.colorScheme.onTertiaryContainer
+        : theme.colorScheme.onSecondaryContainer;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: onColor,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/bulletins_tab.dart
+++ b/lib/screens/bulletins_tab.dart
@@ -1,0 +1,421 @@
+/// Bulletins tab body inside [MessagesScreen].
+///
+/// Shows the chronological bulletin feed with filter chips (All / General /
+/// Groups / My bulletins). Gates on `BulletinService.showBulletins` and
+/// displays the location-unknown banner when APRS-IS is connected but the
+/// operator hasn't set a station location (spec §4.4). "My bulletins" is
+/// empty in PR 3 — `OutgoingBulletin` CRUD lands in PR 4.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../core/connection/connection_registry.dart';
+import '../models/bulletin.dart';
+import '../services/bulletin_service.dart';
+import '../services/station_settings_service.dart';
+import '../ui/utils/platform_route.dart';
+import 'bulletin_detail_screen.dart';
+
+enum _BulletinFilter { all, general, groups, mine }
+
+class BulletinsTab extends StatefulWidget {
+  const BulletinsTab({super.key});
+
+  @override
+  State<BulletinsTab> createState() => _BulletinsTabState();
+}
+
+class _BulletinsTabState extends State<BulletinsTab> {
+  _BulletinFilter _filter = _BulletinFilter.all;
+
+  @override
+  Widget build(BuildContext context) {
+    final bulletins = context.watch<BulletinService>();
+    final station = context.watch<StationSettingsService>();
+    final registry = context.watch<ConnectionRegistry>();
+
+    if (!bulletins.showBulletins) {
+      return const _BulletinsDisabledState();
+    }
+
+    final aprsIsConn = registry.byId('aprs_is');
+    final aprsIsConnected = aprsIsConn?.isConnected ?? false;
+    final hasLocation = station.hasManualPosition;
+    final showLocationBanner = aprsIsConnected && !hasLocation;
+
+    final visible = _applyFilter(
+      bulletins.bulletins,
+      _filter,
+      showLocationBanner,
+    );
+
+    return Column(
+      children: [
+        if (showLocationBanner)
+          _LocationUnknownBanner(
+            onSetLocation: () {
+              // v0.12 onboarding handles initial location entry. Keep this
+              // hook here; the routing target is introduced in PR 5 when the
+              // Settings → My Station "Set location" action is added.
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    'Open Settings → My Station to set your location. '
+                    'Direct hook lands in PR 5.',
+                  ),
+                ),
+              );
+            },
+          ),
+        _FilterChipRow(
+          current: _filter,
+          onChanged: (f) => setState(() => _filter = f),
+        ),
+        Expanded(
+          child: visible.isEmpty
+              ? _EmptyForFilter(filter: _filter)
+              : ListView.separated(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  itemCount: visible.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 2),
+                  itemBuilder: (ctx, i) {
+                    final b = visible[i];
+                    return _BulletinRow(
+                      bulletin: b,
+                      onTap: () {
+                        if (!b.isRead) bulletins.markRead(b.id);
+                        Navigator.push(
+                          ctx,
+                          buildPlatformRoute(
+                            (_) => BulletinDetailScreen(bulletinId: b.id),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+
+  /// Apply both the filter-chip choice and the location-aware scope gate.
+  /// When [hideApisGeneralWithoutLocation] is true, general bulletins that
+  /// were heard only over APRS-IS are dropped — matching the banner copy.
+  List<Bulletin> _applyFilter(
+    List<Bulletin> all,
+    _BulletinFilter filter,
+    bool hideApisGeneralWithoutLocation,
+  ) {
+    Iterable<Bulletin> base = all;
+    if (hideApisGeneralWithoutLocation) {
+      base = base.where((b) {
+        if (b.category != BulletinCategory.general) return true;
+        final onlyIs =
+            b.transports.length == 1 &&
+            b.transports.contains(BulletinTransport.aprsIs);
+        return !onlyIs;
+      });
+    }
+    final filtered = switch (filter) {
+      _BulletinFilter.all => base,
+      _BulletinFilter.general => base.where(
+        (b) => b.category == BulletinCategory.general,
+      ),
+      _BulletinFilter.groups => base.where(
+        (b) => b.category == BulletinCategory.groupNamed,
+      ),
+      // "My bulletins" is empty in PR 3 — OutgoingBulletin arrives in PR 4.
+      _BulletinFilter.mine => const Iterable<Bulletin>.empty(),
+    };
+    return filtered.toList();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filter chip row
+// ---------------------------------------------------------------------------
+
+class _FilterChipRow extends StatelessWidget {
+  const _FilterChipRow({required this.current, required this.onChanged});
+  final _BulletinFilter current;
+  final ValueChanged<_BulletinFilter> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Wrap(
+        spacing: 8,
+        children: [
+          for (final f in _BulletinFilter.values)
+            ChoiceChip(
+              label: Text(_labelFor(f)),
+              selected: current == f,
+              onSelected: (_) => onChanged(f),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _labelFor(_BulletinFilter f) => switch (f) {
+    _BulletinFilter.all => 'All',
+    _BulletinFilter.general => 'General',
+    _BulletinFilter.groups => 'Groups',
+    _BulletinFilter.mine => 'My bulletins',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
+class _BulletinRow extends StatelessWidget {
+  const _BulletinRow({required this.bulletin, required this.onTap});
+
+  final Bulletin bulletin;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isUnread = !bulletin.isRead;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Symbols.campaign,
+                    size: 18,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    bulletin.addressee,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: isUnread ? FontWeight.bold : FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '· ${bulletin.sourceCallsign}',
+                    style: theme.textTheme.labelSmall,
+                  ),
+                  const Spacer(),
+                  for (final t in bulletin.transports)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: _TransportChip(transport: t),
+                    ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _formatTime(bulletin.lastHeardAt),
+                    style: theme.textTheme.labelSmall,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                bulletin.body,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontWeight: isUnread ? FontWeight.w500 : FontWeight.normal,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m';
+    if (diff.inHours < 24) return '${diff.inHours}h';
+    return '${diff.inDays}d';
+  }
+}
+
+class _TransportChip extends StatelessWidget {
+  const _TransportChip({required this.transport});
+  final BulletinTransport transport;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = transport == BulletinTransport.rf ? 'RF' : 'IS';
+    final color = transport == BulletinTransport.rf
+        ? theme.colorScheme.tertiaryContainer
+        : theme.colorScheme.secondaryContainer;
+    final onColor = transport == BulletinTransport.rf
+        ? theme.colorScheme.onTertiaryContainer
+        : theme.colorScheme.onSecondaryContainer;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: onColor,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Location unknown banner
+// ---------------------------------------------------------------------------
+
+class _LocationUnknownBanner extends StatelessWidget {
+  const _LocationUnknownBanner({required this.onSetLocation});
+  final VoidCallback onSetLocation;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.tertiaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Icon(
+              Symbols.location_off,
+              color: theme.colorScheme.onTertiaryContainer,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'General APRS-IS bulletins are hidden because your station '
+                'location is not set. RF bulletins and subscribed named '
+                'groups are unaffected.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onTertiaryContainer,
+                ),
+              ),
+            ),
+            TextButton(
+              onPressed: onSetLocation,
+              child: const Text('Set location'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty states
+// ---------------------------------------------------------------------------
+
+class _BulletinsDisabledState extends StatelessWidget {
+  const _BulletinsDisabledState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.notifications_off,
+              size: 64,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 16),
+            Text('Bulletins are hidden', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Turn on "Show bulletins" in Settings → Messaging → Bulletins '
+              'to see the feed.',
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyForFilter extends StatelessWidget {
+  const _EmptyForFilter({required this.filter});
+  final _BulletinFilter filter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final String title;
+    final String body;
+    switch (filter) {
+      case _BulletinFilter.all:
+        title = 'No bulletins yet';
+        body =
+            'Bulletins broadcast on APRS (BLN0–BLN9 and named groups) will '
+            'appear here when they arrive.';
+      case _BulletinFilter.general:
+        title = 'No general bulletins';
+        body = 'No BLN0–BLN9 bulletins are in scope right now.';
+      case _BulletinFilter.groups:
+        title = 'No group bulletins';
+        body =
+            'Subscribe to named bulletin groups like WX or SRARC in '
+            'Settings → Messaging → Bulletins.';
+      case _BulletinFilter.mine:
+        title = 'No bulletins from you';
+        body =
+            'Bulletins you transmit will appear here. Bulletin composition '
+            'ships in the next release.';
+    }
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.campaign,
+              size: 56,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              body,
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/group_channel_screen.dart
+++ b/lib/screens/group_channel_screen.dart
@@ -1,0 +1,440 @@
+/// Group channel screen — chronological feed for a single [GroupSubscription].
+///
+/// Each bubble shows the sender callsign prominently (per spec §4.3). The
+/// compose bar adapts to the group's `replyMode`:
+///
+///   - `group`  → "Message to GROUPNAME"  [Send]
+///   - `sender` → "Reply to sender callsign"  [Send]  + secondary "Send to group"
+///
+/// PR 3 stubs the send actions behind a SnackBar. PR 4 wires TX through
+/// `TxService` with `AprsEncoder.encodeGroupMessage` + the Advanced-mode
+/// Group message path.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../models/group_subscription.dart';
+import '../services/group_subscription_service.dart';
+import '../services/message_service.dart';
+import '../services/station_settings_service.dart';
+import '../ui/utils/platform_route.dart';
+import 'message_thread_screen.dart';
+
+class GroupChannelScreen extends StatefulWidget {
+  const GroupChannelScreen({super.key, required this.groupName});
+
+  final String groupName;
+
+  @override
+  State<GroupChannelScreen> createState() => _GroupChannelScreenState();
+}
+
+class _GroupChannelScreenState extends State<GroupChannelScreen> {
+  final _scrollCtrl = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollCtrl.dispose();
+    super.dispose();
+  }
+
+  GroupSubscription? _resolveSubscription(GroupSubscriptionService groups) {
+    final name = widget.groupName.toUpperCase();
+    for (final s in groups.subscriptions) {
+      if (s.name == name) return s;
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = context.watch<GroupSubscriptionService>();
+    final messages = context.watch<MessageService>();
+    final isLicensed = context.select<StationSettingsService, bool>(
+      (s) => s.isLicensed,
+    );
+
+    final sub = _resolveSubscription(groups);
+    final conversation = messages.conversationForGroup(widget.groupName);
+    final entries = conversation?.messages ?? const <MessageEntry>[];
+    final lastIncoming = entries
+        .where((e) => !e.isOutgoing)
+        .cast<MessageEntry?>()
+        .fold<MessageEntry?>(
+          null,
+          (prev, m) => m, // last element wins
+        );
+
+    return Scaffold(
+      appBar: AppBar(
+        titleSpacing: 0,
+        title: Row(
+          children: [
+            Icon(
+              sub?.replyMode == ReplyMode.sender
+                  ? Symbols.campaign
+                  : Symbols.forum,
+            ),
+            const SizedBox(width: 12),
+            Expanded(child: Text(widget.groupName)),
+          ],
+        ),
+        bottom: sub == null
+            ? null
+            : PreferredSize(
+                preferredSize: const Size.fromHeight(22),
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Text(
+                    sub.replyMode == ReplyMode.sender
+                        ? 'Replies route to the individual sender'
+                        : 'Replies broadcast to the group',
+                    style: Theme.of(context).textTheme.labelSmall,
+                  ),
+                ),
+              ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: entries.isEmpty
+                ? const _GroupChannelEmptyState()
+                : ListView.builder(
+                    controller: _scrollCtrl,
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 12,
+                      horizontal: 8,
+                    ),
+                    itemCount: entries.length,
+                    itemBuilder: (_, i) => _GroupBubble(entry: entries[i]),
+                  ),
+          ),
+          if (!isLicensed)
+            const _GroupUnlicensedBar()
+          else if (sub == null)
+            const _GroupMissingSubscriptionBar()
+          else
+            _GroupComposeBar(
+              subscription: sub,
+              lastSenderCallsign: lastIncoming?.fromCallsign,
+              onSendToGroup: _sendToGroupStub,
+              onSendToSender: _sendToSenderStub,
+            ),
+        ],
+      ),
+    );
+  }
+
+  // --- Send stubs (PR 4 wires actual TX) ------------------------------------
+
+  void _sendToGroupStub(String text) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Group send wired in PR 4 — would send "$text" to '
+          '${widget.groupName}.',
+        ),
+      ),
+    );
+  }
+
+  void _sendToSenderStub(String text, String toCallsign) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Reply-to-sender wired in PR 4 — would send "$text" to '
+          '$toCallsign.',
+        ),
+      ),
+      // ignore: no_logic_in_create_state
+    );
+    // Provide a useful fallback even in PR 3: open the direct thread so
+    // the user can type a reply there immediately.
+    Navigator.push(
+      context,
+      buildPlatformRoute((_) => MessageThreadScreen(peerCallsign: toCallsign)),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bubble
+// ---------------------------------------------------------------------------
+
+class _GroupBubble extends StatelessWidget {
+  const _GroupBubble({required this.entry});
+  final MessageEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isOutgoing = entry.isOutgoing;
+    final alignment = isOutgoing ? Alignment.centerRight : Alignment.centerLeft;
+    final bubbleColor = isOutgoing
+        ? theme.colorScheme.primaryContainer
+        : theme.colorScheme.surfaceContainerHighest;
+    final senderLabel = isOutgoing ? 'You' : (entry.fromCallsign ?? 'Unknown');
+
+    return Align(
+      alignment: alignment,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.78,
+        ),
+        child: Container(
+          margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+          padding: const EdgeInsets.fromLTRB(14, 8, 14, 10),
+          decoration: BoxDecoration(
+            color: bubbleColor,
+            borderRadius: BorderRadius.circular(18),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                senderLabel,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(entry.text),
+              const SizedBox(height: 4),
+              Text(
+                _formatTime(entry.timestamp),
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(DateTime dt) {
+    final h = dt.hour.toString().padLeft(2, '0');
+    final m = dt.minute.toString().padLeft(2, '0');
+    return '$h:$m';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compose bar (adaptive per reply_mode)
+// ---------------------------------------------------------------------------
+
+class _GroupComposeBar extends StatefulWidget {
+  const _GroupComposeBar({
+    required this.subscription,
+    required this.lastSenderCallsign,
+    required this.onSendToGroup,
+    required this.onSendToSender,
+  });
+
+  final GroupSubscription subscription;
+  final String? lastSenderCallsign;
+  final void Function(String text) onSendToGroup;
+  final void Function(String text, String toCallsign) onSendToSender;
+
+  @override
+  State<_GroupComposeBar> createState() => _GroupComposeBarState();
+}
+
+class _GroupComposeBarState extends State<_GroupComposeBar> {
+  final _controller = TextEditingController();
+  bool _canSend = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      final can = _controller.text.trim().isNotEmpty;
+      if (can != _canSend) setState(() => _canSend = can);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isSenderMode = widget.subscription.replyMode == ReplyMode.sender;
+    final hasLastSender = widget.lastSenderCallsign != null;
+    final primaryHint = isSenderMode && hasLastSender
+        ? 'Reply to ${widget.lastSenderCallsign}'
+        : 'Message to ${widget.subscription.name}';
+
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          border: Border(
+            top: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+        ),
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+        child: Column(
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    maxLength: 67,
+                    maxLines: 3,
+                    minLines: 1,
+                    textInputAction: TextInputAction.send,
+                    decoration: InputDecoration(
+                      isDense: true,
+                      hintText: primaryHint,
+                      border: const OutlineInputBorder(),
+                      counterText: '',
+                    ),
+                    onSubmitted: _canSend ? (_) => _primarySend() : null,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton.filled(
+                  onPressed: _canSend ? _primarySend : null,
+                  icon: Icon(
+                    isSenderMode && hasLastSender
+                        ? Symbols.reply
+                        : Symbols.send,
+                  ),
+                  tooltip: primaryHint,
+                ),
+              ],
+            ),
+            if (isSenderMode && hasLastSender)
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  onPressed: _canSend
+                      ? () {
+                          widget.onSendToGroup(_controller.text.trim());
+                          _controller.clear();
+                        }
+                      : null,
+                  icon: const Icon(Symbols.forum, size: 18),
+                  label: Text('Send to ${widget.subscription.name} instead'),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _primarySend() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    final isSenderMode = widget.subscription.replyMode == ReplyMode.sender;
+    if (isSenderMode && widget.lastSenderCallsign != null) {
+      widget.onSendToSender(text, widget.lastSenderCallsign!);
+    } else {
+      widget.onSendToGroup(text);
+    }
+    _controller.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fallback states
+// ---------------------------------------------------------------------------
+
+class _GroupUnlicensedBar extends StatelessWidget {
+  const _GroupUnlicensedBar();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      top: false,
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHigh,
+          border: Border(
+            top: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+        ),
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          'An amateur radio license is required to send group messages.',
+          style: theme.textTheme.bodySmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupMissingSubscriptionBar extends StatelessWidget {
+  const _GroupMissingSubscriptionBar();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SafeArea(
+      top: false,
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHigh,
+          border: Border(
+            top: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+        ),
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          'This group is no longer in your subscriptions — re-add it from '
+          'Settings → Messaging → Groups to send messages.',
+          style: theme.textTheme.bodySmall,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupChannelEmptyState extends StatelessWidget {
+  const _GroupChannelEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.forum,
+              size: 64,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 16),
+            Text('No messages yet', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Messages addressed to this group will appear here.',
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/groups_tab.dart
+++ b/lib/screens/groups_tab.dart
@@ -1,0 +1,213 @@
+/// Groups tab body inside [MessagesScreen].
+///
+/// Lists the user's enabled [GroupSubscription]s with reply-mode icon,
+/// per-group unread badge (from `MessageService.conversationForGroup`), and
+/// last-message preview. Empty / disabled-state copy routes the user to
+/// Settings → Messaging → Groups to manage their subscriptions.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../models/group_subscription.dart';
+import '../services/group_subscription_service.dart';
+import '../services/message_service.dart';
+
+class GroupsTab extends StatelessWidget {
+  const GroupsTab({super.key, required this.onOpenGroup});
+
+  /// Called when the user taps a group tile. Receives the bare group name
+  /// (not the `#GROUP:` key).
+  final ValueChanged<String> onOpenGroup;
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = context.watch<GroupSubscriptionService>();
+    final messages = context.watch<MessageService>();
+
+    // Respect user order (matcher-semantics) so the tab reads the same as
+    // Settings. Show all — enabled + disabled — with the disabled ones dimmed,
+    // because a disabled group still holds historical messages the user may
+    // want to see.
+    final subs = groups.subscriptions;
+    if (subs.isEmpty) {
+      return const _GroupsEmptyState();
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      itemCount: subs.length,
+      separatorBuilder: (_, _) => const SizedBox(height: 2),
+      itemBuilder: (ctx, i) {
+        final sub = subs[i];
+        final conv = messages.conversationForGroup(sub.name);
+        return _GroupTile(
+          sub: sub,
+          conversation: conv,
+          onTap: () => onOpenGroup(sub.name),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group tile
+// ---------------------------------------------------------------------------
+
+class _GroupTile extends StatelessWidget {
+  const _GroupTile({
+    required this.sub,
+    required this.conversation,
+    required this.onTap,
+  });
+
+  final GroupSubscription sub;
+  final Conversation? conversation;
+  final VoidCallback onTap;
+
+  String _formatTime(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasUnread = (conversation?.unreadCount ?? 0) > 0;
+    final last = conversation?.lastMessage;
+    final icon = sub.replyMode == ReplyMode.sender
+        ? Symbols.campaign
+        : Symbols.forum;
+
+    // Build the preview: "<sender>: <text>". For group messages the
+    // originator matters as much as the body.
+    String? preview;
+    String? previewSender;
+    if (last != null) {
+      previewSender = last.isOutgoing ? 'You' : last.fromCallsign;
+      preview = last.text;
+    }
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+      clipBehavior: Clip.antiAlias,
+      child: ListTile(
+        leading: Icon(
+          icon,
+          color: sub.enabled
+              ? theme.colorScheme.primary
+              : theme.colorScheme.outline,
+        ),
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(
+                sub.name,
+                style: TextStyle(
+                  fontWeight: hasUnread ? FontWeight.bold : FontWeight.w600,
+                  color: sub.enabled
+                      ? null
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            if (!sub.enabled)
+              Text(
+                'disabled',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+          ],
+        ),
+        subtitle: preview == null
+            ? Text(
+                sub.replyMode == ReplyMode.sender
+                    ? 'No messages — replies route to sender'
+                    : 'No messages — replies route to group',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            : Text.rich(
+                TextSpan(
+                  children: [
+                    if (previewSender != null)
+                      TextSpan(
+                        text: '$previewSender: ',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: theme.colorScheme.primary,
+                        ),
+                      ),
+                    TextSpan(text: preview),
+                  ],
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            if (conversation != null)
+              Text(
+                _formatTime(conversation!.lastActivity),
+                style: theme.textTheme.labelSmall,
+              ),
+            if (hasUnread) ...[
+              const SizedBox(height: 4),
+              Badge(label: Text('${conversation!.unreadCount}')),
+            ],
+          ],
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+class _GroupsEmptyState extends StatelessWidget {
+  const _GroupsEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.forum,
+              size: 64,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No group subscriptions yet',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Add groups like CQ, QST, or a club name in '
+              'Settings → Messaging → Groups.',
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/messages_screen.dart
+++ b/lib/screens/messages_screen.dart
@@ -1,13 +1,14 @@
-/// APRS messages thread list screen.
+/// APRS messages screen with three segmented tabs (Direct / Groups / Bulletins).
 ///
-/// Shows all conversations sorted by most recent activity. Each base callsign
-/// gets its own Card — single-SSID threads are a one-tile card; multi-SSID
-/// threads show a base callsign header row followed by indented sub-rows,
-/// all within the same card.
+/// Direct tab preserves v0.14 behavior byte-for-byte. Groups tab lists the
+/// user's enabled subscriptions; tap opens the group channel. Bulletins tab
+/// shows the chronological feed gated by `BulletinService.showBulletins` and
+/// the location-unknown banner. See ADR-059.
 library;
 
 import 'dart:io' show Platform;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -18,10 +19,221 @@ import '../services/message_service.dart';
 import '../services/station_settings_service.dart';
 import '../ui/utils/platform_route.dart';
 import '../ui/widgets/compose_message_sheet.dart';
+import 'bulletins_tab.dart';
+import 'group_channel_screen.dart';
+import 'groups_tab.dart';
 import 'message_thread_screen.dart';
 
+/// Tabs in the Messages screen's segmented control.
+enum MessagesTab { direct, groups, bulletins }
+
 // ---------------------------------------------------------------------------
-// Group model
+// Screen
+// ---------------------------------------------------------------------------
+
+class MessagesScreen extends StatefulWidget {
+  const MessagesScreen({super.key});
+
+  @override
+  State<MessagesScreen> createState() => _MessagesScreenState();
+}
+
+class _MessagesScreenState extends State<MessagesScreen> {
+  MessagesTab _tab = MessagesTab.direct;
+
+  static bool get _isDesktop =>
+      !kIsWeb && (Platform.isLinux || Platform.isMacOS || Platform.isWindows);
+
+  void _openCompose(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const ComposeMessageSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<MessageService>();
+    final isLicensed = context.select<StationSettingsService, bool>(
+      (s) => s.isLicensed,
+    );
+
+    final directUnread = service.totalUnread;
+    final groupUnread = service.totalGroupUnread;
+
+    final Widget body = switch (_tab) {
+      MessagesTab.direct => _DirectTab(
+        service: service,
+        isLicensed: isLicensed,
+      ),
+      MessagesTab.groups => GroupsTab(
+        onOpenGroup: (groupName) {
+          service.markRead('#GROUP:$groupName');
+          Navigator.push(
+            context,
+            buildPlatformRoute((_) => GroupChannelScreen(groupName: groupName)),
+          );
+        },
+      ),
+      MessagesTab.bulletins => const BulletinsTab(),
+    };
+
+    // Only show the FAB on the Direct tab — group send UI + bulletin compose
+    // live on their own surfaces (PR 4 wires both).
+    final showFab = _tab == MessagesTab.direct && isLicensed && !_isDesktop;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Messages'),
+        actions: [
+          if (_tab == MessagesTab.direct && _isDesktop && isLicensed)
+            IconButton(
+              icon: const Icon(Symbols.edit_square),
+              tooltip: 'New message',
+              onPressed: () => _openCompose(context),
+            ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(56),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: _MessagesTabSwitcher(
+              current: _tab,
+              directUnread: directUnread,
+              groupUnread: groupUnread,
+              onChanged: (t) => setState(() => _tab = t),
+            ),
+          ),
+        ),
+      ),
+      body: body,
+      floatingActionButton: showFab
+          ? FloatingActionButton(
+              heroTag: 'compose_fab',
+              tooltip: 'New message',
+              onPressed: () => _openCompose(context),
+              child: const Icon(Symbols.edit_square),
+            )
+          : null,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Segmented control — adaptive per platform
+// ---------------------------------------------------------------------------
+
+class _MessagesTabSwitcher extends StatelessWidget {
+  const _MessagesTabSwitcher({
+    required this.current,
+    required this.directUnread,
+    required this.groupUnread,
+    required this.onChanged,
+  });
+
+  final MessagesTab current;
+  final int directUnread;
+  final int groupUnread;
+  final ValueChanged<MessagesTab> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    // iOS → Cupertino sliding segmented control (no badges — Cupertino doesn't
+    // support per-segment trailing content. Unread counts surface via the tab
+    // content itself in the iOS flow.)
+    if (!kIsWeb && Platform.isIOS) {
+      return CupertinoSlidingSegmentedControl<MessagesTab>(
+        groupValue: current,
+        onValueChanged: (v) {
+          if (v != null) onChanged(v);
+        },
+        children: const {
+          MessagesTab.direct: Padding(
+            padding: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+            child: Text('Direct'),
+          ),
+          MessagesTab.groups: Padding(
+            padding: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+            child: Text('Groups'),
+          ),
+          MessagesTab.bulletins: Padding(
+            padding: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
+            child: Text('Bulletins'),
+          ),
+        },
+      );
+    }
+
+    // Material M3 SegmentedButton with unread badges as icons.
+    return SegmentedButton<MessagesTab>(
+      segments: [
+        ButtonSegment(
+          value: MessagesTab.direct,
+          icon: _UnreadBadge(count: directUnread),
+          label: const Text('Direct'),
+        ),
+        ButtonSegment(
+          value: MessagesTab.groups,
+          icon: _UnreadBadge(count: groupUnread),
+          label: const Text('Groups'),
+        ),
+        const ButtonSegment(
+          value: MessagesTab.bulletins,
+          label: Text('Bulletins'),
+        ),
+      ],
+      selected: {current},
+      onSelectionChanged: (s) => onChanged(s.first),
+      showSelectedIcon: false,
+    );
+  }
+}
+
+/// Small wrapper so SegmentedButton's icon slot gracefully hides when the
+/// count is zero (otherwise the layout jitters between segments).
+class _UnreadBadge extends StatelessWidget {
+  const _UnreadBadge({required this.count});
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    if (count <= 0) return const SizedBox.shrink();
+    return Badge(label: Text(count > 99 ? '99+' : '$count'));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct tab (existing v0.14 list, unchanged behavior)
+// ---------------------------------------------------------------------------
+
+class _DirectTab extends StatelessWidget {
+  const _DirectTab({required this.service, required this.isLicensed});
+  final MessageService service;
+  final bool isLicensed;
+
+  @override
+  Widget build(BuildContext context) {
+    final conversations = service.conversations;
+    if (conversations.isEmpty) {
+      return _DirectEmptyState(
+        onCompose: isLicensed ? () => _openCompose(context) : null,
+      );
+    }
+    return _DirectList(conversations: conversations, service: service);
+  }
+
+  void _openCompose(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const ComposeMessageSheet(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct list grouping helpers (unchanged from v0.14 implementation)
 // ---------------------------------------------------------------------------
 
 final class _ConvGroup {
@@ -38,10 +250,8 @@ List<_ConvGroup> _buildGroups(List<Conversation> conversations) {
     final base = stripSsid(conv.peerCallsign);
     byBase.putIfAbsent(base, () => []).add(conv);
   }
-
   final groups = <_ConvGroup>[];
   final emitted = <String>{};
-
   for (final conv in conversations) {
     final base = stripSsid(conv.peerCallsign);
     if (emitted.contains(base)) continue;
@@ -51,21 +261,42 @@ List<_ConvGroup> _buildGroups(List<Conversation> conversations) {
   return groups;
 }
 
-// ---------------------------------------------------------------------------
-// Screen
-// ---------------------------------------------------------------------------
+class _DirectList extends StatelessWidget {
+  const _DirectList({required this.conversations, required this.service});
+  final List<Conversation> conversations;
+  final MessageService service;
 
-class MessagesScreen extends StatelessWidget {
-  const MessagesScreen({super.key});
-
-  static bool get _isDesktop =>
-      !kIsWeb && (Platform.isLinux || Platform.isMacOS || Platform.isWindows);
-
-  void _openCompose(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (_) => const ComposeMessageSheet(),
+  @override
+  Widget build(BuildContext context) {
+    final groups = _buildGroups(conversations);
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      itemCount: groups.length,
+      itemBuilder: (ctx, i) {
+        final group = groups[i];
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 6),
+          clipBehavior: Clip.antiAlias,
+          child: group.isMulti
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: _buildMultiCardChildren(context, group, service),
+                )
+              : _ConversationTile(
+                  conversation: group.conversations.first,
+                  onTap: () {
+                    final peer = group.conversations.first.peerCallsign;
+                    service.markRead(peer);
+                    Navigator.push(
+                      context,
+                      buildPlatformRoute(
+                        (_) => MessageThreadScreen(peerCallsign: peer),
+                      ),
+                    );
+                  },
+                ),
+        );
+      },
     );
   }
 
@@ -103,79 +334,6 @@ class MessagesScreen extends StatelessWidget {
       );
     }
     return children;
-  }
-
-  Widget _buildList(
-    BuildContext context,
-    List<Conversation> conversations,
-    MessageService service,
-  ) {
-    final groups = _buildGroups(conversations);
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      itemCount: groups.length,
-      itemBuilder: (ctx, i) {
-        final group = groups[i];
-        return Card(
-          margin: const EdgeInsets.symmetric(vertical: 6),
-          clipBehavior: Clip.antiAlias,
-          child: group.isMulti
-              ? Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: _buildMultiCardChildren(context, group, service),
-                )
-              : _ConversationTile(
-                  conversation: group.conversations.first,
-                  onTap: () {
-                    final peer = group.conversations.first.peerCallsign;
-                    service.markRead(peer);
-                    Navigator.push(
-                      context,
-                      buildPlatformRoute(
-                        (_) => MessageThreadScreen(peerCallsign: peer),
-                      ),
-                    );
-                  },
-                ),
-        );
-      },
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final service = context.watch<MessageService>();
-    final isLicensed = context.select<StationSettingsService, bool>(
-      (s) => s.isLicensed,
-    );
-    final conversations = service.conversations;
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Messages'),
-        actions: [
-          if (_isDesktop && isLicensed)
-            IconButton(
-              icon: const Icon(Symbols.edit_square),
-              tooltip: 'New message',
-              onPressed: () => _openCompose(context),
-            ),
-        ],
-      ),
-      body: conversations.isEmpty
-          ? _EmptyState(
-              onCompose: isLicensed ? () => _openCompose(context) : null,
-            )
-          : _buildList(context, conversations, service),
-      floatingActionButton: (_isDesktop || !isLicensed)
-          ? null
-          : FloatingActionButton(
-              heroTag: 'compose_fab',
-              tooltip: 'New message',
-              onPressed: () => _openCompose(context),
-              child: const Icon(Symbols.edit_square),
-            ),
-    );
   }
 }
 
@@ -248,7 +406,7 @@ class _ConversationTile extends StatelessWidget {
     final hasUnread = conversation.unreadCount > 0;
     final lastMsg = conversation.lastMessage;
 
-    final tile = ListTile(
+    return ListTile(
       tileColor: hasUnread
           ? theme.colorScheme.primaryContainer.withAlpha(60)
           : null,
@@ -298,17 +456,15 @@ class _ConversationTile extends StatelessWidget {
       ),
       onTap: onTap,
     );
-
-    return tile;
   }
 }
 
 // ---------------------------------------------------------------------------
-// Empty state
+// Direct tab empty state
 // ---------------------------------------------------------------------------
 
-class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.onCompose});
+class _DirectEmptyState extends StatelessWidget {
+  const _DirectEmptyState({required this.onCompose});
 
   /// Null when the user is unlicensed — hides the compose button.
   final VoidCallback? onCompose;

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -40,6 +40,7 @@ class MessageEntry {
     required this.timestamp,
     required this.isOutgoing,
     this.addressee,
+    this.fromCallsign,
     this.category = MessageCategory.direct,
     this.groupName,
     this.status = MessageStatus.pending,
@@ -58,6 +59,13 @@ class MessageEntry {
 
   /// Full callsign the message was addressed to (incoming only).
   final String? addressee;
+
+  /// Full callsign of the packet source (incoming only). For direct
+  /// conversations this equals the parent `Conversation.peerCallsign`; for
+  /// group conversations (where the parent key is `#GROUP:<NAME>`) it is
+  /// the only place the actual sender is preserved. Null for outgoing or
+  /// for legacy-deserialized entries that predate this field (v0.14).
+  final String? fromCallsign;
 
   /// Classification category from [AddresseeMatcher.classifyWithPrecedence].
   /// Defaults to [MessageCategory.direct] for legacy-safe deserialization —
@@ -150,35 +158,77 @@ class MessageService extends ChangeNotifier {
 
   bool get showOtherSsids => _showOtherSsids;
 
-  /// All conversations sorted by most recent activity (newest first).
-  /// When [showOtherSsids] is false, hides threads that contain only cross-SSID
-  /// messages (no outgoing messages and no exact-match incoming messages).
+  /// True if [peerCallsign] is a group-conversation key (`#GROUP:<NAME>`).
+  /// Group threads are stored in the same `_conversations` map as direct
+  /// threads but are filtered out of the direct accessors below.
+  static bool _isGroupKey(String peerCallsign) =>
+      peerCallsign.startsWith('#GROUP:');
+
+  /// Direct conversations, sorted by most recent activity (newest first).
+  ///
+  /// Excludes group threads. When [showOtherSsids] is false, also hides
+  /// threads that contain only cross-SSID messages.
   List<Conversation> get conversations {
     final myAddr = myFullAddress;
     final list = _conversations.values.where((conv) {
+      if (_isGroupKey(conv.peerCallsign)) return false;
       if (_showOtherSsids) return true;
       return conv.messages.any((m) => m.isOutgoing || !m.isCrossSsid(myAddr));
     }).toList()..sort((a, b) => b.lastActivity.compareTo(a.lastActivity));
     return list;
   }
 
-  /// All conversations sorted by most recent activity — unfiltered.
-  /// Used by NotificationService to dispatch notifications for cross-SSID messages
-  /// regardless of the display preference.
+  /// All *direct* conversations sorted by most recent activity — unfiltered
+  /// by cross-SSID preference. Used by NotificationService to dispatch
+  /// notifications regardless of the display preference. Group threads are
+  /// excluded (group-message notifications route via a separate channel
+  /// added in PR 5).
   List<Conversation> get allConversations {
-    final list = _conversations.values.toList()
-      ..sort((a, b) => b.lastActivity.compareTo(a.lastActivity));
+    final list =
+        _conversations.values
+            .where((c) => !_isGroupKey(c.peerCallsign))
+            .toList()
+          ..sort((a, b) => b.lastActivity.compareTo(a.lastActivity));
     return list;
   }
+
+  /// Group conversations sorted by most recent activity. Each entry's
+  /// [Conversation.peerCallsign] starts with the `#GROUP:` prefix; use
+  /// [groupNameOf] to extract the bare group name.
+  List<Conversation> get groupConversations {
+    final list =
+        _conversations.values.where((c) => _isGroupKey(c.peerCallsign)).toList()
+          ..sort((a, b) => b.lastActivity.compareTo(a.lastActivity));
+    return list;
+  }
+
+  /// Extract the group name from a `#GROUP:<NAME>` conversation key.
+  /// Returns null if [peerCallsign] is not a group key.
+  static String? groupNameOf(String peerCallsign) {
+    if (!_isGroupKey(peerCallsign)) return null;
+    return peerCallsign.substring('#GROUP:'.length);
+  }
+
+  /// Returns the conversation for a given group [name], or null if empty.
+  Conversation? conversationForGroup(String name) =>
+      _conversations[_groupConvKey(name.toUpperCase())];
 
   /// Max age of persisted messages in days. [forever] (0) means no age limit.
   int get messageHistoryDays => _messageHistoryDays;
 
-  /// Total unread message count across all conversations.
-  int get totalUnread =>
-      _conversations.values.fold(0, (sum, c) => sum + c.unreadCount);
+  /// Total unread count across *direct* conversations only. Groups have
+  /// their own counter.
+  int get totalUnread => _conversations.values
+      .where((c) => !_isGroupKey(c.peerCallsign))
+      .fold(0, (sum, c) => sum + c.unreadCount);
+
+  /// Total unread count across group conversations.
+  int get totalGroupUnread => _conversations.values
+      .where((c) => _isGroupKey(c.peerCallsign))
+      .fold(0, (sum, c) => sum + c.unreadCount);
 
   /// Returns the conversation for [peerCallsign], or null if none exists.
+  /// Accepts either a direct callsign or a `#GROUP:<NAME>` key.
   Conversation? conversationWith(String peerCallsign) =>
       _conversations[peerCallsign.toUpperCase()];
 
@@ -422,6 +472,7 @@ class MessageService extends ChangeNotifier {
       timestamp: packet.receivedAt,
       isOutgoing: false,
       addressee: packet.addressee.trim(),
+      fromCallsign: source,
       category: MessageCategory.direct,
     );
 
@@ -467,6 +518,7 @@ class MessageService extends ChangeNotifier {
       timestamp: packet.receivedAt,
       isOutgoing: false,
       addressee: packet.addressee.trim(),
+      fromCallsign: source,
       category: MessageCategory.group,
       groupName: subscription.name,
     );
@@ -663,6 +715,7 @@ class MessageService extends ChangeNotifier {
     'timestamp': e.timestamp.millisecondsSinceEpoch,
     'isOutgoing': e.isOutgoing,
     'addressee': e.addressee,
+    'fromCallsign': e.fromCallsign,
     'category': e.category.name,
     'groupName': e.groupName,
     'status': e.status.name,
@@ -712,6 +765,7 @@ class MessageService extends ChangeNotifier {
       timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
       isOutgoing: (json['isOutgoing'] as bool?) ?? false,
       addressee: json['addressee'] as String?,
+      fromCallsign: json['fromCallsign'] as String?,
       category: category,
       groupName: json['groupName'] as String?,
       status: status,

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -194,14 +194,23 @@ void main() {
       _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::CQ       :CQ CQ CQ');
       await Future<void>.delayed(Duration.zero);
 
-      // Group thread keyed by `#GROUP:CQ`. Internal key is not public API
-      // but we can verify via allConversations that a thread was created.
-      final matched = f.service.allConversations
-          .where((c) => c.peerCallsign.contains('CQ'))
+      // Group thread keyed by `#GROUP:CQ`. PR 3 added `groupConversations`
+      // as the public accessor — `allConversations` now returns direct
+      // threads only.
+      final matched = f.service.groupConversations
+          .where((c) => c.peerCallsign == '#GROUP:CQ')
           .toList();
       expect(matched, isNotEmpty);
       expect(matched.first.messages.first.category, MessageCategory.group);
       expect(matched.first.messages.first.groupName, 'CQ');
+      // Sender was captured on the MessageEntry (PR 3 addition).
+      expect(matched.first.messages.first.fromCallsign, 'K2ABC');
+
+      // Groups never leak into the direct accessors.
+      expect(
+        f.service.allConversations.any((c) => c.peerCallsign.contains('CQ')),
+        isFalse,
+      );
 
       // No ACK even though the wire carries a messageId (groups never ACK).
       expect(f.sentLines, isEmpty);
@@ -218,11 +227,8 @@ void main() {
       _ingestLine(f, 'K2ABC>APMDN0,TCPIP*::CQ       :CQ CQ CQ');
       await Future<void>.delayed(Duration.zero);
 
-      // No conversation, no bulletin, no ACK.
-      expect(
-        f.service.allConversations.any((c) => c.peerCallsign.contains('CQ')),
-        isFalse,
-      );
+      // No group thread, no bulletin, no ACK.
+      expect(f.service.groupConversations, isEmpty);
       expect(f.bulletins.bulletins, isEmpty);
       expect(f.sentLines, isEmpty);
     });

--- a/test/widget/messages/messages_screen_test.dart
+++ b/test/widget/messages/messages_screen_test.dart
@@ -1,0 +1,349 @@
+/// Widget tests for the v0.17 Messages screen rework (PR 3).
+///
+/// Covers:
+///   - Segmented control renders three tabs and the Direct body is visible
+///     by default (the v0.14 compose FAB is unchanged when Direct is active).
+///   - Tapping the Groups / Bulletins segments swaps the body.
+///   - Bulletins tab respects the `showBulletins` master toggle.
+///   - Location-unknown banner shows only when APRS-IS is connected AND no
+///     station location has been set.
+///   - Bulletin detail has no inline reply affordance.
+///   - Group channel shows adaptive compose based on `replyMode`.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/models/bulletin.dart';
+import 'package:meridian_aprs/models/notification_preferences.dart';
+import 'package:meridian_aprs/screens/bulletin_detail_screen.dart';
+import 'package:meridian_aprs/screens/group_channel_screen.dart';
+import 'package:meridian_aprs/screens/messages_screen.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
+import 'package:meridian_aprs/services/message_service.dart';
+import 'package:meridian_aprs/services/messaging_settings_service.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../../helpers/fake_meridian_connection.dart';
+import '../../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+class _Harness {
+  _Harness._({
+    required this.messages,
+    required this.bulletins,
+    required this.bulletinSubs,
+    required this.groupSubs,
+    required this.settings,
+    required this.registry,
+    required this.aprsIsConn,
+  });
+
+  final MessageService messages;
+  final BulletinService bulletins;
+  final BulletinSubscriptionService bulletinSubs;
+  final GroupSubscriptionService groupSubs;
+  final StationSettingsService settings;
+  final ConnectionRegistry registry;
+  final FakeMeridianConnection aprsIsConn;
+
+  static Future<_Harness> create({
+    bool licensed = true,
+    bool manualLocation = false,
+    bool aprsIsConnected = false,
+    bool showBulletinsEnabled = true,
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1ABC',
+      'user_ssid': 7,
+      'user_is_licensed': licensed,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    if (manualLocation) {
+      await settings.setManualPosition(42.0, -71.0);
+    }
+
+    final aprsIsConn = FakeMeridianConnection(
+      id: 'aprs_is',
+      displayName: 'APRS-IS',
+      type: ConnectionType.aprsIs,
+    );
+    final registry = ConnectionRegistry();
+    registry.register(aprsIsConn);
+    if (aprsIsConnected) {
+      aprsIsConn.setStatus(ConnectionStatus.connected);
+    }
+
+    final stationService = StationService();
+    final tx = TxService(registry, settings);
+
+    final groupSubs = GroupSubscriptionService(prefs: prefs);
+    await groupSubs.load();
+    final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+    await bulletinSubs.load();
+    final bulletins = BulletinService(
+      subscriptions: bulletinSubs,
+      prefs: prefs,
+    );
+    await bulletins.load();
+    if (!showBulletinsEnabled) {
+      await bulletins.setShowBulletins(false);
+    }
+
+    final messagingSettings = MessagingSettingsService(prefs: prefs);
+    await messagingSettings.load();
+
+    final messages = MessageService(
+      settings,
+      tx,
+      stationService,
+      groupSubscriptions: groupSubs,
+      bulletins: bulletins,
+    );
+
+    // Seed notification prefs so downstream widgets that read them don't
+    // hit an uninitialized pref. We don't need a NotificationService in the
+    // widget tree — the screens this test exercises don't read it.
+    await NotificationPreferences.defaults(optedIn: true).save(prefs);
+
+    return _Harness._(
+      messages: messages,
+      bulletins: bulletins,
+      bulletinSubs: bulletinSubs,
+      groupSubs: groupSubs,
+      settings: settings,
+      registry: registry,
+      aprsIsConn: aprsIsConn,
+    );
+  }
+
+  Widget wrap(Widget child) => MaterialApp(
+    home: MultiProvider(
+      providers: [
+        ChangeNotifierProvider<StationSettingsService>.value(value: settings),
+        ChangeNotifierProvider<ConnectionRegistry>.value(value: registry),
+        ChangeNotifierProvider<MessageService>.value(value: messages),
+        ChangeNotifierProvider<BulletinService>.value(value: bulletins),
+        ChangeNotifierProvider<BulletinSubscriptionService>.value(
+          value: bulletinSubs,
+        ),
+        ChangeNotifierProvider<GroupSubscriptionService>.value(
+          value: groupSubs,
+        ),
+      ],
+      child: child,
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MessagesScreen — segmented control', () {
+    testWidgets('renders Direct / Groups / Bulletins segments', (tester) async {
+      final h = await _Harness.create();
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Direct'), findsOneWidget);
+      expect(find.text('Groups'), findsOneWidget);
+      expect(find.text('Bulletins'), findsOneWidget);
+    });
+
+    testWidgets('tapping Groups swaps to the group tab empty state', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Groups'));
+      await tester.pumpAndSettle();
+
+      // Built-ins (CQ/QST/ALL) seed on first run — we expect at least CQ.
+      expect(find.text('CQ'), findsWidgets);
+    });
+
+    testWidgets('tapping Bulletins swaps to bulletins-tab empty state', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+      expect(find.text('No bulletins yet'), findsOneWidget);
+    });
+  });
+
+  group('BulletinsTab — showBulletins gate', () {
+    testWidgets('showBulletins=false hides the feed with disabled state', (
+      tester,
+    ) async {
+      final h = await _Harness.create(showBulletinsEnabled: false);
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+      expect(find.text('Bulletins are hidden'), findsOneWidget);
+    });
+  });
+
+  group('BulletinsTab — location-unknown banner', () {
+    testWidgets('banner shows when APRS-IS connected + no station location', (
+      tester,
+    ) async {
+      final h = await _Harness.create(
+        aprsIsConnected: true,
+        manualLocation: false,
+      );
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('station location is not set'),
+        findsOneWidget,
+      );
+      expect(find.text('Set location'), findsOneWidget);
+    });
+
+    testWidgets('banner hidden when APRS-IS disconnected', (tester) async {
+      final h = await _Harness.create(
+        aprsIsConnected: false,
+        manualLocation: false,
+      );
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('station location is not set'), findsNothing);
+    });
+
+    testWidgets('banner hidden when station location is set', (tester) async {
+      final h = await _Harness.create(
+        aprsIsConnected: true,
+        manualLocation: true,
+      );
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('station location is not set'), findsNothing);
+    });
+  });
+
+  group('BulletinDetailScreen', () {
+    testWidgets('renders body, source, totals, no inline reply input', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      // Seed a bulletin.
+      h.bulletins.ingest(
+        info: const BulletinAddresseeInfo(
+          addressee: 'BLN0',
+          lineNumber: '0',
+          category: BulletinCategory.general,
+        ),
+        sourceCallsign: 'K5WX-15',
+        body: 'Severe weather alert',
+        transport: PacketSource.aprsIs,
+        receivedAt: DateTime(2026, 4, 23, 12, 0),
+      );
+      final bulletinId = h.bulletins.bulletins.first.id;
+
+      await tester.pumpWidget(
+        h.wrap(BulletinDetailScreen(bulletinId: bulletinId)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('BLN0'), findsWidgets);
+      expect(find.text('Severe weather alert'), findsOneWidget);
+      expect(find.text('From K5WX-15'), findsOneWidget);
+      expect(find.text('Total receipts'), findsOneWidget);
+
+      // Critical: bulletin detail is read-only — no TextField should exist.
+      expect(find.byType(TextField), findsNothing);
+    });
+  });
+
+  group('GroupChannelScreen — adaptive compose', () {
+    testWidgets('sender-mode compose shows reply hint when no last sender', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      // CQ is seeded as reply_mode = sender.
+      await tester.pumpWidget(
+        h.wrap(const GroupChannelScreen(groupName: 'CQ')),
+      );
+      await tester.pumpAndSettle();
+
+      // With no incoming messages yet, compose falls back to "Message to CQ".
+      expect(find.text('Message to CQ'), findsWidgets);
+    });
+
+    testWidgets('group-mode custom group shows "Message to NAME"', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      await h.groupSubs.add(name: 'SRARC'); // defaults to replyMode.group
+      await tester.pumpWidget(
+        h.wrap(const GroupChannelScreen(groupName: 'SRARC')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Message to SRARC'), findsWidgets);
+    });
+
+    testWidgets('missing subscription renders the fallback bar', (
+      tester,
+    ) async {
+      final h = await _Harness.create();
+      await tester.pumpWidget(
+        h.wrap(const GroupChannelScreen(groupName: 'DOESNOTEXIST')),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.textContaining('This group is no longer in your subscriptions'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('unlicensed user sees unlicensed bar instead of compose', (
+      tester,
+    ) async {
+      final h = await _Harness.create(licensed: false);
+      await tester.pumpWidget(
+        h.wrap(const GroupChannelScreen(groupName: 'CQ')),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.textContaining('amateur radio license is required'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MessagesScreen` gets a three-segment control at the top. Direct preserves v0.14 behavior byte-for-byte; Groups and Bulletins are new peers sharing the same destination.
- Platform-adaptive: M3 `SegmentedButton` on Android/desktop, `CupertinoSlidingSegmentedControl` on iOS. Direct + Groups segments carry unread badges (Material side — Cupertino doesn't support per-segment trailing content).
- **Groups tab** — list of enabled + disabled subscriptions with reply-mode icons (`campaign` for sender, `forum` for group), unread badges, last-message preview (sender + body).
- **Group channel screen** — chronological feed with sender callsign prominent on every bubble. Compose adapts to `replyMode`: group mode = "Message to <NAME>"; sender mode = "Reply to <last sender>" + secondary "Send to <NAME> instead". Send buttons SnackBar-stub; PR 4 wires real TX (same UX endpoint — reply-to-sender lands in the direct thread — so the behavior is forward-compatible).
- **Bulletins tab** — chronological feed with filter chips (All / General / Groups / My bulletins), per-row RF/IS transport chips, location-unknown banner when APRS-IS is connected and the operator has not set a station location. Respects the `Show bulletins` master toggle from PR 2. The banner's "general APRS-IS bulletins are hidden" copy is truthful from day one — the filter is applied in `BulletinsTab._applyFilter`.
- **Bulletin detail** — read-only page with full body, source, first/last heard, receipt count, transports, and a "Message sender" action that opens a direct thread. No inline reply.

## MessageService additions
- `MessageEntry.fromCallsign` — captures the packet source for incoming entries. Critical for group channels where the parent `Conversation.peerCallsign` is `#GROUP:<NAME>` and can't recover the sender. Legacy-safe JSON deserialization (null for v0.14-era entries).
- `groupConversations`, `groupNameOf`, `conversationForGroup`, `totalGroupUnread` accessors.
- `allConversations` and `conversations` now exclude `#GROUP:*` keys so direct-message callers (NotificationService, direct thread list) don't accidentally iterate group threads.

## ADR-059
Documents the segmented-control decision (vs. new bottom-nav destinations or subordinate subscreens), why `GroupChannelScreen` is separate from `MessageThreadScreen` rather than reused, the `MessageEntry.fromCallsign` addition, and the `allConversations` scope change.

## Gate check
PR 4 (send path + scheduler + bulletin compose + group-send wiring) stays in v0.17 — not deferring to v0.18. Scheduler complexity is tractable, size is comparable to PR 2, and the PR 3 stubs would leave user-visible dead buttons on `main` otherwise.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 546 passing (534 existing + 12 new widget tests)
- [x] Widget: segmented control renders three tabs, tapping swaps body, Bulletins-tab disabled state when showBulletins=false, location-unknown banner toggles correctly across three states (IS+loc unknown, IS disconnected, loc set), bulletin detail has no TextField, group channel compose shows adaptive hint per reply mode, missing-subscription fallback, unlicensed fallback
- [x] Service/ingestion: PR 1 classification test updated for new `groupConversations` accessor; sender captured on `MessageEntry.fromCallsign`
- [x] Manual (user-tested): three segments render + swap cleanly; Direct tab still behaves like v0.14; Groups tab shows seeded built-ins; group channel compose hint adapts to reply mode; tapping Send in sender mode navigates to direct thread (PR 4 will make it actually send); Bulletins tab filter chips work; location-unknown banner shows when appropriate; bulletin detail is read-only