### PR TITLE
fix(beaconing): log background-fired beacons and bulletins locally

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -278,6 +278,8 @@ Future<void> main() async {
     registry: registry,
     beaconing: beaconingService,
     tx: txService,
+    onPacketLogged: (line) =>
+        service.ingestLine(line, source: PacketSource.aprsIs),
   );
 
   // ---------------------------------------------------------------------------

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -113,10 +113,12 @@ class BackgroundServiceManager extends ChangeNotifier
     required BeaconingService beaconing,
     required TxService tx,
     ForegroundServiceApi? taskApi,
+    void Function(String line)? onPacketLogged,
   }) : _registry = registry,
        _beaconing = beaconing,
        _tx = tx,
-       _taskApi = taskApi ?? const _DefaultForegroundServiceApi() {
+       _taskApi = taskApi ?? const _DefaultForegroundServiceApi(),
+       _onPacketLogged = onPacketLogged {
     _registry.addListener(_onServiceStateChanged);
     _beaconing.addListener(_onServiceStateChanged);
     if (!kIsWeb && Platform.isAndroid) {
@@ -133,6 +135,13 @@ class BackgroundServiceManager extends ChangeNotifier
   final BeaconingService _beaconing;
   final TxService _tx;
   final ForegroundServiceApi _taskApi;
+
+  /// Invoked when the background isolate reports a transmitted line
+  /// (`beacon_sent` / `bulletin_sent` IPC). Wire this to
+  /// [StationService.ingestLine] so background-fired packets appear in the
+  /// local packet log — same loopback semantics as
+  /// [BeaconingService.onBeaconSent] for the foreground path.
+  final void Function(String line)? _onPacketLogged;
 
   static const _keyBgActivity = 'bg_activity_enabled';
 
@@ -435,11 +444,20 @@ class BackgroundServiceManager extends ChangeNotifier
           ); // ignore: unawaited_futures
         }
       case 'beacon_sent':
-        break;
+        final aprsLine = msg['aprs_line'] as String?;
+        if (aprsLine != null) _onPacketLogged?.call(aprsLine);
+      case 'bulletin_sent':
+        final aprsLine = msg['aprs_line'] as String?;
+        if (aprsLine != null) _onPacketLogged?.call(aprsLine);
       case 'aprs_is_liveness_check':
         _checkAprsIsLiveness();
     }
   }
+
+  /// Test-only entrypoint for IPC dispatch. Mirrors what
+  /// [FlutterForegroundTask.addTaskDataCallback] would deliver in production.
+  @visibleForTesting
+  void debugDispatchTaskData(Object data) => _onTaskData(data);
 
   /// Inspect each APRS-IS connection's [AprsIsConnection.lastLineAt] and
   /// recycle any whose last inbound line is older than [_kAprsIsStaleAfter].

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -267,8 +267,14 @@ class MeridianConnectionTask extends TaskHandler {
     await prefs.setInt('bg_last_beacon_ts', tsMs);
 
     // Notify main isolate. This queues if the main isolate is suspended and
-    // delivers when it resumes.
-    FlutterForegroundTask.sendDataToMain({'type': 'beacon_sent', 'ts': tsMs});
+    // delivers when it resumes. The aprs_line is included so the main isolate
+    // can self-ingest into StationService — same loopback semantics as the
+    // foreground BeaconingService.onBeaconSent callback.
+    FlutterForegroundTask.sendDataToMain({
+      'type': 'beacon_sent',
+      'ts': tsMs,
+      'aprs_line': line,
+    });
 
     // Update notification body only — title is managed by BackgroundServiceManager
     // on the main isolate and reflects the actual connection state.
@@ -433,6 +439,14 @@ class MeridianConnectionTask extends TaskHandler {
           transmissionCount: ob.transmissionCount + 1,
         );
         mutated = true;
+
+        // Notify main isolate so the line is self-ingested into StationService —
+        // mirrors the beacon_sent loopback so background-fired bulletins appear
+        // in the local packet log.
+        FlutterForegroundTask.sendDataToMain({
+          'type': 'bulletin_sent',
+          'aprs_line': line,
+        });
       }
     }
 

--- a/test/services/background_service_manager_test.dart
+++ b/test/services/background_service_manager_test.dart
@@ -314,6 +314,92 @@ void main() {
     });
   });
 
+  group('BackgroundServiceManager — IPC packet ingest', () {
+    test('beacon_sent IPC with aprs_line invokes onPacketLogged', () async {
+      final deps = await _buildDeps();
+      final logged = <String>[];
+      final manager = BackgroundServiceManager(
+        registry: deps.registry,
+        beaconing: deps.beaconing,
+        tx: deps.tx,
+        taskApi: FakeForegroundServiceApi(),
+        onPacketLogged: logged.add,
+      );
+
+      manager.debugDispatchTaskData({
+        'type': 'beacon_sent',
+        'ts': 123,
+        'aprs_line': 'NOCALL-7>APMDN0:=4012.34N/07412.34W>test',
+      });
+
+      expect(logged, ['NOCALL-7>APMDN0:=4012.34N/07412.34W>test']);
+      manager.dispose();
+    });
+
+    test('bulletin_sent IPC with aprs_line invokes onPacketLogged', () async {
+      final deps = await _buildDeps();
+      final logged = <String>[];
+      final manager = BackgroundServiceManager(
+        registry: deps.registry,
+        beaconing: deps.beaconing,
+        tx: deps.tx,
+        taskApi: FakeForegroundServiceApi(),
+        onPacketLogged: logged.add,
+      );
+
+      manager.debugDispatchTaskData({
+        'type': 'bulletin_sent',
+        'aprs_line': 'NOCALL-7>APMDN0::BLN0     :Net at 8pm',
+      });
+
+      expect(logged, ['NOCALL-7>APMDN0::BLN0     :Net at 8pm']);
+      manager.dispose();
+    });
+
+    test(
+      'beacon_sent IPC without aprs_line is a no-op (legacy payload safety)',
+      () async {
+        final deps = await _buildDeps();
+        final logged = <String>[];
+        final manager = BackgroundServiceManager(
+          registry: deps.registry,
+          beaconing: deps.beaconing,
+          tx: deps.tx,
+          taskApi: FakeForegroundServiceApi(),
+          onPacketLogged: logged.add,
+        );
+
+        manager.debugDispatchTaskData({'type': 'beacon_sent', 'ts': 123});
+
+        expect(logged, isEmpty);
+        manager.dispose();
+      },
+    );
+
+    test(
+      'IPC dispatch without onPacketLogged callback does not throw',
+      () async {
+        final deps = await _buildDeps();
+        final manager = BackgroundServiceManager(
+          registry: deps.registry,
+          beaconing: deps.beaconing,
+          tx: deps.tx,
+          taskApi: FakeForegroundServiceApi(),
+        );
+
+        expect(
+          () => manager.debugDispatchTaskData({
+            'type': 'beacon_sent',
+            'ts': 123,
+            'aprs_line': 'X>Y:=test',
+          }),
+          returnsNormally,
+        );
+        manager.dispose();
+      },
+    );
+  });
+
   group('BackgroundServiceManager — non-Android platform', () {
     testWidgets(
       'requestStartService returns false on non-Android (test runs on Linux)',


### PR DESCRIPTION
## Summary
- Background-fired beacons reached APRS-IS / TNC but never appeared in the in-app packet log; bulletins fired in the background had the same gap.
- Foreground `BeaconingService` self-ingests its outbound line via `onBeaconSent` → `StationService.ingestLine`. The background isolate had no equivalent loopback — its `beacon_sent` IPC was received and silently dropped, and the bulletin path had no IPC at all.
- Extended the `beacon_sent` IPC payload to carry the encoded line, added a parallel `bulletin_sent` IPC, and wired `BackgroundServiceManager.onPacketLogged` → `StationService.ingestLine` so background-fired packets are logged with the same semantics as foreground.

## Changes
- `lib/services/meridian_connection_task.dart` — include `aprs_line` in `beacon_sent` IPC; emit new `bulletin_sent` IPC after each successful bulletin transmission.
- `lib/services/background_service_manager.dart` — new `onPacketLogged` constructor parameter; `_onTaskData` handles `beacon_sent` and `bulletin_sent` by invoking the callback.
- `lib/main.dart` — wire `onPacketLogged` to `service.ingestLine(line, source: PacketSource.aprsIs)`.
- `test/services/background_service_manager_test.dart` — four new IPC-dispatch test cases (beacon_sent with line, bulletin_sent with line, legacy payload safety, no-callback safety).

## Test plan
- [x] `dart format .` clean
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 622 tests passing
- [x] Manual: lock screen with foreground beaconing active, wait one interval, unlock → background beacon appears in the packet log
- [ ] Manual: schedule an outgoing bulletin to fire while screen-off → bulletin appears in the packet log on resume

## Notes
- Smart beaconing in the Android background isolate (currently fixed-interval regardless of `beacon_mode`) is a separate, larger fix tracked as Part 2 in the implementation plan.
- iOS is unaffected — `IosBackgroundService` keeps the main isolate alive, so the foreground self-ingest path already works there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)