### PR TITLE
feat(beaconing): smart beaconing in the Android background isolate

### DIFF
--- a/lib/core/beaconing/smart_beacon_scheduler.dart
+++ b/lib/core/beaconing/smart_beacon_scheduler.dart
@@ -1,0 +1,146 @@
+/// Stateful smart-beaconing scheduler used by the Android background isolate
+/// (see `MeridianConnectionTask`). Wraps the pure-function [SmartBeaconing]
+/// math with the speed/heading state that decisions depend on, in a form that
+/// is testable without spinning up a `flutter_foreground_task` TaskHandler.
+///
+/// The foreground [BeaconingService] keeps equivalent state inline; this
+/// helper exists so the background isolate can reuse the same semantics
+/// (turn-triggered immediate beacons, only-shorten reschedules, post-turn
+/// heading reset) without duplicating the math in two places.
+library;
+
+import 'package:geolocator/geolocator.dart';
+
+import 'smart_beaconing.dart';
+
+/// Decision returned by [SmartBeaconScheduler.onPositionUpdate].
+sealed class SmartAction {
+  const SmartAction();
+}
+
+/// Fire a beacon immediately. The caller must cancel any pending timer and
+/// call [SmartBeaconScheduler.markBeaconSent] once the beacon is on its way.
+class FireNow extends SmartAction {
+  const FireNow();
+}
+
+/// Cancel the current timer and reschedule it for [delay] from now.
+/// Only emitted when the new interval would fire sooner than the existing
+/// timer — never used to push a beacon further out.
+class Reschedule extends SmartAction {
+  const Reschedule(this.delay);
+  final Duration delay;
+}
+
+/// No change to the current timer.
+class Keep extends SmartAction {
+  const Keep();
+}
+
+class SmartBeaconScheduler {
+  SmartBeaconScheduler({required SmartBeaconingParams params})
+    : _params = params;
+
+  SmartBeaconingParams _params;
+  Position? _lastPosition;
+  double? _lastHeading;
+  DateTime? _lastBeaconAt;
+  DateTime? _currentTimerStartedAt;
+  int? _currentTimerIntervalS;
+
+  /// Hot-reload tunable params (e.g. when the user changes them in Settings
+  /// while the background service is running).
+  void updateParams(SmartBeaconingParams params) {
+    _params = params;
+  }
+
+  /// Record that a beacon was just transmitted. Resets the turn-trigger window.
+  void markBeaconSent(DateTime ts) {
+    _lastBeaconAt = ts;
+  }
+
+  /// Seed the "current timer" bookkeeping when the caller schedules a timer
+  /// from a known start time other than `now` — e.g. when resuming after the
+  /// foreground fired the last beacon at `lastBeaconTs` and the background
+  /// timer is set to fire at `lastBeaconTs + intervalS`.
+  ///
+  /// Maintains the invariant `startedAt + intervalS == fire time` so that
+  /// later [onPositionUpdate] calls compute remaining time correctly.
+  void seedCurrentTimer({required DateTime startedAt, required int intervalS}) {
+    _currentTimerStartedAt = startedAt;
+    _currentTimerIntervalS = intervalS;
+  }
+
+  /// Compute the interval the caller should use to schedule the next beacon
+  /// timer (typically called immediately after a beacon fires). Stores the
+  /// deadline so future [onPositionUpdate] calls can decide whether to
+  /// shorten it.
+  ///
+  /// If no GPS fix is available yet, falls back to the slowRate.
+  Duration intervalAfterBeacon({DateTime? now}) {
+    final stamp = now ?? DateTime.now();
+    final speedKmh = _speedKmhFromLast();
+    final intervalS = SmartBeaconing.computeInterval(_params, speedKmh);
+    _currentTimerStartedAt = stamp;
+    _currentTimerIntervalS = intervalS;
+    return Duration(seconds: intervalS);
+  }
+
+  /// Process a new GPS [position]. Returns the action the caller should take.
+  ///
+  /// Mirrors [BeaconingService._onPositionUpdate] exactly — turn trigger
+  /// check first (gated on minTurnTimeS), then only-shorten reschedule.
+  SmartAction onPositionUpdate(Position position, {DateTime? now}) {
+    final stamp = now ?? DateTime.now();
+    final speedKmh = (position.speed * 3.6).clamp(0.0, double.infinity);
+    final heading = position.heading;
+
+    if (_lastPosition != null &&
+        _lastBeaconAt != null &&
+        _lastHeading != null) {
+      final headingDelta = _angleDiff(heading, _lastHeading!);
+      final timeSinceLast = stamp.difference(_lastBeaconAt!);
+      if (SmartBeaconing.shouldTriggerTurn(
+        _params,
+        speedKmh,
+        headingDelta,
+        timeSinceLast,
+      )) {
+        // Reset heading to current pre-fire so the next delta is measured
+        // from the post-turn heading, not the pre-turn one.
+        _lastHeading = heading;
+        _lastPosition = position;
+        return const FireNow();
+      }
+    }
+
+    _lastHeading = heading;
+    _lastPosition = position;
+
+    if (_currentTimerStartedAt != null && _currentTimerIntervalS != null) {
+      final newIntervalS = SmartBeaconing.computeInterval(_params, speedKmh);
+      final elapsed = stamp.difference(_currentTimerStartedAt!).inSeconds;
+      final remaining = _currentTimerIntervalS! - elapsed;
+      // Only shorten — never push the beacon further out.
+      if (newIntervalS < remaining) {
+        _currentTimerStartedAt = stamp;
+        _currentTimerIntervalS = newIntervalS;
+        return Reschedule(Duration(seconds: newIntervalS));
+      }
+    }
+
+    return const Keep();
+  }
+
+  double _speedKmhFromLast() {
+    final last = _lastPosition;
+    if (last == null) return 0.0;
+    return (last.speed * 3.6).clamp(0.0, double.infinity);
+  }
+
+  /// Absolute angular difference in [0, 180].
+  static double _angleDiff(double a, double b) {
+    final diff = (a - b).abs() % 360;
+    return diff > 180 ? 360 - diff : diff;
+  }
+}

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -6,10 +6,13 @@ import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/beaconing/smart_beacon_scheduler.dart';
+import '../core/beaconing/smart_beaconing.dart';
 import '../core/credentials/credential_key.dart';
 import '../core/credentials/secure_credential_store.dart';
 import '../core/packet/aprs_encoder.dart';
 import '../models/outgoing_bulletin.dart';
+import 'beaconing_service.dart' show BeaconMode;
 import 'bulletin_service.dart';
 import 'messaging_settings_service.dart';
 
@@ -45,6 +48,16 @@ class MeridianConnectionTask extends TaskHandler {
   Timer? _beaconTimer;
   Timer? _bulletinTimer;
   int? _lastBeaconTs; // ms since epoch; null until first beacon this session
+
+  /// Active beacon mode for this background session. Set on `start_beaconing`
+  /// IPC from the main isolate; treated as auto if not yet set.
+  BeaconMode _activeMode = BeaconMode.auto;
+
+  /// Smart-mode scheduler. Non-null only while `_activeMode == BeaconMode.smart`.
+  SmartBeaconScheduler? _smart;
+
+  /// GPS position stream subscription. Active only in smart mode.
+  StreamSubscription<Position>? _positionSub;
 
   /// Bulletin scheduler tick interval in the background isolate. Matches the
   /// main-isolate `BulletinScheduler` cadence so schedule math is consistent.
@@ -99,6 +112,8 @@ class MeridianConnectionTask extends TaskHandler {
       case 'stop_beaconing':
         _beaconTimer?.cancel();
         _beaconTimer = null;
+        _stopSmartPositionStream();
+        _smart = null;
         _lastBeaconTs =
             null; // Stop onRepeatEvent updating notification after handoff
     }
@@ -108,6 +123,8 @@ class MeridianConnectionTask extends TaskHandler {
   Future<void> onDestroy(DateTime timestamp) async {
     _beaconTimer?.cancel();
     _bulletinTimer?.cancel();
+    await _positionSub?.cancel();
+    _positionSub = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -118,20 +135,66 @@ class MeridianConnectionTask extends TaskHandler {
   /// main isolate last beaconed, so there is no gap after the screen locks.
   void _scheduleFirstBeacon(int lastBeaconTsMs) {
     _beaconTimer?.cancel();
+    _stopSmartPositionStream();
+    _smart = null;
     // Seed _lastBeaconTs so onRepeatEvent can start updating the notification
     // text immediately, before the first background beacon fires.
     if (lastBeaconTsMs > 0) _lastBeaconTs = lastBeaconTsMs;
-    SharedPreferences.getInstance().then((prefs) {
-      final intervalS = prefs.getInt('beacon_interval_s') ?? 600;
+    SharedPreferences.getInstance().then((prefs) async {
+      await prefs.reload();
+      _activeMode = _readBeaconMode(prefs);
+
+      // Manual mode never auto-fires. The user explicitly chose to send only
+      // when triggered; the prior background path would auto-fire anyway,
+      // which was a separate latent bug — this branch closes it.
+      if (_activeMode == BeaconMode.manual) return;
+
+      final intervalS = _resolveInitialIntervalS(prefs);
       final elapsedMs = DateTime.now().millisecondsSinceEpoch - lastBeaconTsMs;
       final elapsedS = elapsedMs ~/ 1000;
       final remainingS = (intervalS - elapsedS).clamp(0, intervalS);
       _beaconTimer = Timer(Duration(seconds: remainingS), _onBeaconTimer);
+
+      if (_activeMode == BeaconMode.smart) {
+        final params = _loadSmartParamsFromPrefs(prefs);
+        final smart = SmartBeaconScheduler(params: params);
+        // Seed the scheduler so the in-flight timer's deadline is visible to
+        // onPositionUpdate's only-shorten reschedule check.
+        smart.markBeaconSent(
+          DateTime.fromMillisecondsSinceEpoch(
+            lastBeaconTsMs > 0
+                ? lastBeaconTsMs
+                : DateTime.now().millisecondsSinceEpoch,
+          ),
+        );
+        smart.seedCurrentTimer(
+          startedAt: DateTime.fromMillisecondsSinceEpoch(
+            lastBeaconTsMs > 0
+                ? lastBeaconTsMs
+                : DateTime.now().millisecondsSinceEpoch,
+          ),
+          intervalS: intervalS,
+        );
+        _smart = smart;
+        await _startSmartPositionStream();
+      }
     });
   }
 
   void _scheduleNextBeacon() {
-    SharedPreferences.getInstance().then((prefs) {
+    SharedPreferences.getInstance().then((prefs) async {
+      await prefs.reload();
+
+      if (_activeMode == BeaconMode.manual) return;
+
+      if (_activeMode == BeaconMode.smart && _smart != null) {
+        // Hot-reload params so user changes apply on the next cycle without
+        // restarting the FGS.
+        _smart!.updateParams(_loadSmartParamsFromPrefs(prefs));
+        _beaconTimer = Timer(_smart!.intervalAfterBeacon(), _onBeaconTimer);
+        return;
+      }
+
       final intervalS = prefs.getInt('beacon_interval_s') ?? 600;
       _beaconTimer = Timer(Duration(seconds: intervalS), _onBeaconTimer);
     });
@@ -140,6 +203,98 @@ class MeridianConnectionTask extends TaskHandler {
   void _onBeaconTimer() {
     // whenComplete ensures the next timer is always scheduled, even if _sendBeacon throws.
     _sendBeacon().whenComplete(_scheduleNextBeacon);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mode + smart-beaconing helpers
+  // ---------------------------------------------------------------------------
+
+  BeaconMode _readBeaconMode(SharedPreferences prefs) {
+    final idx = prefs.getInt('beacon_mode') ?? BeaconMode.auto.index;
+    if (idx >= 0 && idx < BeaconMode.values.length) {
+      return BeaconMode.values[idx];
+    }
+    return BeaconMode.auto;
+  }
+
+  /// Initial interval to use when scheduling the first background beacon.
+  /// In smart mode we don't have a speed yet; fall back to slowRate as a
+  /// fail-safe upper bound — onPositionUpdate will shorten it once a fix
+  /// arrives if the user is moving.
+  int _resolveInitialIntervalS(SharedPreferences prefs) {
+    if (_activeMode == BeaconMode.smart) {
+      return prefs.getInt('smart_slowRateS') ??
+          SmartBeaconingParams.defaults.slowRateS;
+    }
+    return prefs.getInt('beacon_interval_s') ?? 600;
+  }
+
+  SmartBeaconingParams _loadSmartParamsFromPrefs(SharedPreferences prefs) {
+    final map = <String, dynamic>{};
+    for (final key in prefs.getKeys()) {
+      if (key.startsWith('smart_')) {
+        map[key.substring('smart_'.length)] = prefs.get(key);
+      }
+    }
+    return map.isEmpty
+        ? SmartBeaconingParams.defaults
+        : SmartBeaconingParams.fromMap(map);
+  }
+
+  Future<void> _startSmartPositionStream() async {
+    await _positionSub?.cancel();
+    _positionSub = null;
+    try {
+      final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        await FlutterForegroundTask.updateService(
+          notificationText:
+              'Smart beaconing unavailable — location service off',
+        );
+        return;
+      }
+      final permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        await FlutterForegroundTask.updateService(
+          notificationText:
+              'Smart beaconing unavailable — location permission required',
+        );
+        return;
+      }
+      _positionSub = Geolocator.getPositionStream(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.best,
+        ),
+      ).listen(_onSmartPositionUpdate);
+    } catch (_) {
+      // Stream couldn't start — fall back to fixed cadence (slowRate timer
+      // is already scheduled in _scheduleFirstBeacon / _scheduleNextBeacon).
+    }
+  }
+
+  void _stopSmartPositionStream() {
+    _positionSub?.cancel();
+    _positionSub = null;
+  }
+
+  void _onSmartPositionUpdate(Position position) {
+    final smart = _smart;
+    if (smart == null || _activeMode != BeaconMode.smart) return;
+
+    final action = smart.onPositionUpdate(position);
+    switch (action) {
+      case FireNow():
+        _beaconTimer?.cancel();
+        _beaconTimer = null;
+        _onBeaconTimer();
+      case Reschedule(:final delay):
+        _beaconTimer?.cancel();
+        _beaconTimer = Timer(delay, _onBeaconTimer);
+      case Keep():
+        // No timer change.
+        break;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -261,6 +416,10 @@ class MeridianConnectionTask extends TaskHandler {
 
     final tsMs = DateTime.now().millisecondsSinceEpoch;
     _lastBeaconTs = tsMs;
+
+    // Reset the smart scheduler's turn-trigger window so the next sharp turn
+    // is measured from this beacon, not from the previous one.
+    _smart?.markBeaconSent(DateTime.fromMillisecondsSinceEpoch(tsMs));
 
     // Persist timestamp to SharedPreferences so the main isolate can sync
     // the BeaconingService timer on resume, even if the IPC message is delayed.

--- a/test/core/beaconing/smart_beacon_scheduler_test.dart
+++ b/test/core/beaconing/smart_beacon_scheduler_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+
+import 'package:meridian_aprs/core/beaconing/smart_beacon_scheduler.dart';
+import 'package:meridian_aprs/core/beaconing/smart_beaconing.dart';
+
+Position _pos({
+  required double speedMs,
+  required double headingDeg,
+  DateTime? timestamp,
+}) {
+  return Position(
+    longitude: 0,
+    latitude: 0,
+    timestamp: timestamp ?? DateTime.now(),
+    accuracy: 1,
+    altitude: 0,
+    altitudeAccuracy: 1,
+    heading: headingDeg,
+    headingAccuracy: 1,
+    speed: speedMs,
+    speedAccuracy: 1,
+  );
+}
+
+void main() {
+  group('SmartBeaconScheduler — intervalAfterBeacon', () {
+    test('returns slowRate when no GPS fix yet', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final d = s.intervalAfterBeacon();
+      expect(d.inSeconds, SmartBeaconingParams.defaults.slowRateS);
+    });
+
+    test('returns fastRate at or above fastSpeed', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      // 30 m/s = 108 km/h, above fastSpeedKmh=100 default
+      s.onPositionUpdate(_pos(speedMs: 30, headingDeg: 0));
+      final d = s.intervalAfterBeacon();
+      expect(d.inSeconds, SmartBeaconingParams.defaults.fastRateS);
+    });
+
+    test('returns slowRate at or below slowSpeed', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      s.onPositionUpdate(_pos(speedMs: 0, headingDeg: 0));
+      final d = s.intervalAfterBeacon();
+      expect(d.inSeconds, SmartBeaconingParams.defaults.slowRateS);
+    });
+
+    test('returns interpolated value at moderate speeds', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      // 14 m/s ~= 50.4 km/h, between slow (5) and fast (100)
+      s.onPositionUpdate(_pos(speedMs: 14, headingDeg: 0));
+      final d = s.intervalAfterBeacon();
+      // SmartBeaconing.computeInterval = (180 * 100 / 50.4).round() = 357
+      expect(d.inSeconds, greaterThan(SmartBeaconingParams.defaults.fastRateS));
+      expect(d.inSeconds, lessThan(SmartBeaconingParams.defaults.slowRateS));
+    });
+  });
+
+  group('SmartBeaconScheduler — onPositionUpdate (no prior state)', () {
+    test('first position ever returns Keep — no baseline yet', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final action = s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 0));
+      expect(action, isA<Keep>());
+    });
+
+    test(
+      'second position returns Keep when no timer is active and no beacon yet',
+      () {
+        final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+        s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 0));
+        final action = s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 5));
+        // No beacon has fired (markBeaconSent never called) so turn trigger
+        // is gated; no timer is set so reschedule is not possible.
+        expect(action, isA<Keep>());
+      },
+    );
+  });
+
+  group('SmartBeaconScheduler — turn trigger', () {
+    test('sharp turn at speed fires immediately after minTurnTime', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      // Establish baseline: position fix with heading=0, beacon sent.
+      s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 0), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0);
+
+      // 30 s later, heading swings 90° at 20 m/s (~72 km/h).
+      // turnThreshold at 72 km/h = (255 / (72/1.609)) + 28 = 5.7 + 28 = 33.7°
+      // 90 ≫ 33.7 and 30 s ≥ minTurnTimeS=15 → FireNow.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 20, headingDeg: 90),
+        now: t0.add(const Duration(seconds: 30)),
+      );
+      expect(action, isA<FireNow>());
+    });
+
+    test('sharp turn before minTurnTime does NOT fire', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 0), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0);
+
+      // Only 5 s elapsed — minTurnTimeS=15 default, gate blocks.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 20, headingDeg: 90),
+        now: t0.add(const Duration(seconds: 5)),
+      );
+      expect(action, isNot(isA<FireNow>()));
+    });
+
+    test('small heading delta does not fire even after minTurnTime', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 0), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0);
+
+      // 5° delta at 72 km/h is well below the ~34° threshold.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 20, headingDeg: 5),
+        now: t0.add(const Duration(seconds: 60)),
+      );
+      expect(action, isNot(isA<FireNow>()));
+    });
+
+    test('heading wraparound is handled (350° → 10° = 20° delta)', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      s.onPositionUpdate(_pos(speedMs: 20, headingDeg: 350), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0);
+
+      // Apparent delta = 340°, true delta = 20° → below threshold → no fire.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 20, headingDeg: 10),
+        now: t0.add(const Duration(seconds: 60)),
+      );
+      expect(action, isNot(isA<FireNow>()));
+    });
+  });
+
+  group('SmartBeaconScheduler — reschedule (only shorten)', () {
+    test('speed-up shortens timer to new (shorter) interval', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      // Slow start: beacon at slowRate (1800 s).
+      s.onPositionUpdate(_pos(speedMs: 0, headingDeg: 0), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0); // schedules 1800 s timer at t0.
+
+      // 1 s later, accelerate to 30 m/s (108 km/h) → fastRate (180 s).
+      // Remaining = 1800 - 1 = 1799 s. New = 180 s. Should reschedule.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 30, headingDeg: 0),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+      expect(action, isA<Reschedule>());
+      expect(
+        (action as Reschedule).delay,
+        Duration(seconds: SmartBeaconingParams.defaults.fastRateS),
+      );
+    });
+
+    test('slowdown does NOT extend timer (keep existing shorter timer)', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      // Fast start: beacon at fastRate (180 s).
+      s.onPositionUpdate(_pos(speedMs: 30, headingDeg: 0), now: t0);
+      s.markBeaconSent(t0);
+      s.intervalAfterBeacon(now: t0); // schedules 180 s timer at t0.
+
+      // 1 s later, slow to a stop → slowRate (1800 s) > remaining (179 s).
+      // Should NOT push the beacon out.
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 0, headingDeg: 0),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+      expect(action, isA<Keep>());
+    });
+
+    test('reschedule is suppressed if no timer is active', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+      // Two position updates, no markBeaconSent / intervalAfterBeacon.
+      s.onPositionUpdate(_pos(speedMs: 0, headingDeg: 0), now: t0);
+      final action = s.onPositionUpdate(
+        _pos(speedMs: 30, headingDeg: 0),
+        now: t0.add(const Duration(seconds: 1)),
+      );
+      expect(action, isA<Keep>());
+    });
+  });
+
+  group('SmartBeaconScheduler — updateParams', () {
+    test('hot-reload changes subsequent computations', () {
+      final s = SmartBeaconScheduler(params: SmartBeaconingParams.defaults);
+      s.onPositionUpdate(_pos(speedMs: 0, headingDeg: 0));
+
+      final defaultInterval = s.intervalAfterBeacon();
+      expect(
+        defaultInterval.inSeconds,
+        SmartBeaconingParams.defaults.slowRateS,
+      );
+
+      // Tighten slowRate to 600 s and re-check.
+      s.updateParams(SmartBeaconingParams.defaults.copyWith(slowRateS: 600));
+      final updated = s.intervalAfterBeacon();
+      expect(updated.inSeconds, 600);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Smart beaconing previously only worked while the app was foregrounded. The Android background isolate (`MeridianConnectionTask`) ignored `beacon_mode` entirely and always used a fixed `beacon_interval_s` timer — even when the user picked Smart.
- New pure-Dart `SmartBeaconScheduler` wraps `SmartBeaconing` math with the speed/heading bookkeeping the foreground `BeaconingService` keeps inline. The TaskHandler now reads `beacon_mode` on `start_beaconing` and dispatches per mode (manual / auto / smart).
- Manual mode no longer auto-fires from the background — closes a separate latent bug.

## How smart mode works in the background now
- Subscribes to `Geolocator.getPositionStream(LocationSettings(accuracy: best))`.
- On each position update: speed-adaptive interval via `SmartBeaconing.computeInterval`; rescheduled only if it would fire sooner (never extended).
- Sharp turns past the speed-dependent threshold trigger an immediate beacon (gated by `minTurnTimeS`); heading reset to current pre-fire so the next delta is measured from the post-turn heading.
- `smart_*` params hot-reloaded each beacon so user changes apply on the next cycle without restarting the FGS.
- If the position stream cannot start (permission missing, location service off, plugin error), the slowRate fallback timer keeps beaconing alive at fixed cadence and the FGS notification surfaces the limitation.

## Changes
- `lib/core/beaconing/smart_beacon_scheduler.dart` (new) — stateful helper with `SmartAction` sealed result type (`FireNow` / `Reschedule` / `Keep`).
- `lib/services/meridian_connection_task.dart` — mode dispatch in `_scheduleFirstBeacon` / `_scheduleNextBeacon`; new `_startSmartPositionStream` / `_onSmartPositionUpdate`; `markBeaconSent` after every successful TX; cleanup on `stop_beaconing` / `onDestroy`.
- `test/core/beaconing/smart_beacon_scheduler_test.dart` (new) — 14 unit tests covering turn trigger gating, heading wraparound, only-shorten reschedule, params hot-reload, and no-fix fallback.

## Test plan
- [x] `dart format .` clean
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 636 tests passing
- [x] Manual: smart-mode beaconing observed working in the background on Android (full drive test deferred — issue can be re-opened if real-world cadence shows problems)
- [ ] Future: real drive test to validate cadence shortening at speed and turn-triggered immediate fires

## Notes
- iOS unaffected — `IosBackgroundService` keeps the main isolate alive via `UIBackgroundModes`, so the foreground `BeaconingService` continues to run there with no changes.
- Builds on #95 — Part 1's `aprs_line` IPC payload + this PR's `markBeaconSent` compose so background smart beacons also appear in the local packet log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)