### PR TITLE
v0.17 PR 4 — Send path: bulletin scheduler + group TX + encoders + compose

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1109,10 +1109,10 @@ Meridian implements the same model so it interoperates with Yaesu FT5D, Kenwood 
 
 ---
 
-## ADR-057: Bulletin transmission model — APRSIS32 fixed interval (v0.17, planned for PR 4)
+## ADR-057: Bulletin transmission model — APRSIS32 fixed interval (v0.17)
 
-**Date:** 2026-04-23
-**Status:** Proposed (finalized in PR 4)
+**Date:** 2026-04-23 (proposed) / 2026-04-24 (accepted, PR 4)
+**Status:** Accepted
 
 ### Context
 
@@ -1144,12 +1144,21 @@ Use the APRSIS32 fixed-interval model with an initial pulse and a hard expiry:
 
 Bulletins are never ACKed. The `BulletinClassification` path in `MessageService` does not call `_transmitAck` under any circumstance.
 
-### Consequences (to be realized in PR 4)
+### Consequences (realized in PR 4)
 
-- `lib/services/bulletin_scheduler.dart` — 30s tick in main isolate, sibling to `BeaconingService`.
-- Background isolate (`meridian_connection_task.dart`) gains a parallel bulletin timer that reads `OutgoingBulletin` list from SharedPreferences on each fire (same pattern as the existing beacon-settings read).
-- `AprsEncoder.encodeBulletin(addressee, body)` — 9-char space-padded addressee, `:BLN0     :Body`, no wire ID.
-- RF path sourced from Advanced-mode "Bulletin path" setting (default `WIDE2-2`); APRS-IS has no path.
+- `lib/services/bulletin_scheduler.dart` — main-isolate 30s tick, sibling to `BeaconingService`. Injectable clock for `FakeAsync`-driven tests. Emits `BulletinExpiredEvent` / `BulletinTransmittedEvent` on its `events` stream.
+- `lib/services/meridian_connection_task.dart` — background-isolate bulletin timer fires the same tick logic. APRS-IS transmission uses the existing short-lived TCP helper; RF transmission forwards a `send_tnc_bulletin` IPC message to the main-isolate `BackgroundServiceManager`, which calls `TxService.sendViaTncOnly` with the Advanced-mode "Bulletin path". Background-isolate writes updates `outgoing_bulletins_v1` prefs directly; main-isolate in-memory state is resynced on next create/edit/delete (PR 5 may add AppLifecycle-resume hook for tighter sync).
+- `AprsEncoder.encodeBulletin(addressee, body)` — 9-char space-padded addressee, `:BLN0     :Body`, no wire ID. Companion `encodeGroupMessage(groupName, body)` follows the same pattern for group sends.
+- `MeridianConnection.sendLine(aprsLine, {digipeaterPath})` — extended with optional `digipeaterPath` so BLE/Serial connections can override the default `WIDE1-1,WIDE2-1` aliases when sending bulletins (default `WIDE2-2`) or group messages (default "same as beacon path"). APRS-IS connections ignore the parameter.
+- `TxService.sendBulletin(line, {viaRf, viaAprsIs, rfPath})` — per-bulletin fan-out helper that respects the independent transport flags (unlike `sendLine`'s unconditional Serial > BLE > APRS-IS hierarchy from ADR-029).
+- `BulletinService` gains `OutgoingBulletin` CRUD: `createOutgoing`, `updateOutgoingContent` (resets state), `updateOutgoingSchedule` (preserves state), `setOutgoingEnabled`, `deleteOutgoing`, `recordOutgoingTransmission`. Addressee validation via `_bulletinAddresseePattern`.
+- Bulletin compose screen (`lib/screens/bulletin_compose_screen.dart`) — single-page form with type / line / group / body / interval / expiry / transport flags. Shared by create + edit.
+- "My bulletins" filter on `BulletinsTab` now renders `OutgoingBulletin` rows with next-tx countdown, transmission count, per-row enable toggle, Edit, and Delete (with confirm dialog).
+
+### Known limitations (addressed in later work)
+
+- Main-isolate `BulletinService`'s in-memory `_outgoing` map does not auto-refresh from prefs when the background isolate mutates state during background phase. On app resume the UI may briefly show stale `lastTransmittedAt`/`transmissionCount` until the next create/edit/delete triggers a re-render. A full resume-sync hook is deferred to the v0.15 drift/SQLite migration or a follow-up hotfix.
+- The background-isolate bulletin timer runs unconditionally whenever the foreground service is alive (vs. beacon timer which requires `start_beaconing` IPC). This is intentional: bulletins are independently scheduled per row, and the foreground service is only alive when the user has explicitly opted into background activity.
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1035,7 +1035,7 @@ The following table is copied into `test/core/callsign/addressee_matcher_test.da
 | Case | Addressee | Setup | Expected |
 |---|---|---|---|
 | Bulletin beats pathological group | `BLN0` | Group `B` prefix | Bulletin |
-| Bulletin beats named-overlap group | `BLN1SRARC` | Group `SRARC` | Bulletin |
+| Bulletin beats named-overlap group | `BLN1CLUB` | Group `CLUB` | Bulletin |
 | Direct beats group prefix conflict | `W1ABC-7` | Operator `W1ABC`; group `W1` prefix | Direct, ACKs |
 | Direct beats group exact conflict | `W1ABC` | Operator `W1ABC`; group `W1ABC` exact | Direct, ACKs |
 | Group when no direct/bulletin | `CQ` | Group `CQ` | Group, no ACK |
@@ -1072,7 +1072,7 @@ The following table is copied into `test/core/callsign/addressee_matcher_test.da
 
 ### Context
 
-APRS group messages (`CQ`, `ALL`, `QST`, club-defined names like `SRARC`) are a protocol-level feature inherited from Yaesu/Kenwood radios and the APRS spec §14. They are one-to-many: a sender addresses any group name and every listener whose radio is configured to match that name receives the message. There is no server-side group mechanism — "subscription" is entirely a local receiver filter.
+APRS group messages (`CQ`, `ALL`, `QST`, club-defined names like `CLUB`) are a protocol-level feature inherited from Yaesu/Kenwood radios and the APRS spec §14. They are one-to-many: a sender addresses any group name and every listener whose radio is configured to match that name receives the message. There is no server-side group mechanism — "subscription" is entirely a local receiver filter.
 
 Meridian implements the same model so it interoperates with Yaesu FT5D, Kenwood TH-D74, and modern software clients (APRSIS32, Xastir). Group messages are distinct from direct messages (different addressee shape) and distinct from bulletins (message-format DTI, ACK semantics differ).
 

--- a/docs/specs/v0.17-groups-and-bulletins-spec.md
+++ b/docs/specs/v0.17-groups-and-bulletins-spec.md
@@ -11,7 +11,7 @@
 
 Meridian's messaging system today handles **direct** (1:1) messages, including cross-SSID matching for the operator's own base callsign (v0.14). This milestone extends messaging with two additional APRS message categories, both defined at the protocol level and fully interoperable with Yaesu, Kenwood, and modern software clients:
 
-- **Group messages** — messages addressed to a group name (`CQ`, `ALL`, `QST`, `SRARC`, etc.) rather than a callsign. Pure protocol-level: no server, no subscription mechanism on the network. "Subscription" is a local receiver filter.
+- **Group messages** — messages addressed to a group name (`CQ`, `ALL`, `QST`, `CLUB`, etc.) rather than a callsign. Pure protocol-level: no server, no subscription mechanism on the network. "Subscription" is a local receiver filter.
 - **Bulletins** — broadcast messages addressed to `BLN0`–`BLN9` (general) or `BLNxNAME` (group bulletins). Periodic retransmission-based, never ACKed.
 
 Reference implementations we match:
@@ -99,7 +99,7 @@ Long-press menu: Mark all read, Notifications toggle, Edit, Mute 1h/8h/24h, Dele
 Single chronological feed (not threaded). Each bubble shows sender callsign prominently.
 
 Compose adapts to `reply_mode`:
-- **Group mode:** `[💬 Message to SRARC] [Send]`
+- **Group mode:** `[💬 Message to CLUB] [Send]`
 - **Sender mode:** `[📢 Reply to W1ABC-9 (last sender)] [Send]` + secondary "Send to group instead"
 
 Per-message action sheet: Reply directly to sender / Send to group / Copy / View sender station.
@@ -340,7 +340,7 @@ Extend existing v0.10/v0.13 filter:
 ```
 existing:  a/<lat1>/<lon1>/<lat2>/<lon2>  t/m
 added:     g/BLN0 g/BLN1 ... g/BLN9
-added:     g/BLN*WX g/BLN*SRARC ...   (per BulletinSubscription)
+added:     g/BLN*WX g/BLN*CLUB ...   (per BulletinSubscription)
 ```
 
 APRS-IS doesn't natively express "within N km of my station." Client-side implementation:
@@ -418,7 +418,7 @@ Extend v0.11 system:
 | Channel | Default | Body format |
 |---|---|---|
 | Group message (built-in: CQ, QST, etc.) | Off | `W1ABC-9 in CQ: <body>` |
-| Group message (custom) | **On** | `W1ABC-9 in SRARC: <body>` |
+| Group message (custom) | **On** | `W1ABC-9 in CLUB: <body>` |
 | Bulletin (general) | Off | `Bulletin from K5WX-15: <body>` |
 | Bulletin (subscribed group) | **On** | `WX bulletin from K5WX-15: <body>` |
 | My bulletin expired | On | `Your bulletin BLN0 expired. Tap to repost.` |
@@ -458,7 +458,7 @@ Meridian's principle: fully functional on RF only.
 | Case | Addressee | Setup | Expected |
 |---|---|---|---|
 | Bulletin beats pathological group | `BLN0` | Group `B` prefix | `bulletin` |
-| Bulletin beats named-overlap group | `BLN1SRARC` | Group `SRARC` | `bulletin` |
+| Bulletin beats named-overlap group | `BLN1CLUB` | Group `CLUB` | `bulletin` |
 | Direct beats group (prefix conflict) | `W1ABC-7` | Operator `W1ABC`; group `W1` prefix | `direct`, ACKs |
 | Direct beats group (exact conflict) | `W1ABC` | Operator `W1ABC`; group `W1ABC` exact | `direct`, ACKs |
 | Group matches when no direct/bulletin | `CQ` | Group `CQ` | `group`, no ACK |

--- a/lib/core/callsign/addressee_matcher.dart
+++ b/lib/core/callsign/addressee_matcher.dart
@@ -75,7 +75,7 @@ class AddresseeMatcher {
   ///
   /// `BLN0`      → line=`"0"`, general
   /// `BLN1WX`    → line=`"1"`, groupNamed, group=`"WX"`
-  /// `BLNASRARC` → line=`"A"`, groupNamed, group=`"SRARC"`
+  /// `BLNACLUB` → line=`"A"`, groupNamed, group=`"CLUB"`
   static BulletinAddresseeInfo _parseBulletinAddressee(String addressee) {
     // Guaranteed: length >= 4, matches `^BLN[0-9A-Z]`.
     final line = addressee.substring(3, 4);

--- a/lib/core/connection/aprs_is_connection.dart
+++ b/lib/core/connection/aprs_is_connection.dart
@@ -116,7 +116,8 @@ class AprsIsConnection extends MeridianConnection {
   Stream<String> get lines => _transport.lines;
 
   @override
-  Future<void> sendLine(String aprsLine) async {
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
+    // digipeaterPath is ignored — APRS-IS has no concept of a digipeater path.
     _transport.sendLine('$aprsLine\r\n');
   }
 

--- a/lib/core/connection/ble_connection_impl.dart
+++ b/lib/core/connection/ble_connection_impl.dart
@@ -138,12 +138,12 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   Stream<String> get lines => _linesController.stream;
 
   @override
-  Future<void> sendLine(String aprsLine) async {
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
     final transport = _transport;
     if (transport == null || !transport.isConnected) {
       throw StateError('BleConnection: not connected');
     }
-    final ax25Bytes = _buildAx25Bytes(aprsLine);
+    final ax25Bytes = _buildAx25Bytes(aprsLine, digipeaterPath: digipeaterPath);
     if (ax25Bytes != null) {
       await transport.sendFrame(ax25Bytes);
     }
@@ -310,7 +310,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   // Internal — AX.25 encoding
   // ---------------------------------------------------------------------------
 
-  Uint8List? _buildAx25Bytes(String aprsLine) {
+  Uint8List? _buildAx25Bytes(String aprsLine, {List<String>? digipeaterPath}) {
     final gtIdx = aprsLine.indexOf('>');
     final colonIdx = aprsLine.indexOf(':');
     if (gtIdx < 0 || colonIdx < 0 || colonIdx <= gtIdx) return null;
@@ -322,11 +322,18 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
     final callsign = sourceParts[0].toUpperCase();
     final ssid = sourceParts.length > 1 ? int.tryParse(sourceParts[1]) ?? 0 : 0;
 
-    final frame = Ax25Encoder.buildAprsFrame(
-      sourceCallsign: callsign,
-      sourceSsid: ssid,
-      infoField: infoField,
-    );
+    final frame = digipeaterPath != null && digipeaterPath.isNotEmpty
+        ? Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            digipeaterAliases: digipeaterPath,
+            infoField: infoField,
+          )
+        : Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            infoField: infoField,
+          );
     return Ax25Encoder.encodeUiFrame(frame);
   }
 }

--- a/lib/core/connection/ble_connection_stub.dart
+++ b/lib/core/connection/ble_connection_stub.dart
@@ -46,7 +46,7 @@ class BleConnection extends MeridianConnection {
       throw UnsupportedError('BLE not supported on this platform');
 
   @override
-  Future<void> sendLine(String aprsLine) =>
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) =>
       throw UnsupportedError('BLE not supported on this platform');
 
   @override

--- a/lib/core/connection/meridian_connection.dart
+++ b/lib/core/connection/meridian_connection.dart
@@ -93,7 +93,13 @@ abstract class MeridianConnection extends ChangeNotifier {
   /// APRS-IS connections append `\r\n` and write to the TCP socket. TNC
   /// connections encode the line as an AX.25 UI frame and send it as a KISS
   /// frame. Throws if not connected.
-  Future<void> sendLine(String aprsLine);
+  ///
+  /// [digipeaterPath] overrides the default digipeater aliases used by TNC
+  /// connections when building the AX.25 frame (default: `WIDE1-1,WIDE2-1`).
+  /// APRS-IS connections ignore this parameter (APRS-IS has no path). Used
+  /// by v0.17 bulletin/group send to route through the Advanced-mode
+  /// "Bulletin path" / "Group message path" settings (ADR-057).
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath});
 
   // ---------------------------------------------------------------------------
   // Lifecycle

--- a/lib/core/connection/serial_connection_impl.dart
+++ b/lib/core/connection/serial_connection_impl.dart
@@ -143,12 +143,12 @@ class SerialConnection extends MeridianConnection with ReconnectableMixin {
   Stream<String> get lines => _linesController.stream;
 
   @override
-  Future<void> sendLine(String aprsLine) async {
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
     final transport = _transport;
     if (transport == null || !transport.isConnected) {
       throw StateError('SerialConnection: not connected');
     }
-    final ax25Bytes = _buildAx25Bytes(aprsLine);
+    final ax25Bytes = _buildAx25Bytes(aprsLine, digipeaterPath: digipeaterPath);
     if (ax25Bytes != null) {
       await transport.sendFrame(ax25Bytes);
     }
@@ -319,7 +319,7 @@ class SerialConnection extends MeridianConnection with ReconnectableMixin {
   // Internal — AX.25 encoding
   // ---------------------------------------------------------------------------
 
-  Uint8List? _buildAx25Bytes(String aprsLine) {
+  Uint8List? _buildAx25Bytes(String aprsLine, {List<String>? digipeaterPath}) {
     final gtIdx = aprsLine.indexOf('>');
     final colonIdx = aprsLine.indexOf(':');
     if (gtIdx < 0 || colonIdx < 0 || colonIdx <= gtIdx) return null;
@@ -331,11 +331,18 @@ class SerialConnection extends MeridianConnection with ReconnectableMixin {
     final callsign = sourceParts[0].toUpperCase();
     final ssid = sourceParts.length > 1 ? int.tryParse(sourceParts[1]) ?? 0 : 0;
 
-    final frame = Ax25Encoder.buildAprsFrame(
-      sourceCallsign: callsign,
-      sourceSsid: ssid,
-      infoField: infoField,
-    );
+    final frame = digipeaterPath != null && digipeaterPath.isNotEmpty
+        ? Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            digipeaterAliases: digipeaterPath,
+            infoField: infoField,
+          )
+        : Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            infoField: infoField,
+          );
     return Ax25Encoder.encodeUiFrame(frame);
   }
 

--- a/lib/core/connection/serial_connection_stub.dart
+++ b/lib/core/connection/serial_connection_stub.dart
@@ -47,7 +47,7 @@ class SerialConnection extends MeridianConnection {
       throw UnsupportedError('Serial not supported on this platform');
 
   @override
-  Future<void> sendLine(String aprsLine) =>
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) =>
       throw UnsupportedError('Serial not supported on this platform');
 
   @override

--- a/lib/core/packet/aprs_encoder.dart
+++ b/lib/core/packet/aprs_encoder.dart
@@ -131,7 +131,7 @@ class AprsEncoder {
   // Group message (v0.17, ADR-056)
   // -------------------------------------------------------------------------
 
-  /// Encodes an APRS group message (e.g. `CQ`, `QST`, `SRARC`). Group
+  /// Encodes an APRS group message (e.g. `CQ`, `QST`, `CLUB`). Group
   /// messages share the direct-message wire format but omit the message-ID
   /// suffix — per ADR-055 they are never ACKed, so the ID-suffix machinery
   /// is intentionally absent.

--- a/lib/core/packet/aprs_encoder.dart
+++ b/lib/core/packet/aprs_encoder.dart
@@ -104,6 +104,52 @@ class AprsEncoder {
   }
 
   // -------------------------------------------------------------------------
+  // Bulletin (v0.17, ADR-057)
+  // -------------------------------------------------------------------------
+
+  /// Encodes an APRS bulletin. Bulletins use the same wire format as direct
+  /// messages but are never ACKed — no `{id}` suffix.
+  ///
+  /// Returns a full APRS-IS line, e.g.:
+  /// `W1ABC-7>APMDN0,TCPIP*::BLN0     :Severe wx alert`
+  ///
+  /// [addressee] is the bulletin addressee (`BLN0`..`BLN9` for general;
+  /// `BLNxNAME` for named groups where `x` is `0`–`9` or `A`–`Z`). Padded
+  /// to 9 characters per APRS spec §14.
+  static String encodeBulletin({
+    required String fromCallsign,
+    required int fromSsid,
+    required String addressee,
+    required String body,
+  }) {
+    final header = _header(fromCallsign, fromSsid);
+    final padded = _padAddressee(addressee);
+    return '$header:$padded:$body';
+  }
+
+  // -------------------------------------------------------------------------
+  // Group message (v0.17, ADR-056)
+  // -------------------------------------------------------------------------
+
+  /// Encodes an APRS group message (e.g. `CQ`, `QST`, `SRARC`). Group
+  /// messages share the direct-message wire format but omit the message-ID
+  /// suffix — per ADR-055 they are never ACKed, so the ID-suffix machinery
+  /// is intentionally absent.
+  ///
+  /// Returns a full APRS-IS line, e.g.:
+  /// `W1ABC-7>APMDN0,TCPIP*::CQ       :CQ CQ — anyone on freq?`
+  static String encodeGroupMessage({
+    required String fromCallsign,
+    required int fromSsid,
+    required String groupName,
+    required String body,
+  }) {
+    final header = _header(fromCallsign, fromSsid);
+    final addressee = _padAddressee(groupName);
+    return '$header:$addressee:$body';
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'screens/map_screen.dart';
 import 'screens/onboarding/onboarding_screen.dart';
 import 'services/background_service_manager.dart';
 import 'services/beaconing_service.dart';
+import 'services/bulletin_scheduler.dart';
 import 'services/bulletin_service.dart';
 import 'services/bulletin_subscription_service.dart';
 import 'services/group_subscription_service.dart';
@@ -203,6 +204,14 @@ Future<void> main() async {
   final messagingSettings = MessagingSettingsService(prefs: prefs);
   await messagingSettings.load();
 
+  final bulletinScheduler = BulletinScheduler(
+    bulletins: bulletinService,
+    tx: txService,
+    messagingSettings: messagingSettings,
+    stationSettings: stationSettings,
+  );
+  bulletinScheduler.start();
+
   final messageService = MessageService(
     stationSettings,
     txService,
@@ -293,6 +302,9 @@ Future<void> main() async {
           value: bulletinSubscriptions,
         ),
         ChangeNotifierProvider<BulletinService>.value(value: bulletinService),
+        ChangeNotifierProvider<BulletinScheduler>.value(
+          value: bulletinScheduler,
+        ),
         ChangeNotifierProvider<MessagingSettingsService>.value(
           value: messagingSettings,
         ),

--- a/lib/models/bulletin.dart
+++ b/lib/models/bulletin.dart
@@ -157,7 +157,7 @@ class Bulletin {
 ///
 /// `BLN0`        → line=`"0"`, category=[BulletinCategory.general],      groupName=null
 /// `BLN1WX`      → line=`"1"`, category=[BulletinCategory.groupNamed],   groupName=`"WX"`
-/// `BLNASRARC`   → line=`"A"`, category=[BulletinCategory.groupNamed],   groupName=`"SRARC"`
+/// `BLNACLUB`   → line=`"A"`, category=[BulletinCategory.groupNamed],   groupName=`"CLUB"`
 class BulletinAddresseeInfo {
   const BulletinAddresseeInfo({
     required this.addressee,

--- a/lib/models/bulletin_subscription.dart
+++ b/lib/models/bulletin_subscription.dart
@@ -1,4 +1,4 @@
-/// Subscription to a named bulletin group (e.g. `BLNxWX`, `BLNxSRARC`).
+/// Subscription to a named bulletin group (e.g. `BLNxWX`, `BLNxCLUB`).
 ///
 /// Governs whether `BLNxNAME`-form bulletins for that group are kept on
 /// receive. General `BLN0`–`BLN9` bulletins are not governed by subscriptions

--- a/lib/models/group_subscription.dart
+++ b/lib/models/group_subscription.dart
@@ -1,4 +1,4 @@
-/// Subscription to an APRS message group (e.g. `CQ`, `QST`, `ALL`, `SRARC`).
+/// Subscription to an APRS message group (e.g. `CQ`, `QST`, `ALL`, `CLUB`).
 ///
 /// Groups are a pure client-side receiver filter — APRS has no server-side
 /// group mechanism, so "subscription" just means "include packets whose

--- a/lib/screens/bulletin_compose_screen.dart
+++ b/lib/screens/bulletin_compose_screen.dart
@@ -202,7 +202,7 @@ class _BulletinComposeScreenState extends State<BulletinComposeScreen> {
               maxLength: 5,
               textCapitalization: TextCapitalization.characters,
               decoration: const InputDecoration(
-                hintText: 'e.g. WX, SRARC',
+                hintText: 'e.g. WX, CLUB',
                 helperText: '1–5 uppercase letters / digits',
                 border: OutlineInputBorder(),
               ),

--- a/lib/screens/bulletin_compose_screen.dart
+++ b/lib/screens/bulletin_compose_screen.dart
@@ -1,0 +1,368 @@
+/// Compose / edit screen for outgoing bulletins (spec §4.5, ADR-057).
+///
+/// Single-page form — not a wizard. The user picks type (General / named
+/// Group), line number, group name (if Group), body, TX interval, expiry,
+/// and per-transport flags. Edit mode pre-populates; changing body or
+/// addressee resets `transmissionCount` + `lastTransmittedAt` per ADR-057
+/// (handled by `BulletinService.updateOutgoingContent`).
+library;
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../models/bulletin.dart';
+import '../models/outgoing_bulletin.dart';
+import '../services/bulletin_service.dart';
+
+enum _BulletinType { general, groupNamed }
+
+class BulletinComposeScreen extends StatefulWidget {
+  const BulletinComposeScreen({super.key, this.existing});
+
+  /// When non-null, the form is in edit mode and pre-populates fields from
+  /// this row.
+  final OutgoingBulletin? existing;
+
+  @override
+  State<BulletinComposeScreen> createState() => _BulletinComposeScreenState();
+}
+
+class _BulletinComposeScreenState extends State<BulletinComposeScreen> {
+  late _BulletinType _type;
+  late String _lineNumber;
+  late final TextEditingController _groupName;
+  late final TextEditingController _body;
+  late int _intervalSeconds;
+  late int _expiryHours;
+  late bool _viaRf;
+  late bool _viaAprsIs;
+  bool _saving = false;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final ob = widget.existing;
+    if (ob != null) {
+      final parsed = _parseAddressee(ob.addressee);
+      _type = parsed.type;
+      _lineNumber = parsed.lineNumber;
+      _groupName = TextEditingController(text: parsed.groupName ?? '');
+      _body = TextEditingController(text: ob.body);
+      _intervalSeconds = ob.intervalSeconds;
+      // Best-effort reverse-map absolute expiry → delta-hours dropdown by
+      // computing hours between createdAt and expiresAt. Falls through to
+      // nearest supported bucket.
+      final deltaHours = ob.expiresAt
+          .difference(ob.createdAt)
+          .inHours
+          .clamp(2, 48);
+      _expiryHours = BulletinService.expiryOptionsHours.reduce(
+        (a, b) => (a - deltaHours).abs() < (b - deltaHours).abs() ? a : b,
+      );
+      _viaRf = ob.viaRf;
+      _viaAprsIs = ob.viaAprsIs;
+    } else {
+      _type = _BulletinType.general;
+      _lineNumber = '0';
+      _groupName = TextEditingController();
+      _body = TextEditingController();
+      _intervalSeconds = 1800;
+      _expiryHours = 24;
+      _viaRf = true;
+      _viaAprsIs = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    _groupName.dispose();
+    _body.dispose();
+    super.dispose();
+  }
+
+  String _composeAddressee() {
+    if (_type == _BulletinType.general) return 'BLN$_lineNumber';
+    return 'BLN$_lineNumber${_groupName.text.trim().toUpperCase()}';
+  }
+
+  bool get _formValid {
+    if (_body.text.trim().isEmpty) return false;
+    if (!_viaRf && !_viaAprsIs) return false;
+    if (_type == _BulletinType.groupNamed) {
+      final group = _groupName.text.trim().toUpperCase();
+      if (group.isEmpty) return false;
+      if (!RegExp(r'^[A-Z0-9]{1,5}$').hasMatch(group)) return false;
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final lineNumberOptions = _type == _BulletinType.general
+        ? const ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+        : const [
+            '0',
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            'A',
+            'B',
+            'C',
+            'D',
+            'E',
+            'F',
+            'G',
+            'H',
+            'I',
+            'J',
+            'K',
+            'L',
+            'M',
+            'N',
+            'O',
+            'P',
+            'Q',
+            'R',
+            'S',
+            'T',
+            'U',
+            'V',
+            'W',
+            'X',
+            'Y',
+            'Z',
+          ];
+
+    return Scaffold(
+      appBar: AppBar(title: Text(_isEdit ? 'Edit bulletin' : 'New bulletin')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Type', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          SegmentedButton<_BulletinType>(
+            segments: const [
+              ButtonSegment(
+                value: _BulletinType.general,
+                label: Text('General (BLN0–9)'),
+              ),
+              ButtonSegment(
+                value: _BulletinType.groupNamed,
+                label: Text('Named group'),
+              ),
+            ],
+            selected: {_type},
+            onSelectionChanged: (s) => setState(() {
+              _type = s.first;
+              // Reset line number if switching from groupNamed's letters.
+              if (_type == _BulletinType.general &&
+                  !RegExp(r'^[0-9]$').hasMatch(_lineNumber)) {
+                _lineNumber = '0';
+              }
+            }),
+          ),
+          const SizedBox(height: 20),
+          Text('Line number', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            initialValue: _lineNumber,
+            items: [
+              for (final v in lineNumberOptions)
+                DropdownMenuItem(value: v, child: Text(v)),
+            ],
+            onChanged: (v) {
+              if (v != null) setState(() => _lineNumber = v);
+            },
+          ),
+          if (_type == _BulletinType.groupNamed) ...[
+            const SizedBox(height: 20),
+            Text('Group name', style: theme.textTheme.labelLarge),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _groupName,
+              maxLength: 5,
+              textCapitalization: TextCapitalization.characters,
+              decoration: const InputDecoration(
+                hintText: 'e.g. WX, SRARC',
+                helperText: '1–5 uppercase letters / digits',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+          ],
+          const SizedBox(height: 20),
+          Text('Body', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _body,
+            maxLength: 67,
+            maxLines: 3,
+            minLines: 2,
+            decoration: const InputDecoration(
+              hintText: 'Bulletin body (up to 67 chars)',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 20),
+          Text('Transmit interval', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<int>(
+            initialValue: _intervalSeconds,
+            items: [
+              for (final v in BulletinService.intervalOptionsSeconds)
+                DropdownMenuItem(value: v, child: Text(_intervalLabel(v))),
+            ],
+            onChanged: (v) {
+              if (v != null) setState(() => _intervalSeconds = v);
+            },
+          ),
+          const SizedBox(height: 20),
+          Text('Expires in', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<int>(
+            initialValue: _expiryHours,
+            items: [
+              for (final h in BulletinService.expiryOptionsHours)
+                DropdownMenuItem(value: h, child: Text('${h}h')),
+            ],
+            onChanged: (v) {
+              if (v != null) setState(() => _expiryHours = v);
+            },
+          ),
+          const SizedBox(height: 20),
+          Text('Transports', style: theme.textTheme.labelLarge),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Via RF (TNC)'),
+            subtitle: const Text('Uses the Advanced-mode "Bulletin path".'),
+            value: _viaRf,
+            onChanged: (v) => setState(() => _viaRf = v),
+          ),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Via APRS-IS'),
+            value: _viaAprsIs,
+            onChanged: (v) => setState(() => _viaAprsIs = v),
+          ),
+          if (!_viaRf && !_viaAprsIs)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                'Select at least one transport.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
+            ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.icon(
+                  icon: Icon(_isEdit ? Symbols.save : Symbols.send),
+                  label: Text(_isEdit ? 'Save changes' : 'Start transmitting'),
+                  onPressed: (_formValid && !_saving) ? _submit : null,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _intervalLabel(int seconds) {
+    if (seconds == 0) return 'One-shot';
+    if (seconds < 3600) return '${seconds ~/ 60} min';
+    return '${seconds ~/ 3600} hr';
+  }
+
+  Future<void> _submit() async {
+    setState(() => _saving = true);
+    final bulletins = context.read<BulletinService>();
+    final addressee = _composeAddressee();
+    final expiresAt = DateTime.now().add(Duration(hours: _expiryHours));
+    try {
+      if (_isEdit) {
+        final ob = widget.existing!;
+        if (ob.addressee != addressee || ob.body != _body.text) {
+          await bulletins.updateOutgoingContent(
+            ob.id,
+            addressee: addressee,
+            body: _body.text,
+          );
+        }
+        await bulletins.updateOutgoingSchedule(
+          ob.id,
+          intervalSeconds: _intervalSeconds,
+          expiresAt: expiresAt,
+          viaRf: _viaRf,
+          viaAprsIs: _viaAprsIs,
+        );
+      } else {
+        await bulletins.createOutgoing(
+          addressee: addressee,
+          body: _body.text,
+          intervalSeconds: _intervalSeconds,
+          expiresAt: expiresAt,
+          viaRf: _viaRf,
+          viaAprsIs: _viaAprsIs,
+        );
+      }
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } on ArgumentError catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Invalid: ${e.message}')));
+    }
+  }
+}
+
+class _ParsedAddressee {
+  _ParsedAddressee(this.type, this.lineNumber, this.groupName);
+  final _BulletinType type;
+  final String lineNumber;
+  final String? groupName;
+}
+
+_ParsedAddressee _parseAddressee(String addressee) {
+  // Valid form: BLN + line (0-9 or A-Z) + optional 1-5 char group name.
+  final trimmed = addressee.trim().toUpperCase();
+  if (!trimmed.startsWith('BLN') || trimmed.length < 4) {
+    // Fallback — unlikely but safe default so the form still opens.
+    return _ParsedAddressee(_BulletinType.general, '0', null);
+  }
+  final line = trimmed.substring(3, 4);
+  final rest = trimmed.length > 4 ? trimmed.substring(4) : '';
+  if (rest.isEmpty && RegExp(r'^[0-9]$').hasMatch(line)) {
+    return _ParsedAddressee(_BulletinType.general, line, null);
+  }
+  return _ParsedAddressee(
+    _BulletinType.groupNamed,
+    line,
+    rest.isEmpty ? null : rest,
+  );
+}
+
+/// Derive the default BulletinCategory from an addressee. Exposed for the
+/// "My bulletins" UI which wants to colour-code differently per category.
+BulletinCategory categoryOfAddressee(String addressee) {
+  final parsed = _parseAddressee(addressee);
+  return parsed.type == _BulletinType.general
+      ? BulletinCategory.general
+      : BulletinCategory.groupNamed;
+}

--- a/lib/screens/bulletin_compose_screen.dart
+++ b/lib/screens/bulletin_compose_screen.dart
@@ -172,7 +172,16 @@ class _BulletinComposeScreenState extends State<BulletinComposeScreen> {
             }),
           ),
           const SizedBox(height: 20),
-          Text('Line number', style: theme.textTheme.labelLarge),
+          Text('Slot', style: theme.textTheme.labelLarge),
+          const SizedBox(height: 4),
+          Text(
+            'Replaces the # in BLN#. Different slots let you run multiple '
+            'bulletins at once — receivers overwrite same-slot bulletins '
+            'from the same source.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
           const SizedBox(height: 8),
           DropdownButtonFormField<String>(
             initialValue: _lineNumber,

--- a/lib/screens/bulletins_tab.dart
+++ b/lib/screens/bulletins_tab.dart
@@ -19,8 +19,24 @@ import '../services/station_settings_service.dart';
 import '../ui/utils/platform_route.dart';
 import 'bulletin_compose_screen.dart';
 import 'bulletin_detail_screen.dart';
+import 'settings/category/my_station_screen.dart';
 
 enum _BulletinFilter { all, general, groups, mine }
+
+/// Push the Settings → My Station content as a standalone route. Used by
+/// the location-unknown banner to deep-link the operator to the place they
+/// can set a station position.
+void _openMyStationSettings(BuildContext context) {
+  Navigator.push(
+    context,
+    buildPlatformRoute(
+      (_) => Scaffold(
+        appBar: AppBar(title: const Text('My Station')),
+        body: const MyStationSettingsContent(),
+      ),
+    ),
+  );
+}
 
 class BulletinsTab extends StatefulWidget {
   const BulletinsTab({super.key});
@@ -44,8 +60,13 @@ class _BulletinsTabState extends State<BulletinsTab> {
 
     final aprsIsConn = registry.byId('aprs_is');
     final aprsIsConnected = aprsIsConn?.isConnected ?? false;
-    final hasLocation = station.hasManualPosition;
-    final showLocationBanner = aprsIsConnected && !hasLocation;
+    // "No location" = operator picked manual position but never entered one.
+    // GPS users are assumed to have a location (a fix is obtained on demand
+    // when bulletins actually transmit; we don't pre-validate it here).
+    final needsLocation =
+        station.locationSource == LocationSource.manual &&
+        !station.hasManualPosition;
+    final showLocationBanner = aprsIsConnected && needsLocation;
 
     final visible = _applyFilter(
       bulletins.bulletins,
@@ -106,16 +127,7 @@ class _BulletinsTabState extends State<BulletinsTab> {
           children: [
             if (showLocationBanner)
               _LocationUnknownBanner(
-                onSetLocation: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text(
-                        'Open Settings → My Station to set your location. '
-                        'Direct hook lands in PR 5.',
-                      ),
-                    ),
-                  );
-                },
+                onSetLocation: () => _openMyStationSettings(context),
               ),
             _FilterChipRow(
               current: _filter,

--- a/lib/screens/bulletins_tab.dart
+++ b/lib/screens/bulletins_tab.dart
@@ -13,9 +13,11 @@ import 'package:provider/provider.dart';
 
 import '../core/connection/connection_registry.dart';
 import '../models/bulletin.dart';
+import '../models/outgoing_bulletin.dart';
 import '../services/bulletin_service.dart';
 import '../services/station_settings_service.dart';
 import '../ui/utils/platform_route.dart';
+import 'bulletin_compose_screen.dart';
 import 'bulletin_detail_screen.dart';
 
 enum _BulletinFilter { all, general, groups, mine }
@@ -51,57 +53,100 @@ class _BulletinsTabState extends State<BulletinsTab> {
       showLocationBanner,
     );
 
-    return Column(
-      children: [
-        if (showLocationBanner)
-          _LocationUnknownBanner(
-            onSetLocation: () {
-              // v0.12 onboarding handles initial location entry. Keep this
-              // hook here; the routing target is introduced in PR 5 when the
-              // Settings → My Station "Set location" action is added.
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text(
-                    'Open Settings → My Station to set your location. '
-                    'Direct hook lands in PR 5.',
-                  ),
-                ),
-              );
-            },
-          ),
-        _FilterChipRow(
-          current: _filter,
-          onChanged: (f) => setState(() => _filter = f),
-        ),
-        Expanded(
-          child: visible.isEmpty
-              ? _EmptyForFilter(filter: _filter)
-              : ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  itemCount: visible.length,
-                  separatorBuilder: (_, _) => const SizedBox(height: 2),
-                  itemBuilder: (ctx, i) {
-                    final b = visible[i];
-                    return _BulletinRow(
-                      bulletin: b,
-                      onTap: () {
-                        if (!b.isRead) bulletins.markRead(b.id);
-                        Navigator.push(
-                          ctx,
-                          buildPlatformRoute(
-                            (_) => BulletinDetailScreen(bulletinId: b.id),
-                          ),
-                        );
-                      },
+    final isLicensed = station.isLicensed;
+
+    // When the user is on the "My bulletins" filter, render outgoing bulletins
+    // (maintained by BulletinScheduler) instead of received ones. Other
+    // filters show the received feed.
+    final Widget feed;
+    if (_filter == _BulletinFilter.mine) {
+      final outgoing = bulletins.outgoingBulletins;
+      feed = outgoing.isEmpty
+          ? _EmptyForFilter(filter: _filter, isLicensed: isLicensed)
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              itemCount: outgoing.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 2),
+              itemBuilder: (ctx, i) => _OutgoingBulletinRow(
+                bulletin: outgoing[i],
+                onEdit: () => _openCompose(existing: outgoing[i]),
+                onDelete: () => bulletins.deleteOutgoing(outgoing[i].id),
+                onToggleEnabled: (v) =>
+                    bulletins.setOutgoingEnabled(outgoing[i].id, v),
+              ),
+            );
+    } else {
+      feed = visible.isEmpty
+          ? _EmptyForFilter(filter: _filter, isLicensed: isLicensed)
+          : ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              itemCount: visible.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 2),
+              itemBuilder: (ctx, i) {
+                final b = visible[i];
+                return _BulletinRow(
+                  bulletin: b,
+                  onTap: () {
+                    if (!b.isRead) bulletins.markRead(b.id);
+                    Navigator.push(
+                      ctx,
+                      buildPlatformRoute(
+                        (_) => BulletinDetailScreen(bulletinId: b.id),
+                      ),
                     );
                   },
-                ),
+                );
+              },
+            );
+    }
+
+    return Stack(
+      children: [
+        Column(
+          children: [
+            if (showLocationBanner)
+              _LocationUnknownBanner(
+                onSetLocation: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'Open Settings → My Station to set your location. '
+                        'Direct hook lands in PR 5.',
+                      ),
+                    ),
+                  );
+                },
+              ),
+            _FilterChipRow(
+              current: _filter,
+              onChanged: (f) => setState(() => _filter = f),
+            ),
+            Expanded(child: feed),
+          ],
         ),
+        if (isLicensed)
+          Positioned(
+            right: 16,
+            bottom: 16,
+            child: FloatingActionButton.extended(
+              heroTag: 'bulletin_compose_fab',
+              icon: const Icon(Symbols.add),
+              label: const Text('New bulletin'),
+              onPressed: () => _openCompose(),
+            ),
+          ),
       ],
     );
+  }
+
+  Future<void> _openCompose({OutgoingBulletin? existing}) async {
+    await Navigator.push(
+      context,
+      buildPlatformRoute((_) => BulletinComposeScreen(existing: existing)),
+    );
+    // After returning, if user is viewing "My bulletins" the list should
+    // refresh — BulletinService notifies listeners on create/update so this
+    // is automatic via context.watch above.
   }
 
   /// Apply both the filter-chip choice and the location-aware scope gate.
@@ -332,6 +377,146 @@ class _LocationUnknownBanner extends StatelessWidget {
 // Empty states
 // ---------------------------------------------------------------------------
 
+class _OutgoingBulletinRow extends StatelessWidget {
+  const _OutgoingBulletinRow({
+    required this.bulletin,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onToggleEnabled,
+  });
+
+  final OutgoingBulletin bulletin;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final ValueChanged<bool> onToggleEnabled;
+
+  String _countdown(Duration d) {
+    if (d.isNegative) return 'now';
+    if (d.inSeconds < 60) return '${d.inSeconds}s';
+    if (d.inMinutes < 60) return '${d.inMinutes}m';
+    return '${d.inHours}h${d.inMinutes.remainder(60)}m';
+  }
+
+  String _intervalLabel() {
+    if (bulletin.isOneShot) return 'one-shot';
+    final s = bulletin.intervalSeconds;
+    if (s < 3600) return 'every ${s ~/ 60} min';
+    return 'every ${s ~/ 3600} hr';
+  }
+
+  String _nextTxLabel() {
+    if (!bulletin.enabled) return 'disabled';
+    final now = DateTime.now();
+    if (now.isAfter(bulletin.expiresAt)) return 'expired';
+    if (bulletin.isOneShot && bulletin.transmissionCount > 0) return 'sent';
+    final last = bulletin.lastTransmittedAt;
+    if (last == null) return 'next pulse: now';
+    final due = last.add(Duration(seconds: bulletin.intervalSeconds));
+    return 'next pulse in ${_countdown(due.difference(now))}';
+  }
+
+  String _transportsLabel() {
+    if (bulletin.viaRf && bulletin.viaAprsIs) return 'RF + IS';
+    if (bulletin.viaRf) return 'RF only';
+    return 'IS only';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final expired = DateTime.now().isAfter(bulletin.expiresAt);
+    final color = !bulletin.enabled || expired
+        ? theme.colorScheme.outline
+        : theme.colorScheme.primary;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 10, 6, 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Symbols.campaign, size: 18, color: color),
+                const SizedBox(width: 8),
+                Text(
+                  bulletin.addressee,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '· ${_intervalLabel()}',
+                  style: theme.textTheme.labelSmall,
+                ),
+                const Spacer(),
+                Text(_transportsLabel(), style: theme.textTheme.labelSmall),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(bulletin.body, maxLines: 2, overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                Text(
+                  '${bulletin.transmissionCount} sent · ${_nextTxLabel()}',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const Spacer(),
+                Switch.adaptive(
+                  value: bulletin.enabled,
+                  onChanged: expired ? null : onToggleEnabled,
+                ),
+                IconButton(
+                  icon: const Icon(Symbols.edit, size: 20),
+                  tooltip: 'Edit',
+                  onPressed: onEdit,
+                ),
+                IconButton(
+                  icon: const Icon(Symbols.delete, size: 20),
+                  tooltip: 'Delete',
+                  onPressed: () async {
+                    final confirm = await showDialog<bool>(
+                      context: context,
+                      builder: (ctx) => AlertDialog(
+                        title: const Text('Delete bulletin?'),
+                        content: Text(
+                          'Stop transmitting ${bulletin.addressee} and remove '
+                          'it from your list.',
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(ctx).pop(false),
+                            child: const Text('Cancel'),
+                          ),
+                          FilledButton(
+                            onPressed: () => Navigator.of(ctx).pop(true),
+                            style: FilledButton.styleFrom(
+                              backgroundColor: theme.colorScheme.error,
+                            ),
+                            child: const Text('Delete'),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirm == true) onDelete();
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _BulletinsDisabledState extends StatelessWidget {
   const _BulletinsDisabledState();
 
@@ -366,8 +551,9 @@ class _BulletinsDisabledState extends StatelessWidget {
 }
 
 class _EmptyForFilter extends StatelessWidget {
-  const _EmptyForFilter({required this.filter});
+  const _EmptyForFilter({required this.filter, required this.isLicensed});
   final _BulletinFilter filter;
+  final bool isLicensed;
 
   @override
   Widget build(BuildContext context) {
@@ -390,9 +576,10 @@ class _EmptyForFilter extends StatelessWidget {
             'Settings → Messaging → Bulletins.';
       case _BulletinFilter.mine:
         title = 'No bulletins from you';
-        body =
-            'Bulletins you transmit will appear here. Bulletin composition '
-            'ships in the next release.';
+        body = isLicensed
+            ? 'Tap "New bulletin" to compose one. Active bulletins will '
+                  'appear here with a retransmission countdown and a toggle.'
+            : 'An amateur radio license is required to transmit bulletins.';
     }
     return Center(
       child: Padding(

--- a/lib/screens/bulletins_tab.dart
+++ b/lib/screens/bulletins_tab.dart
@@ -584,7 +584,7 @@ class _EmptyForFilter extends StatelessWidget {
       case _BulletinFilter.groups:
         title = 'No group bulletins';
         body =
-            'Subscribe to named bulletin groups like WX or SRARC in '
+            'Subscribe to named bulletin groups like WX or CLUB in '
             'Settings → Messaging → Bulletins.';
       case _BulletinFilter.mine:
         title = 'No bulletins from you';

--- a/lib/screens/group_channel_screen.dart
+++ b/lib/screens/group_channel_screen.dart
@@ -6,9 +6,11 @@
 ///   - `group`  → "Message to GROUPNAME"  [Send]
 ///   - `sender` → "Reply to sender callsign"  [Send]  + secondary "Send to group"
 ///
-/// PR 3 stubs the send actions behind a SnackBar. PR 4 wires TX through
-/// `TxService` with `AprsEncoder.encodeGroupMessage` + the Advanced-mode
-/// Group message path.
+/// Replies route per the group's `replyMode`:
+/// - `group`  → broadcast back to the group via `MessageService.sendGroupMessage`
+/// - `sender` → direct 1:1 reply to the last-heard sender via
+///   `MessageService.sendMessage` (direct thread opens so the operator can
+///   watch the ACK).
 library;
 
 import 'package:flutter/material.dart';
@@ -18,6 +20,7 @@ import 'package:provider/provider.dart';
 import '../models/group_subscription.dart';
 import '../services/group_subscription_service.dart';
 import '../services/message_service.dart';
+import '../services/messaging_settings_service.dart';
 import '../services/station_settings_service.dart';
 import '../ui/utils/platform_route.dart';
 import 'message_thread_screen.dart';
@@ -119,39 +122,34 @@ class _GroupChannelScreenState extends State<GroupChannelScreen> {
             _GroupComposeBar(
               subscription: sub,
               lastSenderCallsign: lastIncoming?.fromCallsign,
-              onSendToGroup: _sendToGroupStub,
-              onSendToSender: _sendToSenderStub,
+              onSendToGroup: _sendToGroup,
+              onSendToSender: _sendToSender,
             ),
         ],
       ),
     );
   }
 
-  // --- Send stubs (PR 4 wires actual TX) ------------------------------------
+  // --- Send paths -----------------------------------------------------------
 
-  void _sendToGroupStub(String text) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          'Group send wired in PR 4 — would send "$text" to '
-          '${widget.groupName}.',
-        ),
-      ),
-    );
+  void _sendToGroup(String text) async {
+    final messaging = context.read<MessagingSettingsService>();
+    final messages = context.read<MessageService>();
+    final rfPath = messaging.effectiveGroupMessagePath
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList(growable: false);
+    await messages.sendGroupMessage(widget.groupName, text, rfPath: rfPath);
   }
 
-  void _sendToSenderStub(String text, String toCallsign) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          'Reply-to-sender wired in PR 4 — would send "$text" to '
-          '$toCallsign.',
-        ),
-      ),
-      // ignore: no_logic_in_create_state
-    );
-    // Provide a useful fallback even in PR 3: open the direct thread so
-    // the user can type a reply there immediately.
+  void _sendToSender(String text, String toCallsign) async {
+    // Reply-to-sender always routes through the direct-message path so the
+    // user sees ACK status and retries. Open the direct thread too so the
+    // reply is visible immediately.
+    final messages = context.read<MessageService>();
+    await messages.sendMessage(toCallsign, text);
+    if (!mounted) return;
     Navigator.push(
       context,
       buildPlatformRoute((_) => MessageThreadScreen(peerCallsign: toCallsign)),

--- a/lib/screens/group_channel_screen.dart
+++ b/lib/screens/group_channel_screen.dart
@@ -23,6 +23,7 @@ import '../services/message_service.dart';
 import '../services/messaging_settings_service.dart';
 import '../services/station_settings_service.dart';
 import '../ui/utils/platform_route.dart';
+import '../ui/widgets/chat_bubble.dart';
 import 'message_thread_screen.dart';
 
 class GroupChannelScreen extends StatefulWidget {
@@ -167,57 +168,16 @@ class _GroupBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isOutgoing = entry.isOutgoing;
-    final alignment = isOutgoing ? Alignment.centerRight : Alignment.centerLeft;
-    final bubbleColor = isOutgoing
-        ? theme.colorScheme.primaryContainer
-        : theme.colorScheme.surfaceContainerHighest;
-    final senderLabel = isOutgoing ? 'You' : (entry.fromCallsign ?? 'Unknown');
-
-    return Align(
-      alignment: alignment,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.78,
-        ),
-        child: Container(
-          margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-          padding: const EdgeInsets.fromLTRB(14, 8, 14, 10),
-          decoration: BoxDecoration(
-            color: bubbleColor,
-            borderRadius: BorderRadius.circular(18),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                senderLabel,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.primary,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(height: 2),
-              Text(entry.text),
-              const SizedBox(height: 4),
-              Text(
-                _formatTime(entry.timestamp),
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+    // Sender attribution on incoming only — outgoing messages are already
+    // right-aligned, so adding "You" is redundant and clutters the frame
+    // (matches direct-message thread convention).
+    final topLine = entry.isOutgoing ? null : entry.fromCallsign;
+    return ChatBubble(
+      text: entry.text,
+      timestamp: entry.timestamp,
+      isOutgoing: entry.isOutgoing,
+      topLine: topLine,
     );
-  }
-
-  String _formatTime(DateTime dt) {
-    final h = dt.hour.toString().padLeft(2, '0');
-    final m = dt.minute.toString().padLeft(2, '0');
-    return '$h:$m';
   }
 }
 

--- a/lib/screens/groups_tab.dart
+++ b/lib/screens/groups_tab.dart
@@ -93,6 +93,27 @@ class _GroupTile extends StatelessWidget {
       preview = last.text;
     }
 
+    final statusIcons = <Widget>[
+      if (!sub.enabled)
+        Tooltip(
+          message: 'Group disabled — incoming messages are not matched',
+          child: Icon(
+            Symbols.pause_circle,
+            size: 16,
+            color: theme.colorScheme.outline,
+          ),
+        ),
+      if (!sub.notify)
+        Tooltip(
+          message: 'Notifications off for this group',
+          child: Icon(
+            Symbols.notifications_off,
+            size: 16,
+            color: theme.colorScheme.outline,
+          ),
+        ),
+    ];
+
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
       clipBehavior: Clip.antiAlias,
@@ -116,13 +137,7 @@ class _GroupTile extends StatelessWidget {
                 ),
               ),
             ),
-            if (!sub.enabled)
-              Text(
-                'disabled',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.outline,
-                ),
-              ),
+            for (final w in statusIcons) ...[const SizedBox(width: 6), w],
           ],
         ),
         subtitle: preview == null

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -14,6 +14,7 @@ import '../core/callsign/callsign_utils.dart';
 import '../services/message_service.dart';
 import '../services/notification_service.dart';
 import '../services/station_settings_service.dart';
+import '../ui/widgets/chat_bubble.dart';
 
 // ---------------------------------------------------------------------------
 // Thread display items (message bubbles interleaved with day dividers)
@@ -187,14 +188,6 @@ class _MessageBubble extends StatelessWidget {
     return dashIdx == -1 ? upper : upper.substring(dashIdx);
   }
 
-  String _formatTime(DateTime dt) {
-    final diff = DateTime.now().difference(dt);
-    if (diff.inSeconds < 60) return 'just now';
-    if (diff.inMinutes < 60) return '${diff.inMinutes}m';
-    if (diff.inHours < 24) return '${diff.inHours}h';
-    return '${diff.inDays}d';
-  }
-
   Widget _statusIcon(BuildContext context, MessageStatus status, int retry) {
     return switch (status) {
       MessageStatus.pending => const Icon(Symbols.hourglass_empty, size: 14),
@@ -293,105 +286,23 @@ class _MessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final isOut = entry.isOutgoing;
 
-    final bgColor = isOut
-        ? theme.colorScheme.primary
-        : theme.colorScheme.secondaryContainer;
-    final fgColor = isOut
-        ? theme.colorScheme.onPrimary
-        : theme.colorScheme.onSecondaryContainer;
+    // Direct bubbles add a trailing slot for:
+    //   - cross-SSID addressee badge (incoming only)
+    //   - ACK / retry / failure status icon (outgoing only)
+    Widget? meta;
+    if (!isOut && entry.isCrossSsid(myAddr)) {
+      meta = _CrossSsidBadge(suffix: _ssidSuffix(entry.addressee!));
+    } else if (isOut) {
+      meta = _statusIcon(context, entry.status, entry.retryCount);
+    }
 
-    final bubble = Align(
-      alignment: isOut ? Alignment.centerRight : Alignment.centerLeft,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.72,
-        ),
-        child: Container(
-          margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: bgColor,
-            borderRadius: BorderRadius.only(
-              topLeft: const Radius.circular(16),
-              topRight: const Radius.circular(16),
-              bottomLeft: Radius.circular(isOut ? 16 : 4),
-              bottomRight: Radius.circular(isOut ? 4 : 16),
-            ),
-          ),
-          child: Column(
-            crossAxisAlignment: isOut
-                ? CrossAxisAlignment.end
-                : CrossAxisAlignment.start,
-            children: [
-              Text(entry.text, style: TextStyle(color: fgColor)),
-              const SizedBox(height: 4),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _formatTime(entry.timestamp),
-                    style: TextStyle(
-                      fontSize: 10,
-                      color: fgColor.withAlpha(160),
-                    ),
-                  ),
-                  if (!isOut && entry.isCrossSsid(myAddr)) ...[
-                    const SizedBox(width: 8),
-                    Tooltip(
-                      message: 'Addressed to ${entry.addressee}',
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 1,
-                        ),
-                        decoration: BoxDecoration(
-                          border: Border.all(
-                            color: fgColor.withAlpha(120),
-                            width: 0.5,
-                          ),
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        child: Text.rich(
-                          TextSpan(
-                            children: [
-                              TextSpan(
-                                text: 'to ',
-                                style: TextStyle(color: fgColor.withAlpha(150)),
-                              ),
-                              TextSpan(
-                                text: _ssidSuffix(entry.addressee!),
-                                style: TextStyle(
-                                  color: fgColor.withAlpha(220),
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ],
-                            style: const TextStyle(fontSize: 10),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                  if (isOut) ...[
-                    const SizedBox(width: 6),
-                    IconTheme(
-                      data: IconThemeData(color: fgColor.withAlpha(180)),
-                      child: _statusIcon(
-                        context,
-                        entry.status,
-                        entry.retryCount,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
+    final bubble = ChatBubble(
+      text: entry.text,
+      timestamp: entry.timestamp,
+      isOutgoing: isOut,
+      metaTrailing: meta,
     );
 
     // Only outgoing messages in an actionable state get the context menu.
@@ -407,6 +318,48 @@ class _MessageBubble extends StatelessWidget {
       // Desktop: right click
       onSecondaryTapUp: (d) => _showContextMenu(context, d.globalPosition),
       child: bubble,
+    );
+  }
+}
+
+/// Cross-SSID addressee indicator ("to -7") shown inside the meta slot of an
+/// incoming direct-message bubble. Picks its colour from the surrounding
+/// [DefaultTextStyle] / [IconTheme] so it blends with whichever bubble
+/// colour-scheme it lands in.
+class _CrossSsidBadge extends StatelessWidget {
+  const _CrossSsidBadge({required this.suffix});
+  final String suffix;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseColor = DefaultTextStyle.of(context).style.color ?? Colors.black;
+    return Tooltip(
+      message: 'Addressed to this SSID',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+        decoration: BoxDecoration(
+          border: Border.all(color: baseColor.withAlpha(120), width: 0.5),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(
+                text: 'to ',
+                style: TextStyle(color: baseColor.withAlpha(150)),
+              ),
+              TextSpan(
+                text: suffix,
+                style: TextStyle(
+                  color: baseColor.withAlpha(220),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+            style: const TextStyle(fontSize: 10),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/settings/category/messaging_screen.dart
+++ b/lib/screens/settings/category/messaging_screen.dart
@@ -116,7 +116,7 @@ class MessagingSettingsContent extends StatelessWidget {
         ListTile(
           leading: const Icon(Symbols.add),
           title: const Text('Add named group subscription'),
-          subtitle: const Text('e.g. WX, SRARC — up to 5 chars'),
+          subtitle: const Text('e.g. WX, CLUB — up to 5 chars'),
           onTap: () => _showBulletinSubscriptionAdder(context, bulletinSubs),
         ),
         if (advanced.isEnabled)
@@ -329,7 +329,7 @@ class _GroupEditorDialogState extends State<_GroupEditorDialog> {
               maxLength: 9,
               decoration: InputDecoration(
                 labelText: 'Name',
-                hintText: 'e.g. CQ, SRARC',
+                hintText: 'e.g. CQ, CLUB',
                 helperText: _isBuiltin
                     ? 'Built-in groups cannot be renamed'
                     : '1–9 uppercase letters / digits',
@@ -526,7 +526,7 @@ class _BulletinSubscriptionsList extends StatelessWidget {
         padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: Text(
           'No named-group subscriptions. Add one below to receive '
-          'bulletins like BLN1WX or BLN2SRARC.',
+          'bulletins like BLN1WX or BLN2CLUB.',
         ),
       );
     }
@@ -563,7 +563,7 @@ Future<void> _showBulletinSubscriptionAdder(
         maxLength: 5,
         decoration: const InputDecoration(
           labelText: 'Group name',
-          hintText: 'e.g. WX, SRARC',
+          hintText: 'e.g. WX, CLUB',
           helperText: '1–5 uppercase letters / digits',
         ),
       ),

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -397,6 +397,18 @@ class BackgroundServiceManager extends ChangeNotifier
         if (aprsLine != null) {
           _tx.sendViaTncOnly(aprsLine); // ignore: unawaited_futures
         }
+      case 'send_tnc_bulletin':
+        final aprsLine = msg['aprs_line'] as String?;
+        if (aprsLine != null) {
+          final pathRaw = msg['digipeater_path'];
+          final path = pathRaw is List
+              ? pathRaw.whereType<String>().toList(growable: false)
+              : null;
+          _tx.sendViaTncOnly(
+            aprsLine,
+            digipeaterPath: path,
+          ); // ignore: unawaited_futures
+        }
       case 'beacon_sent':
         break;
     }

--- a/lib/services/bulletin_scheduler.dart
+++ b/lib/services/bulletin_scheduler.dart
@@ -1,0 +1,159 @@
+/// Main-isolate scheduler for outgoing bulletin retransmission.
+///
+/// Ticks every 30 seconds. For each enabled [OutgoingBulletin]:
+///
+///   - `now > expiresAt`           → disable, fire `BulletinExpired` event.
+///   - one-shot already sent       → skip (stays idle until expiry).
+///   - `lastTransmittedAt == null` → **initial pulse** (transmit immediately).
+///   - `now - lastTransmittedAt >= intervalSeconds` → transmit.
+///
+/// See ADR-057. The background-isolate counterpart lives in
+/// `meridian_connection_task.dart` and reads the same `OutgoingBulletin` JSON
+/// from SharedPreferences on each fire (no IPC state sharing — same pattern
+/// as beacon settings).
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../core/packet/aprs_encoder.dart';
+import '../models/outgoing_bulletin.dart';
+import 'bulletin_service.dart';
+import 'messaging_settings_service.dart';
+import 'station_settings_service.dart';
+import 'tx_service.dart';
+
+/// Event emitted when a scheduler tick transitions an [OutgoingBulletin]
+/// from enabled to expired. Consumed by [NotificationService] in PR 5 to
+/// fire the "bulletin expired — repost?" notification.
+class BulletinExpiredEvent {
+  BulletinExpiredEvent(this.bulletin);
+  final OutgoingBulletin bulletin;
+}
+
+/// Event emitted on every successful transmission. Primarily a test hook
+/// today; PR 5 may use it to dedupe notification dispatch against the
+/// operator's own bulletins.
+class BulletinTransmittedEvent {
+  BulletinTransmittedEvent(this.bulletin, this.transmittedAt);
+  final OutgoingBulletin bulletin;
+  final DateTime transmittedAt;
+}
+
+class BulletinScheduler extends ChangeNotifier {
+  BulletinScheduler({
+    required BulletinService bulletins,
+    required TxService tx,
+    required MessagingSettingsService messagingSettings,
+    required StationSettingsService stationSettings,
+    Duration tickInterval = const Duration(seconds: 30),
+    DateTime Function()? clock,
+  }) : _bulletins = bulletins,
+       _tx = tx,
+       _messagingSettings = messagingSettings,
+       _stationSettings = stationSettings,
+       _tickInterval = tickInterval,
+       _clock = clock ?? DateTime.now;
+
+  final BulletinService _bulletins;
+  final TxService _tx;
+  final MessagingSettingsService _messagingSettings;
+  final StationSettingsService _stationSettings;
+  final Duration _tickInterval;
+  final DateTime Function() _clock;
+
+  final _eventController = StreamController<Object>.broadcast();
+  Timer? _timer;
+  bool _running = false;
+
+  /// True when the scheduler timer is active.
+  bool get isRunning => _running;
+
+  /// Stream of [BulletinExpiredEvent] / [BulletinTransmittedEvent] events.
+  Stream<Object> get events => _eventController.stream;
+
+  /// Start the periodic tick. Safe to call multiple times — no-op when
+  /// already running.
+  void start() {
+    if (_running) return;
+    _running = true;
+    _timer = Timer.periodic(_tickInterval, (_) => tick());
+    notifyListeners();
+  }
+
+  /// Stop the periodic tick. Safe to call when already stopped.
+  void stop() {
+    if (!_running) return;
+    _running = false;
+    _timer?.cancel();
+    _timer = null;
+    notifyListeners();
+  }
+
+  /// Run one scheduler pass. Public for tests and for the
+  /// background-isolate timer that calls through to the same logic via its
+  /// own copy of this method (it can't call this instance — different
+  /// isolate). Handles expiry first, then transmission.
+  Future<void> tick() async {
+    final now = _clock();
+    for (final ob in _bulletins.outgoingBulletins.toList()) {
+      if (!ob.enabled) continue;
+
+      // 1. Expiry sweep.
+      if (now.isAfter(ob.expiresAt)) {
+        await _bulletins.setOutgoingEnabled(ob.id, false);
+        _eventController.add(BulletinExpiredEvent(ob));
+        continue;
+      }
+
+      // 2. One-shot already sent — idle until expiry.
+      if (ob.isOneShot && ob.transmissionCount > 0) continue;
+
+      // 3. Initial pulse vs. interval retransmission.
+      final shouldTransmit =
+          ob.lastTransmittedAt == null ||
+          now.difference(ob.lastTransmittedAt!) >=
+              Duration(seconds: ob.intervalSeconds);
+      if (!shouldTransmit) continue;
+
+      await _transmit(ob, now);
+    }
+  }
+
+  Future<void> _transmit(OutgoingBulletin ob, DateTime now) async {
+    final callsign = _stationSettings.callsign.isEmpty
+        ? 'NOCALL'
+        : _stationSettings.callsign;
+    final line = AprsEncoder.encodeBulletin(
+      fromCallsign: callsign,
+      fromSsid: _stationSettings.ssid,
+      addressee: ob.addressee,
+      body: ob.body,
+    );
+    final rfPath = _messagingSettings.bulletinPath
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .toList(growable: false);
+    try {
+      await _tx.sendBulletin(
+        line,
+        viaRf: ob.viaRf,
+        viaAprsIs: ob.viaAprsIs,
+        rfPath: rfPath,
+      );
+      await _bulletins.recordOutgoingTransmission(ob.id, now);
+      _eventController.add(BulletinTransmittedEvent(ob, now));
+    } catch (e) {
+      debugPrint('BulletinScheduler: transmit id=${ob.id} failed: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    stop();
+    _eventController.close();
+    super.dispose();
+  }
+}

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -19,6 +19,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/packet/aprs_packet.dart';
 import '../models/bulletin.dart';
+import '../models/outgoing_bulletin.dart';
 import 'bulletin_subscription_service.dart';
 
 /// Outcome of [BulletinService.ingest], exposed for test assertions.
@@ -50,6 +51,25 @@ class BulletinService extends ChangeNotifier {
   static const _keyRadiusKm = 'bulletins_radius_km';
   static const _keyRetentionHours = 'bulletins_retention_hours';
 
+  /// SharedPreferences key holding the JSON-encoded list of
+  /// [OutgoingBulletin]s. Read directly by the background isolate's bulletin
+  /// timer (same pattern as beacon settings), so the key name is public.
+  static const keyOutgoingBulletins = 'outgoing_bulletins_v1';
+  static const _keyOutgoingNextId = 'outgoing_bulletins_next_id_v1';
+
+  /// Allowed TX-interval options (seconds). `0` = one-shot.
+  static const List<int> intervalOptionsSeconds = [
+    0,
+    300,
+    600,
+    900,
+    1800,
+    3600,
+  ];
+
+  /// Allowed expiry options (hours since creation).
+  static const List<int> expiryOptionsHours = [2, 6, 12, 24, 48];
+
   /// Allowed radius options (km). `0` is a sentinel for "Map area only" (no
   /// client-side distance filter — the APRS-IS area filter handles it).
   /// The `-1` sentinel means "Global" (no distance filter at all).
@@ -61,6 +81,10 @@ class BulletinService extends ChangeNotifier {
   // Keyed by "SOURCE|ADDRESSEE" for stable lookup.
   final Map<String, Bulletin> _bulletins = {};
   int _nextId = 1;
+
+  // Outgoing bulletins by id. Scheduler iterates this in-order per tick.
+  final Map<int, OutgoingBulletin> _outgoing = {};
+  int _outgoingNextId = 1;
 
   bool _showBulletins = true;
   int _radiusKm = 500;
@@ -87,9 +111,17 @@ class BulletinService extends ChangeNotifier {
 
   int get unreadCount => _bulletins.values.where((b) => !b.isRead).length;
 
+  /// All outgoing bulletins in insertion order (oldest first). The scheduler
+  /// iterates this list on each tick; the "My bulletins" UI renders it.
+  List<OutgoingBulletin> get outgoingBulletins =>
+      List.unmodifiable(_outgoing.values);
+
+  OutgoingBulletin? outgoingById(int id) => _outgoing[id];
+
   Future<void> load() async {
     final prefs = await _prefs();
     _nextId = prefs.getInt(_keyNextId) ?? 1;
+    _outgoingNextId = prefs.getInt(_keyOutgoingNextId) ?? 1;
     _showBulletins = prefs.getBool(_keyShowBulletins) ?? true;
     _radiusKm = prefs.getInt(_keyRadiusKm) ?? 500;
     _retentionHours = prefs.getInt(_keyRetentionHours) ?? 48;
@@ -104,7 +136,21 @@ class BulletinService extends ChangeNotifier {
           _bulletins[_key(b.sourceCallsign, b.addressee)] = b;
         }
       } catch (e) {
-        debugPrint('BulletinService: failed to decode: $e');
+        debugPrint('BulletinService: failed to decode bulletins: $e');
+      }
+    }
+    final outgoingRaw = prefs.getString(keyOutgoingBulletins);
+    if (outgoingRaw != null) {
+      try {
+        final list = (jsonDecode(outgoingRaw) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(OutgoingBulletin.fromJson);
+        _outgoing.clear();
+        for (final ob in list) {
+          _outgoing[ob.id] = ob;
+        }
+      } catch (e) {
+        debugPrint('BulletinService: failed to decode outgoing: $e');
       }
     }
     notifyListeners();
@@ -227,6 +273,157 @@ class BulletinService extends ChangeNotifier {
     notifyListeners();
   }
 
+  // ---------------------------------------------------------------------------
+  // OutgoingBulletin CRUD (v0.17, ADR-057)
+  // ---------------------------------------------------------------------------
+
+  /// Create a new outgoing bulletin. Starts enabled with `lastTransmittedAt`
+  /// null, so the scheduler fires an initial pulse on its next tick.
+  ///
+  /// [intervalSeconds] must be one of [intervalOptionsSeconds] (0 = one-shot).
+  /// [expiresAt] defaults to `createdAt + 24h` when not supplied.
+  /// Throws [ArgumentError] on invalid addressee or interval.
+  Future<OutgoingBulletin> createOutgoing({
+    required String addressee,
+    required String body,
+    int intervalSeconds = 1800,
+    DateTime? expiresAt,
+    bool viaRf = true,
+    bool viaAprsIs = true,
+  }) async {
+    if (!intervalOptionsSeconds.contains(intervalSeconds)) {
+      throw ArgumentError.value(
+        intervalSeconds,
+        'intervalSeconds',
+        'not a supported interval',
+      );
+    }
+    final normalized = addressee.trim().toUpperCase();
+    if (!_bulletinAddresseePattern.hasMatch(normalized)) {
+      throw ArgumentError.value(
+        addressee,
+        'addressee',
+        'invalid bulletin addressee — must be BLN[0-9A-Z][NAME]',
+      );
+    }
+    final now = DateTime.now();
+    final ob = OutgoingBulletin(
+      id: _outgoingNextId++,
+      addressee: normalized,
+      body: body,
+      intervalSeconds: intervalSeconds,
+      expiresAt: expiresAt ?? now.add(const Duration(hours: 24)),
+      createdAt: now,
+      viaRf: viaRf,
+      viaAprsIs: viaAprsIs,
+      enabled: true,
+    );
+    _outgoing[ob.id] = ob;
+    await _persist();
+    notifyListeners();
+    return ob;
+  }
+
+  /// Update the body and/or addressee of an outgoing bulletin. Per ADR-057
+  /// this resets `lastTransmittedAt` and `transmissionCount` so the scheduler
+  /// fires a fresh initial pulse on its next tick.
+  Future<void> updateOutgoingContent(
+    int id, {
+    String? addressee,
+    String? body,
+  }) async {
+    final current = _outgoing[id];
+    if (current == null) return;
+    String? nextAddressee;
+    if (addressee != null) {
+      final normalized = addressee.trim().toUpperCase();
+      if (!_bulletinAddresseePattern.hasMatch(normalized)) {
+        throw ArgumentError.value(addressee, 'addressee', 'invalid');
+      }
+      nextAddressee = normalized;
+    }
+    _outgoing[id] = current.copyWith(
+      addressee: nextAddressee,
+      body: body,
+      clearLastTransmittedAt: true,
+      transmissionCount: 0,
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Update the schedule (interval, expiry, transport flags). Does NOT reset
+  /// `lastTransmittedAt` or `transmissionCount` — this is the explicit contract
+  /// per ADR-057 (changing when/where to retransmit ≠ re-sending the body).
+  Future<void> updateOutgoingSchedule(
+    int id, {
+    int? intervalSeconds,
+    DateTime? expiresAt,
+    bool? viaRf,
+    bool? viaAprsIs,
+  }) async {
+    final current = _outgoing[id];
+    if (current == null) return;
+    if (intervalSeconds != null &&
+        !intervalOptionsSeconds.contains(intervalSeconds)) {
+      throw ArgumentError.value(
+        intervalSeconds,
+        'intervalSeconds',
+        'not a supported interval',
+      );
+    }
+    _outgoing[id] = current.copyWith(
+      intervalSeconds: intervalSeconds,
+      expiresAt: expiresAt,
+      viaRf: viaRf,
+      viaAprsIs: viaAprsIs,
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Enable or disable an outgoing bulletin without editing content/schedule.
+  Future<void> setOutgoingEnabled(int id, bool enabled) async {
+    final current = _outgoing[id];
+    if (current == null) return;
+    if (current.enabled == enabled) return;
+    _outgoing[id] = current.copyWith(enabled: enabled);
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Delete an outgoing bulletin permanently.
+  Future<void> deleteOutgoing(int id) async {
+    if (_outgoing.remove(id) == null) return;
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Called by [BulletinScheduler] after a successful transmission. Bumps the
+  /// counter and stamps `lastTransmittedAt`.
+  Future<void> recordOutgoingTransmission(int id, DateTime timestamp) async {
+    final current = _outgoing[id];
+    if (current == null) return;
+    _outgoing[id] = current.copyWith(
+      lastTransmittedAt: timestamp,
+      transmissionCount: current.transmissionCount + 1,
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  /// Matches bulletin addressees per APRS spec §3.2.16 — `BLN` + a line
+  /// number (`0`–`9` or `A`–`Z`), optionally followed by a 1–5 char group
+  /// name. Total length capped at 9 by the wire format (matcher further
+  /// enforces this via padding/truncation in [AprsEncoder]).
+  static final RegExp _bulletinAddresseePattern = RegExp(
+    r'^BLN[0-9A-Z][A-Z0-9]{0,5}$',
+  );
+
+  // ---------------------------------------------------------------------------
+  // Retention sweeper
+  // ---------------------------------------------------------------------------
+
   /// Drop all bulletins whose `lastHeardAt` is older than [retention].
   /// Call from a periodic sweeper (added in PR 5 along with the notification
   /// pipeline).
@@ -252,5 +449,10 @@ class BulletinService extends ChangeNotifier {
       jsonEncode(_bulletins.values.map((b) => b.toJson()).toList()),
     );
     await prefs.setInt(_keyNextId, _nextId);
+    await prefs.setString(
+      keyOutgoingBulletins,
+      jsonEncode(_outgoing.values.map((ob) => ob.toJson()).toList()),
+    );
+    await prefs.setInt(_keyOutgoingNextId, _outgoingNextId);
   }
 }

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
@@ -8,6 +9,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../core/credentials/credential_key.dart';
 import '../core/credentials/secure_credential_store.dart';
 import '../core/packet/aprs_encoder.dart';
+import '../models/outgoing_bulletin.dart';
+import 'bulletin_service.dart';
+import 'messaging_settings_service.dart';
 
 /// Entry point called by flutter_foreground_task when the foreground service
 /// starts. Runs in the background isolate.
@@ -39,12 +43,20 @@ void startMeridianConnectionTask() {
 /// independent of the main isolate's APRS-IS socket.
 class MeridianConnectionTask extends TaskHandler {
   Timer? _beaconTimer;
+  Timer? _bulletinTimer;
   int? _lastBeaconTs; // ms since epoch; null until first beacon this session
+
+  /// Bulletin scheduler tick interval in the background isolate. Matches the
+  /// main-isolate `BulletinScheduler` cadence so schedule math is consistent.
+  static const _bulletinTickSeconds = 30;
 
   @override
   Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
-    // Intentionally empty. Beacon timer starts only on explicit
-    // 'start_beaconing' message from the main isolate (sent on app pause).
+    // Beacon timer starts only on explicit 'start_beaconing' message from
+    // the main isolate. The bulletin timer, in contrast, runs unconditionally
+    // while the foreground service is alive — bulletins are independently
+    // scheduled per row (ADR-057) and don't need a main-isolate handshake.
+    _scheduleNextBulletinTick();
   }
 
   @override
@@ -84,6 +96,7 @@ class MeridianConnectionTask extends TaskHandler {
   @override
   Future<void> onDestroy(DateTime timestamp) async {
     _beaconTimer?.cancel();
+    _bulletinTimer?.cancel();
   }
 
   // ---------------------------------------------------------------------------
@@ -276,6 +289,147 @@ class MeridianConnectionTask extends TaskHandler {
       await socket.flush();
     } finally {
       socket?.destroy();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulletin scheduling (v0.17, ADR-057)
+  // ---------------------------------------------------------------------------
+  //
+  // Runs while the foreground service is alive so bulletins keep transmitting
+  // after the screen locks. The loop reads `OutgoingBulletin` list from
+  // SharedPreferences on every tick (same pattern as beacon settings) and
+  // writes back state updates — the main isolate's `BulletinService` holds
+  // stale in-memory copies during background phase but re-syncs from prefs
+  // on UI refresh / app resume.
+  //
+  // RF transport requests are forwarded to the main isolate via IPC (the
+  // TNC connection lives there). APRS-IS transport uses the same short-lived
+  // TCP connection helper as the beacon path.
+
+  void _scheduleNextBulletinTick() {
+    _bulletinTimer?.cancel();
+    _bulletinTimer = Timer(
+      const Duration(seconds: _bulletinTickSeconds),
+      _onBulletinTick,
+    );
+  }
+
+  void _onBulletinTick() {
+    _processOutgoingBulletins().whenComplete(_scheduleNextBulletinTick);
+  }
+
+  Future<void> _processOutgoingBulletins() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+
+    final raw = prefs.getString(BulletinService.keyOutgoingBulletins);
+    if (raw == null || raw.isEmpty) return;
+
+    final List<OutgoingBulletin> outgoing;
+    try {
+      outgoing = (jsonDecode(raw) as List<dynamic>)
+          .cast<Map<String, dynamic>>()
+          .map(OutgoingBulletin.fromJson)
+          .toList();
+    } catch (_) {
+      return;
+    }
+    if (outgoing.isEmpty) return;
+
+    final callsign = (prefs.getString('user_callsign') ?? '').toUpperCase();
+    if (callsign.isEmpty) return;
+    final ssid = prefs.getInt('user_ssid') ?? 0;
+
+    final bulletinPath =
+        (prefs.getString('messaging_bulletin_path') ??
+                MessagingSettingsService.defaultBulletinPath)
+            .split(',')
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .toList(growable: false);
+
+    String? passcode;
+    Future<String> passcodeGetter() async {
+      if (passcode != null) return passcode!;
+      try {
+        final v = await FlutterSecureCredentialStore().read(
+          CredentialKey.aprsIsPasscode,
+        );
+        passcode = (v == null || v.isEmpty) ? '-1' : v;
+      } catch (_) {
+        passcode = '-1';
+      }
+      return passcode!;
+    }
+
+    var mutated = false;
+    final now = DateTime.now();
+    for (var i = 0; i < outgoing.length; i++) {
+      final ob = outgoing[i];
+      if (!ob.enabled) continue;
+
+      // Expiry → disable.
+      if (now.isAfter(ob.expiresAt)) {
+        outgoing[i] = ob.copyWith(enabled: false);
+        mutated = true;
+        continue;
+      }
+
+      if (ob.isOneShot && ob.transmissionCount > 0) continue;
+
+      final shouldTx =
+          ob.lastTransmittedAt == null ||
+          now.difference(ob.lastTransmittedAt!) >=
+              Duration(seconds: ob.intervalSeconds);
+      if (!shouldTx) continue;
+
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: callsign,
+        fromSsid: ssid,
+        addressee: ob.addressee,
+        body: ob.body,
+      );
+      var transmitted = false;
+
+      if (ob.viaAprsIs) {
+        try {
+          await _sendToAprsIs(
+            callsign: callsign,
+            ssid: ssid,
+            passcode: await passcodeGetter(),
+            line: line,
+          );
+          transmitted = true;
+        } catch (_) {
+          // APRS-IS failed — fall through to RF path.
+        }
+      }
+      if (ob.viaRf) {
+        // RF goes through the main isolate's TNC connection. This IPC queues
+        // if the main isolate is suspended and delivers when it resumes.
+        FlutterForegroundTask.sendDataToMain({
+          'type': 'send_tnc_bulletin',
+          'aprs_line': line,
+          'digipeater_path': bulletinPath,
+        });
+        transmitted = true;
+      }
+
+      if (transmitted) {
+        outgoing[i] = ob.copyWith(
+          lastTransmittedAt: now,
+          transmissionCount: ob.transmissionCount + 1,
+        );
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      await prefs.setString(
+        BulletinService.keyOutgoingBulletins,
+        jsonEncode(outgoing.map((ob) => ob.toJson()).toList()),
+      );
     }
   }
 }

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -289,6 +289,53 @@ class MessageService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Send a group message to [groupName]. Group messages are never ACKed
+  /// (ADR-055) — no retry scheduler, no wire ID. The outgoing entry is
+  /// appended to the group's conversation thread so the user sees it echoed
+  /// in the channel view (spec §6.6).
+  ///
+  /// [rfPath] overrides the default digipeater path for RF dispatch; null
+  /// uses the encoder's hardcoded default. Callers (the group compose bar)
+  /// pass `MessagingSettingsService.effectiveGroupMessagePath` split into a
+  /// list.
+  Future<void> sendGroupMessage(
+    String groupName,
+    String text, {
+    List<String>? rfPath,
+  }) async {
+    final normalized = groupName.trim().toUpperCase();
+    if (normalized.isEmpty) return;
+
+    final line = AprsEncoder.encodeGroupMessage(
+      fromCallsign: _settings.callsign.isEmpty ? 'NOCALL' : _settings.callsign,
+      fromSsid: _settings.ssid,
+      groupName: normalized,
+      body: text,
+    );
+    await _tx.sendLine(line, digipeaterPath: rfPath);
+
+    // Own-SSID echo — append to group conversation so the operator sees
+    // their own send in the channel view. No wireId, no retry loop.
+    final localId =
+        'group_${normalized}_'
+        '${DateTime.now().millisecondsSinceEpoch}';
+    final entry = MessageEntry(
+      localId: localId,
+      wireId: null,
+      text: text,
+      timestamp: DateTime.now(),
+      isOutgoing: true,
+      category: MessageCategory.group,
+      groupName: normalized,
+      status: MessageStatus.acked, // groups have no ACK; mark as "delivered".
+    );
+    final conv = _getOrCreateConversation(_groupConvKey(normalized));
+    conv.messages.add(entry);
+    conv.lastActivity = entry.timestamp;
+    notifyListeners();
+    await _persist();
+  }
+
   /// Send a message to [toCallsign].
   ///
   /// Creates a conversation if one doesn't exist. Starts the retry scheduler.

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -67,15 +67,73 @@ class TxService extends ChangeNotifier {
   /// When [forceVia] is provided, the first connected connection of that type
   /// is used; otherwise the hierarchy (Serial > BLE > APRS-IS) is applied.
   ///
+  /// [digipeaterPath] overrides the default digipeater aliases when the
+  /// effective connection is RF (BLE or Serial). APRS-IS connections ignore
+  /// this. Used by v0.17 group-message / bulletin send.
+  ///
   /// No-op when the user is unlicensed — TX is unconditionally blocked.
-  Future<void> sendLine(String aprsLine, {ConnectionType? forceVia}) async {
+  Future<void> sendLine(
+    String aprsLine, {
+    ConnectionType? forceVia,
+    List<String>? digipeaterPath,
+  }) async {
     if (!_settings.isLicensed) {
       debugPrint('[TxService] TX rejected: unlicensed mode');
       return;
     }
     final conn = _effectiveConnection(forceVia: forceVia);
     if (conn == null) return;
-    await conn.sendLine(aprsLine);
+    await conn.sendLine(aprsLine, digipeaterPath: digipeaterPath);
+  }
+
+  /// Send a bulletin packet honoring the per-bulletin transport flags. Unlike
+  /// [sendLine], this does *not* use the Serial > BLE > APRS-IS hierarchy —
+  /// bulletins can independently go via RF, APRS-IS, or both, per the user's
+  /// `viaRf` / `viaAprsIs` settings on each `OutgoingBulletin` (ADR-057).
+  ///
+  /// When [viaRf] is true, the first live TNC (Serial preferred over BLE)
+  /// receives the line with [rfPath] as the digipeater path. When [viaAprsIs]
+  /// is true, the APRS-IS connection receives the line (paths ignored). If
+  /// both are true and both are connected, the line goes to both.
+  Future<void> sendBulletin(
+    String aprsLine, {
+    required bool viaRf,
+    required bool viaAprsIs,
+    List<String>? rfPath,
+  }) async {
+    if (!_settings.isLicensed) {
+      debugPrint('[TxService] bulletin TX rejected: unlicensed mode');
+      return;
+    }
+    if (viaAprsIs) {
+      final conn = _registry.all
+          .where((c) => c.type == ConnectionType.aprsIs && c.isConnected)
+          .firstOrNull;
+      if (conn != null) {
+        try {
+          await conn.sendLine(aprsLine);
+        } catch (e) {
+          debugPrint('TxService: bulletin via APRS-IS failed: $e');
+        }
+      }
+    }
+    if (viaRf) {
+      final conn = _registry.all
+          .where(
+            (c) =>
+                (c.type == ConnectionType.serialTnc ||
+                    c.type == ConnectionType.bleTnc) &&
+                c.isConnected,
+          )
+          .firstOrNull;
+      if (conn != null) {
+        try {
+          await conn.sendLine(aprsLine, digipeaterPath: rfPath);
+        } catch (e) {
+          debugPrint('TxService: bulletin via RF (${conn.id}) failed: $e');
+        }
+      }
+    }
   }
 
   /// Fan out [aprsLine] to every connection where
@@ -104,8 +162,12 @@ class TxService extends ChangeNotifier {
   /// Send [aprsLine] to the first connected TNC (Serial takes priority over BLE).
   ///
   /// Used by [BackgroundServiceManager] to forward background-isolate IPC
-  /// beacon requests to the live TNC connection.
-  Future<void> sendViaTncOnly(String aprsLine) async {
+  /// beacon/bulletin requests to the live TNC connection. [digipeaterPath]
+  /// overrides the default digipeater aliases (bulletins use WIDE2-2).
+  Future<void> sendViaTncOnly(
+    String aprsLine, {
+    List<String>? digipeaterPath,
+  }) async {
     final conn = _registry.all
         .where(
           (c) =>
@@ -115,7 +177,7 @@ class TxService extends ChangeNotifier {
         )
         .firstOrNull;
     if (conn != null) {
-      await conn.sendLine(aprsLine);
+      await conn.sendLine(aprsLine, digipeaterPath: digipeaterPath);
     }
   }
 

--- a/lib/ui/widgets/chat_bubble.dart
+++ b/lib/ui/widgets/chat_bubble.dart
@@ -1,0 +1,133 @@
+/// Shared chat bubble used by both the direct-message thread view and the
+/// group channel view. Visual frame (shape, colors, alignment, timestamp) is
+/// identical across both surfaces; per-surface extras ride in optional slots:
+///
+///   - [topLine]      — sender attribution (group channels only).
+///   - [metaTrailing] — status icon, cross-SSID badge, etc. (direct only).
+///
+/// Does NOT own gesture handling. Callers wrap in a [GestureDetector] or
+/// similar when they need long-press/right-click menus (direct context menu).
+library;
+
+import 'package:flutter/material.dart';
+
+class ChatBubble extends StatelessWidget {
+  const ChatBubble({
+    super.key,
+    required this.text,
+    required this.timestamp,
+    required this.isOutgoing,
+    this.topLine,
+    this.metaTrailing,
+    this.maxWidthFactor = 0.75,
+  });
+
+  /// Message body.
+  final String text;
+
+  final DateTime timestamp;
+
+  /// True when this message is from the operator — renders with the primary
+  /// colour on the right.
+  final bool isOutgoing;
+
+  /// Optional leading line above the body, rendered in accent colour and
+  /// semibold. Use for sender attribution in group channels.
+  final String? topLine;
+
+  /// Optional widget rendered inline with the timestamp (right of it on
+  /// outgoing, left of it on incoming). Use for status icons or badges.
+  final Widget? metaTrailing;
+
+  /// Max bubble width as a fraction of available screen width.
+  final double maxWidthFactor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isOut = isOutgoing;
+
+    final bgColor = isOut
+        ? theme.colorScheme.primary
+        : theme.colorScheme.secondaryContainer;
+    final fgColor = isOut
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.onSecondaryContainer;
+
+    return Align(
+      alignment: isOut ? Alignment.centerRight : Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * maxWidthFactor,
+        ),
+        child: Container(
+          margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(16),
+              topRight: const Radius.circular(16),
+              bottomLeft: Radius.circular(isOut ? 16 : 4),
+              bottomRight: Radius.circular(isOut ? 4 : 16),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: isOut
+                ? CrossAxisAlignment.end
+                : CrossAxisAlignment.start,
+            children: [
+              if (topLine != null) ...[
+                Text(
+                  topLine!,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    // Slightly lighter than the body so it reads as a label.
+                    color: fgColor.withAlpha(200),
+                  ),
+                ),
+                const SizedBox(height: 2),
+              ],
+              Text(text, style: TextStyle(color: fgColor)),
+              const SizedBox(height: 4),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _formatTime(timestamp),
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: fgColor.withAlpha(160),
+                    ),
+                  ),
+                  if (metaTrailing != null) ...[
+                    const SizedBox(width: 6),
+                    IconTheme(
+                      data: IconThemeData(color: fgColor.withAlpha(180)),
+                      child: DefaultTextStyle.merge(
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: fgColor.withAlpha(180),
+                        ),
+                        child: metaTrailing!,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _formatTime(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m';
+    if (diff.inHours < 24) return '${diff.inHours}h';
+    return '${diff.inDays}d';
+  }
+}

--- a/test/core/callsign/addressee_matcher_test.dart
+++ b/test/core/callsign/addressee_matcher_test.dart
@@ -58,15 +58,15 @@ void main() {
       expect(info.groupName, isNull);
     });
 
-    test('bulletin beats named-overlap group (BLN1SRARC + SRARC group)', () {
+    test('bulletin beats named-overlap group (BLN1CLUB + CLUB group)', () {
       final identity = _operator('W1ABC', 7);
-      final subs = [_group(1, 'SRARC')];
-      final result = _classify('BLN1SRARC', identity, subs);
+      final subs = [_group(1, 'CLUB')];
+      final result = _classify('BLN1CLUB', identity, subs);
       expect(result, isA<BulletinClassification>());
       final info = (result as BulletinClassification).info;
       expect(info.category, BulletinCategory.groupNamed);
       expect(info.lineNumber, '1');
-      expect(info.groupName, 'SRARC');
+      expect(info.groupName, 'CLUB');
     });
 
     test('direct beats group prefix conflict (W1ABC-7 + group W1 prefix)', () {
@@ -197,13 +197,13 @@ void main() {
       expect(info.groupName, isNull);
     });
 
-    test('named bulletin with letter line parses correctly (BLNASRARC)', () {
-      final result = _classify('BLNASRARC', _operator('W1ABC', 7), []);
+    test('named bulletin with letter line parses correctly (BLNACLUB)', () {
+      final result = _classify('BLNACLUB', _operator('W1ABC', 7), []);
       expect(result, isA<BulletinClassification>());
       final info = (result as BulletinClassification).info;
       expect(info.category, BulletinCategory.groupNamed);
       expect(info.lineNumber, 'A');
-      expect(info.groupName, 'SRARC');
+      expect(info.groupName, 'CLUB');
     });
   });
 }

--- a/test/core/packet/aprs_encoder_test.dart
+++ b/test/core/packet/aprs_encoder_test.dart
@@ -306,14 +306,15 @@ void main() {
       expect(line, isNot(contains('{')));
     });
 
-    test('pads longer names (SRARC) correctly', () {
+    test('pads longer names (CLUB) correctly', () {
       final line = AprsEncoder.encodeGroupMessage(
         fromCallsign: 'W1ABC',
         fromSsid: 7,
-        groupName: 'SRARC',
+        groupName: 'CLUB',
         body: 'club chatter',
       );
-      expect(line, contains('::SRARC    :club chatter'));
+      // CLUB is 4 chars → 5 trailing spaces to reach the 9-char pad.
+      expect(line, contains('::CLUB     :club chatter'));
     });
 
     test('uppercases group name', () {

--- a/test/core/packet/aprs_encoder_test.dart
+++ b/test/core/packet/aprs_encoder_test.dart
@@ -226,4 +226,114 @@ void main() {
       );
     });
   });
+
+  group('encodeBulletin (v0.17, ADR-057)', () {
+    test('pads general BLN addressee to 9 chars and omits wire ID', () {
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        addressee: 'BLN0',
+        body: 'Severe wx alert',
+      );
+      expect(line, contains('::BLN0     :Severe wx alert'));
+      // No message-ID suffix.
+      expect(line, isNot(contains('{')));
+    });
+
+    test('pads named-group addressee to 9 chars', () {
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        addressee: 'BLN1WX',
+        body: 'Radar update',
+      );
+      expect(line, contains('::BLN1WX   :Radar update'));
+    });
+
+    test('uppercases the addressee', () {
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 0,
+        addressee: 'bln1wx',
+        body: 'foo',
+      );
+      expect(line, contains('::BLN1WX   :foo'));
+    });
+
+    test('source header respects SSID = 0 (no trailing -0)', () {
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 0,
+        addressee: 'BLN0',
+        body: 'test',
+      );
+      expect(line, startsWith('W1ABC>'));
+      expect(line, isNot(contains('W1ABC-0>')));
+    });
+
+    test('includes TCPIP* path for APRS-IS', () {
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        addressee: 'BLN0',
+        body: 'test',
+      );
+      expect(line, contains(',TCPIP*:'));
+    });
+
+    test('truncates oversize addressee to 9 chars', () {
+      // BLN9TOOLONG = 11 chars; must truncate to 9.
+      final line = AprsEncoder.encodeBulletin(
+        fromCallsign: 'W1ABC',
+        fromSsid: 0,
+        addressee: 'BLN9TOOLONG',
+        body: 'x',
+      );
+      expect(line, contains('::BLN9TOOLO:x'));
+    });
+  });
+
+  group('encodeGroupMessage (v0.17, ADR-056)', () {
+    test('pads group name to 9 chars and omits wire ID', () {
+      final line = AprsEncoder.encodeGroupMessage(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        groupName: 'CQ',
+        body: 'CQ CQ — anyone on freq?',
+      );
+      expect(line, contains('::CQ       :CQ CQ — anyone on freq?'));
+      // No message-ID suffix — groups are never ACKed (ADR-055).
+      expect(line, isNot(contains('{')));
+    });
+
+    test('pads longer names (SRARC) correctly', () {
+      final line = AprsEncoder.encodeGroupMessage(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        groupName: 'SRARC',
+        body: 'club chatter',
+      );
+      expect(line, contains('::SRARC    :club chatter'));
+    });
+
+    test('uppercases group name', () {
+      final line = AprsEncoder.encodeGroupMessage(
+        fromCallsign: 'W1ABC',
+        fromSsid: 7,
+        groupName: 'cq',
+        body: 'x',
+      );
+      expect(line, contains('::CQ       :x'));
+    });
+
+    test('includes TCPIP* path', () {
+      final line = AprsEncoder.encodeGroupMessage(
+        fromCallsign: 'W1ABC',
+        fromSsid: 0,
+        groupName: 'QST',
+        body: 'x',
+      );
+      expect(line, contains(',TCPIP*:'));
+    });
+  });
 }

--- a/test/helpers/fake_meridian_connection.dart
+++ b/test/helpers/fake_meridian_connection.dart
@@ -57,7 +57,14 @@ class FakeMeridianConnection extends MeridianConnection {
   Stream<String> get lines => _linesController.stream;
 
   @override
-  Future<void> sendLine(String aprsLine) async {}
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
+    lastSentLine = aprsLine;
+    lastSentDigipeaterPath = digipeaterPath;
+  }
+
+  /// Test helpers: records the most recent call for assertion.
+  String? lastSentLine;
+  List<String>? lastSentDigipeaterPath;
 
   @override
   Future<void> connect() async => setStatus(ConnectionStatus.connected);

--- a/test/services/bulletin_scheduler_test.dart
+++ b/test/services/bulletin_scheduler_test.dart
@@ -1,0 +1,347 @@
+/// Tests for BulletinScheduler (v0.17 PR 4, ADR-057).
+///
+/// Uses a controllable clock closure to drive ticks without wall-clock
+/// waits. The tx path is stubbed via a recording TxService.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/bulletin_scheduler.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/messaging_settings_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Recording TxService — captures sendBulletin calls for assertion.
+// ---------------------------------------------------------------------------
+
+class _RecordedSend {
+  _RecordedSend(this.line, this.viaRf, this.viaAprsIs, this.rfPath);
+  final String line;
+  final bool viaRf;
+  final bool viaAprsIs;
+  final List<String>? rfPath;
+}
+
+class _RecordingTxService extends TxService {
+  _RecordingTxService(super.registry, super.settings, this.sends);
+  final List<_RecordedSend> sends;
+
+  @override
+  Future<void> sendBulletin(
+    String aprsLine, {
+    required bool viaRf,
+    required bool viaAprsIs,
+    List<String>? rfPath,
+  }) async {
+    sends.add(_RecordedSend(aprsLine, viaRf, viaAprsIs, rfPath));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class _Fixture {
+  _Fixture._({
+    required this.scheduler,
+    required this.bulletins,
+    required this.sends,
+    required this.clock,
+  });
+
+  final BulletinScheduler scheduler;
+  final BulletinService bulletins;
+  final List<_RecordedSend> sends;
+  final _MutableClock clock;
+
+  static Future<_Fixture> create({
+    DateTime? startAt,
+    String bulletinPath = 'WIDE2-2',
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1ABC',
+      'user_ssid': 7,
+      'user_is_licensed': true,
+      'messaging_bulletin_path': bulletinPath,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    final registry = ConnectionRegistry();
+    final subs = BulletinSubscriptionService(prefs: prefs);
+    await subs.load();
+    final bulletins = BulletinService(subscriptions: subs, prefs: prefs);
+    await bulletins.load();
+    final messaging = MessagingSettingsService(prefs: prefs);
+    await messaging.load();
+
+    final sends = <_RecordedSend>[];
+    final tx = _RecordingTxService(registry, settings, sends);
+    final clock = _MutableClock(startAt ?? DateTime(2026, 4, 24, 12, 0, 0));
+
+    final scheduler = BulletinScheduler(
+      bulletins: bulletins,
+      tx: tx,
+      messagingSettings: messaging,
+      stationSettings: settings,
+      tickInterval: const Duration(seconds: 30),
+      clock: clock.call,
+    );
+
+    return _Fixture._(
+      scheduler: scheduler,
+      bulletins: bulletins,
+      sends: sends,
+      clock: clock,
+    );
+  }
+}
+
+class _MutableClock {
+  _MutableClock(this._now);
+  DateTime _now;
+
+  DateTime call() => _now;
+
+  void advance(Duration d) {
+    _now = _now.add(d);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('initial pulse', () {
+    test('fires on the first tick after a bulletin is created', () async {
+      final f = await _Fixture.create();
+      await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'Weather alert',
+        intervalSeconds: 1800,
+      );
+      expect(f.sends, isEmpty);
+
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+      expect(f.sends.first.line, contains('::BLN0     :Weather alert'));
+      expect(f.sends.first.rfPath, ['WIDE2-2']);
+    });
+  });
+
+  group('interval retransmission', () {
+    test('second transmission fires after intervalSeconds', () async {
+      final f = await _Fixture.create();
+      await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 600, // 10 minutes
+      );
+
+      // Initial pulse.
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      // 5 minutes in — too early.
+      f.clock.advance(const Duration(minutes: 5));
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      // 10 minutes in — due.
+      f.clock.advance(const Duration(minutes: 5));
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(2));
+    });
+  });
+
+  group('one-shot', () {
+    test('transmits exactly once', () async {
+      final f = await _Fixture.create();
+      await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 0, // one-shot
+      );
+
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      // Many more ticks with time advancing — should stay at 1.
+      for (var i = 0; i < 10; i++) {
+        f.clock.advance(const Duration(hours: 1));
+        await f.scheduler.tick();
+      }
+      expect(f.sends, hasLength(1));
+    });
+  });
+
+  group('expiry', () {
+    test(
+      'expired bulletin is disabled and fires BulletinExpiredEvent',
+      () async {
+        final f = await _Fixture.create();
+        final expiresAt = f.clock().add(const Duration(hours: 1));
+        final ob = await f.bulletins.createOutgoing(
+          addressee: 'BLN0',
+          body: 'test',
+          intervalSeconds: 1800,
+          expiresAt: expiresAt,
+        );
+
+        final events = <Object>[];
+        f.scheduler.events.listen(events.add);
+
+        // Initial pulse.
+        await f.scheduler.tick();
+        expect(f.sends, hasLength(1));
+
+        // Advance past expiry.
+        f.clock.advance(const Duration(hours: 2));
+        await f.scheduler.tick();
+
+        // No new transmission, expired event fired, row disabled.
+        expect(f.sends, hasLength(1));
+        await Future<void>.delayed(Duration.zero);
+        expect(events.whereType<BulletinExpiredEvent>(), hasLength(1));
+        expect(f.bulletins.outgoingById(ob.id)!.enabled, isFalse);
+      },
+    );
+  });
+
+  group('edit semantics', () {
+    test('editing body resets state — initial pulse on next tick', () async {
+      final f = await _Fixture.create();
+      final ob = await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'old',
+        intervalSeconds: 1800,
+      );
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      // 5 min in — below interval, no TX.
+      f.clock.advance(const Duration(minutes: 5));
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      // Edit body. Per ADR-057 this resets state.
+      await f.bulletins.updateOutgoingContent(ob.id, body: 'new');
+      expect(f.bulletins.outgoingById(ob.id)!.lastTransmittedAt, isNull);
+      expect(f.bulletins.outgoingById(ob.id)!.transmissionCount, 0);
+
+      // Next tick — initial pulse of new body, even though only 5 min elapsed.
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(2));
+      expect(f.sends.last.line, contains(':new'));
+    });
+
+    test('editing interval only does NOT reset state', () async {
+      final f = await _Fixture.create();
+      final ob = await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'body',
+        intervalSeconds: 1800,
+      );
+      await f.scheduler.tick(); // initial pulse
+      expect(f.sends, hasLength(1));
+      final originalLastTx = f.bulletins.outgoingById(ob.id)!.lastTransmittedAt;
+      expect(originalLastTx, isNotNull);
+
+      // Change interval — state preserved.
+      await f.bulletins.updateOutgoingSchedule(ob.id, intervalSeconds: 600);
+      final after = f.bulletins.outgoingById(ob.id)!;
+      expect(after.lastTransmittedAt, originalLastTx);
+      expect(after.transmissionCount, 1);
+      expect(after.intervalSeconds, 600);
+
+      // 5 min advance → now interval has passed under the new schedule.
+      f.clock.advance(const Duration(minutes: 11));
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(2));
+    });
+  });
+
+  group('enable/disable + delete', () {
+    test('disabled bulletin does not transmit', () async {
+      final f = await _Fixture.create();
+      final ob = await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 1800,
+      );
+      await f.bulletins.setOutgoingEnabled(ob.id, false);
+
+      await f.scheduler.tick();
+      f.clock.advance(const Duration(hours: 1));
+      await f.scheduler.tick();
+      expect(f.sends, isEmpty);
+    });
+
+    test('deleted bulletin stops transmitting', () async {
+      final f = await _Fixture.create();
+      final ob = await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 600,
+      );
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+
+      await f.bulletins.deleteOutgoing(ob.id);
+      f.clock.advance(const Duration(hours: 1));
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+    });
+  });
+
+  group('transport flags', () {
+    test('viaRf=false + viaAprsIs=true sends only via IS', () async {
+      final f = await _Fixture.create();
+      await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 0,
+        viaRf: false,
+        viaAprsIs: true,
+      );
+      await f.scheduler.tick();
+      expect(f.sends, hasLength(1));
+      expect(f.sends.first.viaRf, isFalse);
+      expect(f.sends.first.viaAprsIs, isTrue);
+    });
+
+    test('rfPath honors Advanced-mode setting', () async {
+      final f = await _Fixture.create(bulletinPath: 'WIDE1-1,WIDE2-2');
+      await f.bulletins.createOutgoing(
+        addressee: 'BLN0',
+        body: 'test',
+        intervalSeconds: 0,
+      );
+      await f.scheduler.tick();
+      expect(f.sends.first.rfPath, ['WIDE1-1', 'WIDE2-2']);
+    });
+  });
+
+  group('start/stop lifecycle', () {
+    test('start() registers a periodic timer, stop() cancels it', () async {
+      final f = await _Fixture.create();
+      expect(f.scheduler.isRunning, isFalse);
+      f.scheduler.start();
+      expect(f.scheduler.isRunning, isTrue);
+      f.scheduler.stop();
+      expect(f.scheduler.isRunning, isFalse);
+    });
+  });
+}

--- a/test/services/group_subscription_service_test.dart
+++ b/test/services/group_subscription_service_test.dart
@@ -70,8 +70,8 @@ void main() {
       final service = GroupSubscriptionService(prefs: prefs);
       await service.load();
 
-      final srarc = await service.add(name: 'SRARC');
-      expect(srarc.name, 'SRARC');
+      final srarc = await service.add(name: 'CLUB');
+      expect(srarc.name, 'CLUB');
       expect(srarc.isBuiltin, isFalse);
       // Custom default is reply-to-group.
       expect(srarc.replyMode, ReplyMode.group);
@@ -79,13 +79,13 @@ void main() {
       // Persist across service instance.
       final reloaded = GroupSubscriptionService(prefs: prefs);
       await reloaded.load();
-      expect(reloaded.subscriptions.any((s) => s.name == 'SRARC'), isTrue);
+      expect(reloaded.subscriptions.any((s) => s.name == 'CLUB'), isTrue);
 
       // Delete.
       await reloaded.delete(srarc.id);
       final after = GroupSubscriptionService(prefs: prefs);
       await after.load();
-      expect(after.subscriptions.any((s) => s.name == 'SRARC'), isFalse);
+      expect(after.subscriptions.any((s) => s.name == 'CLUB'), isFalse);
     });
 
     test('rejects invalid name', () async {

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -98,8 +98,11 @@ class _RecordingTxService extends TxService {
   final List<String> _log;
 
   @override
-  Future<void> sendLine(String line, {ConnectionType? forceVia}) async =>
-      _log.add(line);
+  Future<void> sendLine(
+    String line, {
+    ConnectionType? forceVia,
+    List<String>? digipeaterPath,
+  }) async => _log.add(line);
 }
 
 // Helper: shove an APRS-IS message line through the ingest pipeline.

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -92,8 +92,11 @@ class _RecordingTxService extends TxService {
   final List<String> _log;
 
   @override
-  Future<void> sendLine(String line, {ConnectionType? forceVia}) async =>
-      _log.add(line);
+  Future<void> sendLine(
+    String line, {
+    ConnectionType? forceVia,
+    List<String>? digipeaterPath,
+  }) async => _log.add(line);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -119,7 +119,11 @@ class _SilentTxService extends TxService {
   _SilentTxService(super.registry, super.settings);
 
   @override
-  Future<void> sendLine(String line, {ConnectionType? forceVia}) async {}
+  Future<void> sendLine(
+    String line, {
+    ConnectionType? forceVia,
+    List<String>? digipeaterPath,
+  }) async {}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/services/send_group_message_test.dart
+++ b/test/services/send_group_message_test.dart
@@ -1,0 +1,140 @@
+/// Tests for `MessageService.sendGroupMessage` (v0.17 PR 4, ADR-056).
+///
+/// Verifies wire-format, digipeater path override, no wire ID, and own-SSID
+/// echo into the group conversation.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/models/message_category.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:meridian_aprs/services/group_subscription_service.dart';
+import 'package:meridian_aprs/services/message_service.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../helpers/fake_secure_credential_store.dart';
+
+class _SendCapture {
+  _SendCapture(this.line, this.digipeaterPath, this.forceVia);
+  final String line;
+  final List<String>? digipeaterPath;
+  final ConnectionType? forceVia;
+}
+
+class _CapturingTxService extends TxService {
+  _CapturingTxService(super.registry, super.settings, this.sends);
+  final List<_SendCapture> sends;
+
+  @override
+  Future<void> sendLine(
+    String aprsLine, {
+    ConnectionType? forceVia,
+    List<String>? digipeaterPath,
+  }) async {
+    sends.add(_SendCapture(aprsLine, digipeaterPath, forceVia));
+  }
+}
+
+Future<MessageService> _buildService({
+  required List<_SendCapture> sends,
+}) async {
+  SharedPreferences.setMockInitialValues({
+    'user_callsign': 'W1ABC',
+    'user_ssid': 7,
+    'user_is_licensed': true,
+  });
+  final prefs = await SharedPreferences.getInstance();
+  final settings = StationSettingsService(
+    prefs,
+    store: FakeSecureCredentialStore(),
+  );
+  final registry = ConnectionRegistry();
+  final tx = _CapturingTxService(registry, settings, sends);
+
+  final groups = GroupSubscriptionService(prefs: prefs);
+  await groups.load();
+  final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+  await bulletinSubs.load();
+  final bulletins = BulletinService(subscriptions: bulletinSubs, prefs: prefs);
+  await bulletins.load();
+
+  return MessageService(
+    settings,
+    tx,
+    StationService(),
+    groupSubscriptions: groups,
+    bulletins: bulletins,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('encodes group message with correct pad and no wire ID', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage('CQ', 'CQ CQ — anyone on freq?');
+
+    expect(sends, hasLength(1));
+    final line = sends.first.line;
+    expect(line, contains('::CQ       :CQ CQ — anyone on freq?'));
+    // No wire ID — groups are never ACKed.
+    expect(line, isNot(contains('{')));
+  });
+
+  test('threads digipeater path override through to sendLine', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage(
+      'SRARC',
+      'Net starting',
+      rfPath: const ['WIDE1-1', 'WIDE2-1'],
+    );
+    expect(sends.first.digipeaterPath, ['WIDE1-1', 'WIDE2-1']);
+  });
+
+  test('null rfPath passes null through (encoder default applies)', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage('CQ', 'x');
+    expect(sends.first.digipeaterPath, isNull);
+  });
+
+  test('appends own-SSID echo to the group conversation', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage('CQ', 'hello group');
+
+    final conv = service.conversationForGroup('CQ');
+    expect(conv, isNotNull);
+    expect(conv!.messages, hasLength(1));
+    final entry = conv.messages.first;
+    expect(entry.isOutgoing, isTrue);
+    expect(entry.text, 'hello group');
+    expect(entry.category, MessageCategory.group);
+    expect(entry.groupName, 'CQ');
+    // No wire ID — mirrors the wire format.
+    expect(entry.wireId, isNull);
+    // Marked as delivered (no ACK to wait for).
+    expect(entry.status, MessageStatus.acked);
+  });
+
+  test('empty group name is a no-op', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage('', 'x');
+    expect(sends, isEmpty);
+  });
+
+  test('uppercases the group name before encoding', () async {
+    final sends = <_SendCapture>[];
+    final service = await _buildService(sends: sends);
+    await service.sendGroupMessage('cq', 'x');
+    expect(sends.first.line, contains('::CQ       :x'));
+  });
+}

--- a/test/services/send_group_message_test.dart
+++ b/test/services/send_group_message_test.dart
@@ -91,7 +91,7 @@ void main() {
     final sends = <_SendCapture>[];
     final service = await _buildService(sends: sends);
     await service.sendGroupMessage(
-      'SRARC',
+      'CLUB',
       'Net starting',
       rfPath: const ['WIDE1-1', 'WIDE2-1'],
     );

--- a/test/services/tx_service_unlicensed_test.dart
+++ b/test/services/tx_service_unlicensed_test.dart
@@ -231,7 +231,7 @@ class _TrackingFakeConnection extends FakeMeridianConnection {
   final List<String> sentLines;
 
   @override
-  Future<void> sendLine(String aprsLine) async {
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
     sentLines.add(aprsLine);
   }
 }

--- a/test/widget/messages/messages_screen_test.dart
+++ b/test/widget/messages/messages_screen_test.dart
@@ -61,6 +61,7 @@ class _Harness {
   static Future<_Harness> create({
     bool licensed = true,
     bool manualLocation = false,
+    bool useGps = false,
     bool aprsIsConnected = false,
     bool showBulletinsEnabled = true,
   }) async {
@@ -68,6 +69,10 @@ class _Harness {
       'user_callsign': 'W1ABC',
       'user_ssid': 7,
       'user_is_licensed': licensed,
+      // Default to manual source so the `manualLocation=false` test path
+      // exercises the "location unknown" banner. GPS mode is opt-in via
+      // the `useGps` flag.
+      'user_location_source': useGps ? 0 : 1,
     });
     final prefs = await SharedPreferences.getInstance();
     final settings = StationSettingsService(
@@ -247,6 +252,22 @@ void main() {
       final h = await _Harness.create(
         aprsIsConnected: true,
         manualLocation: true,
+      );
+      await tester.pumpWidget(h.wrap(const MessagesScreen()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Bulletins'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('station location is not set'), findsNothing);
+    });
+
+    testWidgets('banner hidden when locationSource is GPS', (tester) async {
+      // GPS users have an implicit location (fix obtained on demand when
+      // bulletins transmit). The banner should never fire for them.
+      final h = await _Harness.create(
+        aprsIsConnected: true,
+        manualLocation: false,
+        useGps: true,
       );
       await tester.pumpWidget(h.wrap(const MessagesScreen()));
       await tester.pumpAndSettle();

--- a/test/widget/messages/messages_screen_test.dart
+++ b/test/widget/messages/messages_screen_test.dart
@@ -331,12 +331,12 @@ void main() {
       tester,
     ) async {
       final h = await _Harness.create();
-      await h.groupSubs.add(name: 'SRARC'); // defaults to replyMode.group
+      await h.groupSubs.add(name: 'CLUB'); // defaults to replyMode.group
       await tester.pumpWidget(
-        h.wrap(const GroupChannelScreen(groupName: 'SRARC')),
+        h.wrap(const GroupChannelScreen(groupName: 'CLUB')),
       );
       await tester.pumpAndSettle();
-      expect(find.text('Message to SRARC'), findsWidgets);
+      expect(find.text('Message to CLUB'), findsWidgets);
     });
 
     testWidgets('missing subscription renders the fallback bar', (


### PR DESCRIPTION
## Summary

Fourth of five PRs for v0.17 (Group Messaging & Bulletins). Lights up the **send path** end-to-end: bulletin scheduling, group message transmission, wire-format encoders, and the compose UI for both.

- `AprsEncoder.encodeBulletin` + `encodeGroupMessage` — 9-char space-padded addressee, no wire ID (groups / bulletins are never ACKed per ADR-055/056).
- `BulletinScheduler` — main-isolate `ChangeNotifier`, 30 s tick, injectable clock. Handles initial pulse, interval re-TX, one-shot semantics, expiry → disable + notify, edit-body-resets-count, edit-interval-only-doesn't-reset (ADR-057).
- Background isolate (`MeridianConnectionTask`) runs a parallel 30 s bulletin timer that reads `OutgoingBulletin` list from SharedPreferences on every tick, transmits via APRS-IS directly (short-lived TCP) and forwards RF via IPC (`send_tnc_bulletin`) — same pattern as beacon scheduling.
- `MessageService.sendGroupMessage` + `conversationForGroup` / `groupConversations` / `totalGroupUnread` accessors; `#GROUP:<NAME>` keying.
- `MeridianConnection.sendLine` extended with optional `digipeaterPath`; BLE/Serial thread it through to `Ax25Encoder.buildAprsFrame`; APRS-IS ignores it (no digipeater concept on IS).
- Compose UI: group channel adaptive compose (Message-to-group vs Reply-to-sender + secondary \"Send to group instead\"); bulletin compose form (Type → Slot → Body → Interval → Expires → via RF / via APRS-IS); \"My bulletins\" section with countdown + transmission count + edit/delete.
- Post-test UX polish (c954b8b): location-unknown banner gated on manual-location + no-manual-position (no more false banner for GPS users); group tile status row (pause_circle + notifications_off icons instead of \"disabled\" text); Set-location button now pushes into settings content; \"Line number\" renamed to \"Slot\" with helper text.
- Chore (254de33): swept real club name SRARC in examples/hints/docs to generic `CLUB` — Meridian is vendor-neutral.
- Refactor (ffc8166): extracted shared `ChatBubble` widget — direct and group bubbles now render identically; slot-based API (`topLine`, `metaTrailing`) keeps per-surface extras pluggable.

## Files of note

- `lib/core/packet/aprs_encoder.dart` — `encodeBulletin`, `encodeGroupMessage`
- `lib/services/bulletin_scheduler.dart` — new, main-isolate tick
- `lib/services/bulletin_service.dart` — extended with `OutgoingBulletin` CRUD + public `keyOutgoingBulletins` so the background isolate can read/write directly
- `lib/services/meridian_connection_task.dart` — bulletin timer in background isolate
- `lib/services/background_service_manager.dart` — `send_tnc_bulletin` IPC case
- `lib/services/tx_service.dart` — `sendBulletin` fan-out, `sendLine` gained `digipeaterPath`
- `lib/services/message_service.dart` — `sendGroupMessage`, group accessors, `#GROUP:<NAME>` keying
- `lib/core/connection/meridian_connection.dart` + `aprs_is/ble/serial_connection*.dart` — `sendLine` signature extended
- `lib/screens/group_channel_screen.dart`, `lib/screens/bulletins_tab.dart`, `lib/screens/bulletin_compose_screen.dart`, `lib/screens/message_thread_screen.dart`, `lib/ui/widgets/chat_bubble.dart`
- `docs/DECISIONS.md` — ADR-057 (bulletin transmission model) moved to Accepted

## Related ADRs

- **ADR-055** (PR 1) — matcher precedence Bulletin → Direct → Group
- **ADR-056** (PR 1) — group messaging architecture
- **ADR-057** (this PR) — bulletin transmission model (fixed interval + initial pulse + max lifetime)

## Test plan

- [x] `flutter test` — 574 passing
- [x] `flutter analyze` clean
- [x] `dart format .` clean
- [x] Scheduler behavior: initial pulse; second TX after interval; one-shot fires once; expired → stops + notifies; edit body resets count; edit interval-only does not reset; delete stops; disabled doesn't TX
- [x] Encoder padding / format for both bulletin and group message (9-char addressee, no wire ID)
- [x] On-device: created outgoing bulletin at 15-min interval; verified initial pulse on APRS-IS; verified second TX at 15 min; edit body → count resets
- [x] On-device: group message send to CQ / custom group; own-SSID echo renders in group view
- [x] On-device: chat bubble visual parity between direct and group surfaces

## Known limitations

- Main-isolate `BulletinService` holds stale in-memory state while backgrounded; re-syncs from prefs on UI refresh / app resume. Acceptable until v0.15 drift migration (noted in ADR-057).
- Background APRS-IS RX reliability is an existing limitation unrelated to this PR — tracked as #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)