### PR TITLE
fix(parser): accept position ambiguity in uncompressed lat/lon (#80)

### DIFF
--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -68,6 +68,12 @@ class PositionPacket extends AprsPacket {
   /// or null if unknown.
   final String? device;
 
+  /// APRS 1.0.1 §6 position ambiguity level (0–4). 0 = full precision; higher
+  /// values indicate the operator rounded to a coarser grid by replacing
+  /// trailing mantissa digits with spaces. The decoded [lat]/[lon] sit at the
+  /// centre of the ambiguity box.
+  final int positionAmbiguity;
+
   const PositionPacket({
     required super.rawLine,
     required super.source,
@@ -86,6 +92,7 @@ class PositionPacket extends AprsPacket {
     required this.hasMessaging,
     this.timestamp,
     this.device,
+    this.positionAmbiguity = 0,
   });
 }
 
@@ -214,6 +221,12 @@ class ObjectPacket extends AprsPacket {
   /// or null if unknown.
   final String? device;
 
+  /// APRS 1.0.1 §6 position ambiguity level (0–4). 0 = full precision; higher
+  /// values indicate the originating station rounded to a coarser grid by
+  /// replacing trailing mantissa digits with spaces. The decoded [lat]/[lon]
+  /// sit at the centre of the ambiguity box.
+  final int positionAmbiguity;
+
   const ObjectPacket({
     required super.rawLine,
     required super.source,
@@ -229,6 +242,7 @@ class ObjectPacket extends AprsPacket {
     required this.comment,
     required this.isAlive,
     this.device,
+    this.positionAmbiguity = 0,
   });
 }
 
@@ -253,6 +267,12 @@ class ItemPacket extends AprsPacket {
   /// or null if unknown.
   final String? device;
 
+  /// APRS 1.0.1 §6 position ambiguity level (0–4). 0 = full precision; higher
+  /// values indicate the originating station rounded to a coarser grid by
+  /// replacing trailing mantissa digits with spaces. The decoded [lat]/[lon]
+  /// sit at the centre of the ambiguity box.
+  final int positionAmbiguity;
+
   const ItemPacket({
     required super.rawLine,
     required super.source,
@@ -268,6 +288,7 @@ class ItemPacket extends AprsPacket {
     required this.comment,
     required this.isAlive,
     this.device,
+    this.positionAmbiguity = 0,
   });
 }
 

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -303,8 +303,15 @@ class AprsParser {
 
   // Uncompressed position regex.
   // Groups: (lat DDMM.HH)(N|S)(symTable)(lon DDDMM.HH)(E|W)(symCode)(comment)
+  //
+  // Per APRS 1.0.1 §6 the four trailing digits of the lat (and longitude)
+  // mantissa may be replaced with spaces to indicate position ambiguity,
+  // working leftward from the last digit. The character classes here accept
+  // either a digit or a space at every ambiguity-eligible position; the
+  // permissive form (rather than enforcing strict leftward order) matches
+  // aprslib and Dire Wolf behaviour.
   static final _uncompressedPosRe = RegExp(
-    r'^(\d{4}\.\d{2})(N|S)(.)(\d{5}\.\d{2})(E|W)(.)(.*)$',
+    r'^(\d{2}[\d ]{2}\.[\d ]{2})(N|S)(.)(\d{3}[\d ]{2}\.[\d ]{2})(E|W)(.)(.*)$',
     dotAll: true,
   );
 
@@ -446,6 +453,7 @@ class AprsParser {
 
     final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
     final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final ambiguity = _ambiguityLevel(m.group(1)!);
     final symbolTable = m.group(3)!;
     final symbolCode = m.group(6)!;
     var comment = m.group(7)!;
@@ -492,6 +500,7 @@ class AprsParser {
       hasMessaging: hasMessaging,
       timestamp: packetTimestamp,
       device: DeviceResolver.resolve(tocall: destination),
+      positionAmbiguity: ambiguity,
     );
   }
 
@@ -692,7 +701,25 @@ class AprsParser {
     final posStr = info.substring(18);
     final m = _uncompressedPosRe.firstMatch(posStr);
     if (m == null) {
-      // Try compressed
+      // Uncompressed positions (with or without ambiguity) always start with a
+      // digit (DDMM.HH). If posStr[0] is a digit, the uncompressed regex was
+      // the correct path — falling through to the compressed decoder would
+      // emit a misleading error. Only attempt compressed when the leading
+      // byte looks like a base-91 symbol-table char (`/`, `\`, A–Z, 0–9
+      // overlay).  Digits at index 0 of a compressed posStr are extremely
+      // rare (overlay codes are usually letters), so erring on the side of a
+      // clearer uncompressed error message is the right tradeoff.
+      if (posStr.isNotEmpty && _isUncompressedPos(posStr)) {
+        return _unknown(
+          rawLine,
+          source,
+          destination,
+          path,
+          'Object uncompressed position regex did not match',
+          rawInfo: info,
+          transportSource: transportSource,
+        );
+      }
       return _tryObjectCompressed(
         posStr: posStr,
         objectName: objectName,
@@ -709,6 +736,7 @@ class AprsParser {
 
     final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
     final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final ambiguity = _ambiguityLevel(m.group(1)!);
 
     return ObjectPacket(
       rawLine: rawLine,
@@ -725,6 +753,7 @@ class AprsParser {
       comment: m.group(7)!,
       isAlive: isAlive,
       device: DeviceResolver.resolve(tocall: destination),
+      positionAmbiguity: ambiguity,
     );
   }
 
@@ -860,6 +889,7 @@ class AprsParser {
 
     final lat = _ddmm(m.group(1)!, isLat: true) * (m.group(2) == 'S' ? -1 : 1);
     final lon = _ddmm(m.group(4)!, isLat: false) * (m.group(5) == 'W' ? -1 : 1);
+    final ambiguity = _ambiguityLevel(m.group(1)!);
 
     return ItemPacket(
       rawLine: rawLine,
@@ -876,6 +906,7 @@ class AprsParser {
       comment: m.group(7)!,
       isAlive: isAlive,
       device: DeviceResolver.resolve(tocall: destination),
+      positionAmbiguity: ambiguity,
     );
   }
 
@@ -1467,10 +1498,27 @@ class AprsParser {
   // ---------------------------------------------------------------------------
 
   /// Convert DDMM.HH string to decimal degrees.
+  ///
+  /// Spaces in the mantissa (APRS 1.0.1 §6 position ambiguity) are replaced
+  /// with `'5'` before parsing so the decoded position sits near the centre
+  /// of the ambiguity box — same convention as aprslib and Dire Wolf.
   double _ddmm(String s, {required bool isLat}) {
+    final s2 = s.replaceAll(' ', '5');
     final d = isLat ? 2 : 3;
-    return double.parse(s.substring(0, d)) +
-        double.parse(s.substring(d)) / 60.0;
+    return double.parse(s2.substring(0, d)) +
+        double.parse(s2.substring(d)) / 60.0;
+  }
+
+  /// Count APRS 1.0.1 §6 position-ambiguity spaces in the lat mantissa.
+  ///
+  /// Returns 0–4. The spec guarantees lat and lon carry the same level of
+  /// ambiguity so deriving from lat alone is sufficient.
+  static int _ambiguityLevel(String latMantissa) {
+    int n = 0;
+    for (int i = 0; i < latMantissa.length; i++) {
+      if (latMantissa.codeUnitAt(i) == 0x20) n++;
+    }
+    return n > 4 ? 4 : n;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -417,13 +417,18 @@ class AprsParser {
   }
 
   /// Heuristic to distinguish uncompressed from compressed position strings.
-  /// Uncompressed lat always begins with a digit (DDMM.HH pattern).
+  ///
+  /// Uncompressed lat is always `DDMM.HH` — first byte is a digit AND byte
+  /// index 4 is a literal `.`. Checking only "starts with a digit" is
+  /// insufficient because APRS 1.0.1 §6 / `symbolsX.txt` permits digit
+  /// overlays (`\0`, `\8`, `\9`, etc.) on the alternate symbol table — these
+  /// are emitted by IRLP/Echolink nodes, 802.11 nodes, gas-station markers,
+  /// and other deployed senders. A digit-overlay compressed position would
+  /// otherwise be misrouted to the uncompressed parser and silently dropped.
   bool _isUncompressedPos(String posStr) {
-    if (posStr.isEmpty) return false;
-    // Skip the symbol table char at index 0 for compressed; for uncompressed
-    // the entire posStr is the position data starting with digit.
-    // Uncompressed posStr starts with digits like '4903.50N...'
-    return posStr[0].codeUnitAt(0) >= 0x30 && posStr[0].codeUnitAt(0) <= 0x39;
+    if (posStr.length < 5) return false;
+    final c0 = posStr.codeUnitAt(0);
+    return c0 >= 0x30 && c0 <= 0x39 && posStr.codeUnitAt(4) == 0x2E;
   }
 
   AprsPacket _parseUncompressedPosition({

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1516,6 +1516,41 @@ void main() {
       });
     });
 
+    // Compressed positions may use digit overlays (\0, \8, \9, …) on the
+    // alternate symbol table — IRLP/Echolink, 802.11 nodes, gas stations,
+    // etc. The discriminator that decides "uncompressed vs. compressed" must
+    // not misroute these to the uncompressed parser. Without this fix they
+    // were silently dropped (PositionPacket call site) or reported as
+    // "Object uncompressed position regex did not match" (Object call site).
+    group('digit-overlay compressed positions route correctly', () {
+      test('digit-0 overlay compressed PositionPacket decodes', () {
+        // Same payload as the canonical '/5L!!<*e7>7P[' compressed test, with
+        // the symbol-table char swapped to '0' (alternate-table digit-0 overlay).
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:=05L!!<*e7>7P[Test',
+        );
+        expect(p.symbolTable, equals('0'));
+      });
+
+      test('digit-9 overlay compressed PositionPacket decodes', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:=95L!!<*e7>7P[Test',
+        );
+        expect(p.symbolTable, equals('9'));
+      });
+
+      test('digit-overlay compressed ObjectPacket decodes', () {
+        // Object name (9 chars) + alive '*' + 7-char timestamp + compressed
+        // position with digit overlay. The new "uncompressed-shaped" error
+        // branch added in this PR must not catch this.
+        final p = expectPacketType<ObjectPacket>(
+          'N0CALL>APRS:;TESTOBJ  *251245z05L!!<*e7>7P[Test',
+        );
+        expect(p.symbolTable, equals('0'));
+        expect(p.objectName, equals('TESTOBJ'));
+      });
+    });
+
     group('Object error reporting', () {
       // Was previously misreported as "Object compressed position decode
       // failed" because the uncompressed regex was too strict and execution

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1403,4 +1403,134 @@ void main() {
       expect(p.message, equals('REJ001'));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Issue #80: Position ambiguity (APRS 1.0.1 §6)
+  // ---------------------------------------------------------------------------
+
+  group('Position ambiguity (APRS 1.0.1 §6)', () {
+    group('PositionPacket DTI !', () {
+      test('no ambiguity → level 0', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.50N/07201.75W-Test',
+        );
+        expect(p.positionAmbiguity, equals(0));
+        expect(p.lat, closeTo(49.0583, 0.001));
+        expect(p.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('ambiguity 1 (last hundredth space) decodes to centre', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!4903.5 N/07201.7 W-Test',
+        );
+        expect(p.positionAmbiguity, equals(1));
+        // 4903.55 → 49 + 3.55/60 = 49.05917
+        expect(p.lat, closeTo(49.0592, 0.001));
+        expect(p.lon, closeTo(-72.0292, 0.001));
+      });
+
+      test('ambiguity 2 (both hundredths spaces) decodes to centre of box', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!3646.  N/07617.  W-Test',
+        );
+        expect(p.positionAmbiguity, equals(2));
+        // 3646.55 → 36 + 46.55/60 = 36.77583
+        expect(p.lat, closeTo(36.776, 0.001));
+        // 07617.55 → -(76 + 17.55/60) = -76.2925
+        expect(p.lon, closeTo(-76.2925, 0.001));
+      });
+
+      test('ambiguity 3 (units of minute also space) decodes', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!364 .  N/0761 .  W-Test',
+        );
+        expect(p.positionAmbiguity, equals(3));
+        // 3645.55 → 36 + 45.55/60 = 36.75917
+        expect(p.lat, closeTo(36.759, 0.001));
+      });
+
+      test('ambiguity 4 (degrees only) decodes', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:!36  .  N/076  .  W-Test',
+        );
+        expect(p.positionAmbiguity, equals(4));
+        // 3655.55 → 36 + 55.55/60 = 36.92583
+        expect(p.lat, closeTo(36.926, 0.001));
+      });
+    });
+
+    group('PositionPacket DTI = (messaging)', () {
+      test('ambiguity preserved with messaging DTI', () {
+        final p = expectPacketType<PositionPacket>(
+          'WB4APR-14>APWW10:=3855.  N/07701.  W-Direwolf',
+        );
+        expect(p.positionAmbiguity, equals(2));
+        expect(p.hasMessaging, isTrue);
+      });
+    });
+
+    group('PositionPacket DTI / (timestamped)', () {
+      test('ambiguity preserved with timestamp', () {
+        final p = expectPacketType<PositionPacket>(
+          'N0CALL>APRS:/221509z3646.  N/07617.  W-Test',
+        );
+        expect(p.positionAmbiguity, equals(2));
+        expect(p.timestamp, isNotNull);
+      });
+    });
+
+    group('ObjectPacket DTI ;', () {
+      // Real-world wire packet from issue #80 — Winlink RMS gateway with
+      // tenth-of-minute ambiguity (APRS 1.0.1 §6).
+      test('Winlink WLNK-1 ambiguous Object decodes to ObjectPacket', () {
+        final p = expectPacketType<ObjectPacket>(
+          'WINLINK>APWL2K,TCPIP*,qAS,WLNK-1:;N4CEC-10 *251245z3646.  N'
+          'W07617.  Wa440.450MHz Winlink VARA FM Wide Gateway',
+        );
+        expect(p.positionAmbiguity, equals(2));
+        expect(p.objectName, equals('N4CEC-10'));
+        expect(p.isAlive, isTrue);
+        expect(p.lat, closeTo(36.776, 0.001));
+        expect(p.lon, closeTo(-76.2925, 0.001));
+        expect(p.symbolTable, equals('W'));
+        expect(p.symbolCode, equals('a'));
+      });
+
+      test('full-precision Object retains ambiguity 0', () {
+        final p = expectPacketType<ObjectPacket>(
+          'N0CALL>APRS:;TESTOBJ  *251245z3646.78N/07617.34W-Comment',
+        );
+        expect(p.positionAmbiguity, equals(0));
+      });
+    });
+
+    group('ItemPacket DTI )', () {
+      test('ambiguous Item decodes with ambiguity tracked', () {
+        final p = expectPacketType<ItemPacket>(
+          'N0CALL>APRS:)TESTITM!3646.  N/07617.  W-Item comment',
+        );
+        expect(p.positionAmbiguity, equals(2));
+        expect(p.itemName, equals('TESTITM'));
+        expect(p.lat, closeTo(36.776, 0.001));
+        expect(p.lon, closeTo(-76.2925, 0.001));
+      });
+    });
+
+    group('Object error reporting', () {
+      // Was previously misreported as "Object compressed position decode
+      // failed" because the uncompressed regex was too strict and execution
+      // fell through to the compressed decoder.
+      test('uncompressed-shaped Object that fails regex reports clearly', () {
+        final p = expectPacketType<UnknownPacket>(
+          // Position starts with digit but is structurally broken (missing
+          // N/S indicator).
+          'N0CALL>APRS:;BROKENOBJ*251245z3646.78X/07617.34W-Comment',
+        );
+        expect(
+          p.reason,
+          equals('Object uncompressed position regex did not match'),
+        );
+      });
+    });
+  });
 }


### PR DESCRIPTION
Closes #80.

## Summary

- Relax `_uncompressedPosRe` to accept `[\d ]` in the four ambiguity-eligible mantissa positions per APRS 1.0.1 §6 — previously, spec-compliant ambiguous packets (Winlink RMS gateways, DX clusters, weather/SKYWARN, legacy hand-key beacons) were silently dropped. The same regex is reused for DTI `!` `=` `/` `@` and Object/Item, so all of those were affected.
- `_ddmm` now substitutes `'5'` for embedded mantissa spaces, placing the decoded coordinate near the centre of the ambiguity box (aprslib / Dire Wolf convention).
- New `positionAmbiguity` field (default `0`) on `PositionPacket`, `ObjectPacket`, `ItemPacket` preserves the level (0–4) for future map UI work.
- Fix the misleading `Object compressed position decode failed` log: when an Object's `posStr` is uncompressed-shaped, the parser now reports `Object uncompressed position regex did not match` instead of falling through to the compressed decoder.
- aprs-auditor follow-up fix: tightened `_isUncompressedPos` to also require `posStr[4] == '.'`. Pre-existing bug — without this, compressed positions on the alternate symbol table with digit overlays (`\0`, `\8`, `\9` — IRLP/Echolink, 802.11 nodes, gas stations per `symbolsX.txt`) were misrouted to the uncompressed parser. The new Object error branch in this PR would have turned that silent drop into a definitive misclassification; this fix prevents it for both Object and Position call sites.

## Spec / audit notes

- aprs-auditor pass run against APRS 1.0.1 §6, §11, §12. Lat-only ambiguity computation is spec-correct: §6 explicitly states *"The level of ambiguity specified in the latitude will automatically apply to the longitude as well."*
- Permissive regex matches aprslib (`aprslib.parsing.position`) and Dire Wolf (`decode_position()`) — the spec defines what conformant *senders* produce, not what receivers must reject.
- Compressed-position decoder (§9) intentionally untouched; §9 has no ambiguity scheme.

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format .` clean
- [x] Full test suite passes (609 tests, 14 new)
- [x] New tests cover ambiguity levels 0–4 for DTI `!`, plus `=` (messaging) and `/` (timestamped) variants
- [x] Exact `WLNK-1` wire packet from the issue decodes to `ObjectPacket` at the centre of the ambiguity box
- [x] Ambiguous `ItemPacket` decodes with ambiguity tracked
- [x] Improved Object error message returned when uncompressed regex fails on a digit-leading posStr
- [x] Digit-overlay compressed positions (`\0`, `\9`) decode as `PositionPacket` and `ObjectPacket` (regression coverage for the audit-driven fix)
- [x] Smoke-tested on Android with live APRS-IS feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)