### PR TITLE
fix(linux): suppress -Wdeprecated-literal-operator for plugin builds

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -42,6 +42,12 @@ endif()
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  # flutter_secure_storage_linux bundles an older nlohmann/json.hpp that
+  # uses pre-C++23 user-defined literal operator syntax (operator"" _json
+  # with whitespace). Clang >= 16 errors on this under -Wall + -Werror
+  # via -Wdeprecated-literal-operator. Suppress narrowly so the rest of
+  # -Wall stays effective for our own code.
+  target_compile_options(${TARGET} PRIVATE -Wno-deprecated-literal-operator)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
## Summary

- `flutter_secure_storage_linux` 1.2.3 bundles an older `nlohmann/json.hpp` that uses pre-C++23 user-defined literal operator syntax (`operator"" _json` with whitespace). Clang ≥ 16 (Fedora 43 ships Clang 19) errors on this under `-Wall` + `-Werror`, breaking `flutter build linux` on modern host toolchains.
- Add a narrow `-Wno-deprecated-literal-operator` after `-Wall` in `apply_standard_settings()` so the suppression reaches plugin targets that opt into the project's standard settings (the plugin in question calls `apply_standard_settings` on line 14 of its `CMakeLists.txt`).
- Rest of `-Wall` stays effective for our own code.

## Test plan

- [x] `flutter build linux --debug` succeeds on Fedora 43 / Clang 19 (verified by @epasch in distrobox)
- [ ] CI Linux build still passes (Ubuntu / GCC — flag is GCC ≥ 11 compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)