### PR TITLE
fix(ui): anchor station distance to operator, not map center (#41)

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -24,6 +24,7 @@ import '../theme/theme_controller.dart';
 import '../ui/widgets/aprs_symbol_widget.dart';
 import '../ui/utils/distance_formatter.dart';
 import '../ui/utils/maidenhead.dart';
+import '../ui/utils/operator_location.dart';
 import '../ui/utils/platform_route.dart';
 import '../ui/widgets/meridian_bottom_sheet.dart';
 import '../ui/widgets/station_info_sheet.dart';
@@ -401,14 +402,6 @@ class _MapScreenState extends State<MapScreen> {
     return (1.0 - t * 0.7).clamp(0.3, 1.0);
   }
 
-  LatLng get _mapCenter {
-    try {
-      return _mapController.camera.center;
-    } catch (_) {
-      return LatLng(widget.initialLat, widget.initialLon);
-    }
-  }
-
   Marker _buildMarker(Station s) => Marker(
     point: LatLng(s.lat, s.lon),
     width: 44,
@@ -417,8 +410,7 @@ class _MapScreenState extends State<MapScreen> {
     child: GestureDetector(
       onTap: () => showModalBottomSheet(
         context: context,
-        builder: (_) =>
-            StationInfoSheet(station: s, referencePosition: _mapCenter),
+        builder: (_) => StationInfoSheet(station: s),
       ),
       child: Tooltip(
         message: s.callsign,
@@ -524,10 +516,7 @@ class _MapScreenState extends State<MapScreen> {
       if (selected != null && mounted) {
         showModalBottomSheet(
           context: context,
-          builder: (_) => StationInfoSheet(
-            station: selected,
-            referencePosition: _mapCenter,
-          ),
+          builder: (_) => StationInfoSheet(station: selected),
         );
       }
     });
@@ -537,8 +526,7 @@ class _MapScreenState extends State<MapScreen> {
     setState(() => _pinLocation = location);
     showModalBottomSheet<void>(
       context: context,
-      builder: (_) =>
-          _PinDropSheet(location: location, referencePosition: _mapCenter),
+      builder: (_) => _PinDropSheet(location: location),
     ).whenComplete(() {
       if (mounted) setState(() => _pinLocation = null);
     });
@@ -727,14 +715,12 @@ class _ClusterRingPainter extends CustomPainter {
 }
 
 /// Bottom sheet shown when the user long-presses on the map to drop a pin.
-/// Displays coordinates, Maidenhead grid square, and distance from map center.
+/// Displays coordinates, Maidenhead grid square, and distance from the
+/// operator's location (manual coords or GPS fix).
 class _PinDropSheet extends StatelessWidget {
-  const _PinDropSheet({required this.location, this.referencePosition});
+  const _PinDropSheet({required this.location});
 
   final LatLng location;
-
-  /// The map center at the time the pin was dropped. Used to display distance.
-  final LatLng? referencePosition;
 
   String get _decimalCoordText {
     final lat = location.latitude.toStringAsFixed(5);
@@ -765,12 +751,13 @@ class _PinDropSheet extends StatelessWidget {
     final imperial = context.watch<StationService>().useImperialUnits;
 
     final grid = maidenheadLocator(location.latitude, location.longitude);
+    final operatorPosition = resolveOperatorLocation(context);
 
     double? distKm;
-    if (referencePosition != null) {
+    if (operatorPosition != null) {
       distKm = const Distance().as(
         LengthUnit.Kilometer,
-        referencePosition!,
+        operatorPosition,
         location,
       );
     }

--- a/lib/services/beaconing_service.dart
+++ b/lib/services/beaconing_service.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show MissingPluginException;
 import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/beaconing/smart_beaconing.dart';
@@ -82,6 +83,12 @@ class BeaconingService extends ChangeNotifier {
   SmartBeaconingParams get smartParams => _smartParams;
   DateTime? get lastBeaconAt => _lastBeaconAt;
   BeaconError? get lastError => _lastError;
+
+  /// Most recent GPS fix as a [LatLng], or null if no fix has been obtained.
+  /// Updated whenever the geolocator stream emits a new position.
+  LatLng? get lastKnownLocation => _lastPosition == null
+      ? null
+      : LatLng(_lastPosition!.latitude, _lastPosition!.longitude);
 
   /// Human-readable description of when the last beacon was sent.
   String? get lastBeaconAgo {

--- a/lib/ui/utils/operator_location.dart
+++ b/lib/ui/utils/operator_location.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/beaconing_service.dart';
+import '../../services/station_settings_service.dart';
+
+/// Resolves the operator's current location for distance / bearing display.
+///
+/// Resolution order:
+/// 1. Manual coordinates if [LocationSource.manual] is selected and set.
+/// 2. Latest GPS fix from [BeaconingService.lastKnownLocation].
+/// 3. Null when nothing is available — callers should hide distance UI.
+///
+/// Reads via [BuildContext.watch] so widgets rebuild when either source
+/// changes (manual coord update, GPS fix update, source switch).
+LatLng? resolveOperatorLocation(BuildContext context) {
+  final settings = context.watch<StationSettingsService>();
+  if (settings.locationSource == LocationSource.manual &&
+      settings.hasManualPosition) {
+    return LatLng(settings.manualLat!, settings.manualLon!);
+  }
+  final beaconing = context.watch<BeaconingService>();
+  return beaconing.lastKnownLocation;
+}

--- a/lib/ui/widgets/station_info_sheet.dart
+++ b/lib/ui/widgets/station_info_sheet.dart
@@ -9,6 +9,7 @@ import '../../screens/message_thread_screen.dart';
 import '../../services/station_service.dart';
 import '../utils/distance_formatter.dart';
 import '../utils/maidenhead.dart';
+import '../utils/operator_location.dart';
 import '../utils/platform_route.dart';
 import '../utils/wx_data.dart';
 import 'aprs_symbol_widget.dart';
@@ -40,18 +41,9 @@ String _formatLastHeard(DateTime lastHeard) {
 /// );
 /// ```
 class StationInfoSheet extends StatelessWidget {
-  const StationInfoSheet({
-    super.key,
-    required this.station,
-    this.referencePosition,
-    this.onShowOnMap,
-  });
+  const StationInfoSheet({super.key, required this.station, this.onShowOnMap});
 
   final Station station;
-
-  /// When provided, the sheet shows the distance from this position to the
-  /// station. Typically the current map center or GPS location.
-  final LatLng? referencePosition;
 
   /// When provided, a "Show on map" button is displayed. The callback should
   /// close the sheet (via [Navigator.pop]) and navigate to the map.
@@ -70,6 +62,7 @@ class StationInfoSheet extends StatelessWidget {
     final relativeTime = _formatLastHeard(station.lastHeard);
     final hasComment = station.comment.isNotEmpty;
     final grid = maidenheadLocator(station.lat, station.lon);
+    final operatorPosition = resolveOperatorLocation(context);
 
     return SafeArea(
       child: Padding(
@@ -198,8 +191,9 @@ class StationInfoSheet extends StatelessWidget {
               ],
             ),
 
-            // Distance from reference point (map center or GPS)
-            if (referencePosition != null) ...[
+            // Distance from operator location (manual coords or GPS).
+            // Hidden entirely when no operator location is available.
+            if (operatorPosition != null) ...[
               const SizedBox(height: 4),
               Row(
                 children: [
@@ -211,7 +205,7 @@ class StationInfoSheet extends StatelessWidget {
                   const SizedBox(width: 4),
                   Text(
                     _distanceText(
-                      referencePosition!,
+                      operatorPosition,
                       station,
                       imperial: context
                           .watch<StationService>()

--- a/test/ui/utils/operator_location_test.dart
+++ b/test/ui/utils/operator_location_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/beaconing_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+import 'package:meridian_aprs/ui/utils/operator_location.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/fake_secure_credential_store.dart';
+
+/// Subclass that lets a test pin `lastKnownLocation` to a known value.
+class _StubBeaconingService extends BeaconingService {
+  _StubBeaconingService(super.settings, super.tx);
+
+  LatLng? stubLocation;
+
+  @override
+  LatLng? get lastKnownLocation => stubLocation;
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<({StationSettingsService settings, _StubBeaconingService beacon})>
+  build() async {
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    final tx = TxService(ConnectionRegistry(), settings);
+    final beacon = _StubBeaconingService(settings, tx);
+    return (settings: settings, beacon: beacon);
+  }
+
+  /// Pumps a widget that captures the resolved operator location.
+  Future<LatLng?> resolve(
+    WidgetTester tester, {
+    required StationSettingsService settings,
+    required BeaconingService beacon,
+  }) async {
+    LatLng? captured;
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<StationSettingsService>.value(value: settings),
+          ChangeNotifierProvider<BeaconingService>.value(value: beacon),
+        ],
+        child: Builder(
+          builder: (context) {
+            captured = resolveOperatorLocation(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return captured;
+  }
+
+  group('resolveOperatorLocation', () {
+    testWidgets('returns manual coords when manual selected and set', (
+      tester,
+    ) async {
+      final ctx = await build();
+      await ctx.settings.setLocationSource(LocationSource.manual);
+      await ctx.settings.setManualPosition(40.0, -75.0);
+
+      final result = await resolve(
+        tester,
+        settings: ctx.settings,
+        beacon: ctx.beacon,
+      );
+
+      expect(result, equals(LatLng(40.0, -75.0)));
+    });
+
+    testWidgets(
+      'falls back to GPS when manual selected but no manual position',
+      (tester) async {
+        final ctx = await build();
+        await ctx.settings.setLocationSource(LocationSource.manual);
+        // Note: no manual position stored.
+        ctx.beacon.stubLocation = LatLng(35.0, -120.0);
+
+        final result = await resolve(
+          tester,
+          settings: ctx.settings,
+          beacon: ctx.beacon,
+        );
+
+        expect(result, equals(LatLng(35.0, -120.0)));
+      },
+    );
+
+    testWidgets('returns GPS fix when GPS source selected', (tester) async {
+      final ctx = await build();
+      await ctx.settings.setLocationSource(LocationSource.gps);
+      ctx.beacon.stubLocation = LatLng(51.5, -0.1);
+
+      final result = await resolve(
+        tester,
+        settings: ctx.settings,
+        beacon: ctx.beacon,
+      );
+
+      expect(result, equals(LatLng(51.5, -0.1)));
+    });
+
+    testWidgets('prefers manual over GPS when both are available', (
+      tester,
+    ) async {
+      final ctx = await build();
+      await ctx.settings.setLocationSource(LocationSource.manual);
+      await ctx.settings.setManualPosition(40.0, -75.0);
+      ctx.beacon.stubLocation = LatLng(51.5, -0.1);
+
+      final result = await resolve(
+        tester,
+        settings: ctx.settings,
+        beacon: ctx.beacon,
+      );
+
+      expect(result, equals(LatLng(40.0, -75.0)));
+    });
+
+    testWidgets('returns null when GPS source and no fix yet', (tester) async {
+      final ctx = await build();
+      await ctx.settings.setLocationSource(LocationSource.gps);
+      // No GPS fix.
+      final result = await resolve(
+        tester,
+        settings: ctx.settings,
+        beacon: ctx.beacon,
+      );
+
+      expect(result, isNull);
+    });
+
+    testWidgets(
+      'returns null when manual selected, no manual coords, no GPS fix',
+      (tester) async {
+        final ctx = await build();
+        await ctx.settings.setLocationSource(LocationSource.manual);
+        // No manual, no GPS.
+        final result = await resolve(
+          tester,
+          settings: ctx.settings,
+          beacon: ctx.beacon,
+        );
+
+        expect(result, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #41.

## Summary
- The station info sheet and dropped-pin sheet computed "distance to station" from the **map viewport center**, so the number changed as the user panned. Now sourced from the operator's own location.
- New `resolveOperatorLocation(context)` helper resolves: manual coords (if selected and set) → latest GPS fix from `BeaconingService.lastKnownLocation` → null. When null, the distance row is hidden entirely.
- `referencePosition` parameter and `_mapCenter` getter removed; distance now appears uniformly on every surface that opens `StationInfoSheet` (station list, search, scaffolds), not just the map-tap path. This is a deliberate behavior expansion.
- Bearing was mentioned in the issue as needing audit, but no bearing display exists in the codebase — kept out of scope.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 624 passing (6 new in `test/ui/utils/operator_location_test.dart` covering manual / GPS / fallback / null cases)
- [x] Manual: set manual coords → tap a station → pan map far → reopen sheet → distance unchanged
- [x] Manual: switch to GPS source → distance reflects GPS fix, not viewport
- [x] Manual: clear both → distance row hidden
- [x] Manual: drop pin (long-press) → pin sheet shows distance from operator location
- [x] Manual: open station from station list → distance now shown (new surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)