### PR TITLE
fix(packet): parse Kenwood Mic-E prefix/suffix per spec

### DIFF
--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1339,6 +1339,18 @@ class AprsParser {
     // Trim leading whitespace after prefix removal.
     comment = comment.trimLeft();
 
+    // Kenwood "legacy" manufacturer prefix per aprs.org/aprs12/mic-e-types.txt:
+    //   `>` = TH-D7 family (D7A / D72A / D74 — distinguished by trailing byte)
+    //   `]` = TM-D700 family (D700 / D710 — distinguished by trailing byte)
+    // Strip the leading byte and remember it; the trailing byte is consumed
+    // after altitude/Yaesu blocks and before suffix-driven device detection.
+    String? micEPrefix;
+    if (comment.isNotEmpty &&
+        (comment.codeUnitAt(0) == 0x3E || comment.codeUnitAt(0) == 0x5D)) {
+      micEPrefix = comment[0];
+      comment = comment.substring(1);
+    }
+
     // Base-91 altitude in Mic-E comment (APRS 1.0.1 ch.10 p.55):
     // Three base-91 chars [!-{] followed by '}' encode altitude.
     // altitude_feet = (c1-33)*91² + (c2-33)*91 + (c3-33) - 10000
@@ -1382,20 +1394,28 @@ class AprsParser {
     // info field (common on Yaesu radios) doesn't prevent `_\d$` from matching.
     comment = comment.trim();
 
-    // Resolve device from comment suffix before stripping the suffix.
-    final device = DeviceResolver.resolve(micECommentSuffix: comment);
+    // Resolve device from (Kenwood prefix, comment) tuple before stripping
+    // any trailing model byte.
+    final device = DeviceResolver.resolve(
+      micEPrefix: micEPrefix,
+      micECommentSuffix: comment,
+    );
 
-    // Strip device-indicator suffixes from the comment.
-    if (comment.endsWith(']=')) {
-      comment = comment.substring(0, comment.length - 2);
-    } else if (comment.endsWith(']\x22')) {
-      comment = comment.substring(0, comment.length - 2);
-    } else if (comment.endsWith(']') ||
-        comment.endsWith('^') ||
-        comment.endsWith('~')) {
+    // Strip device-indicator trailing byte from the comment.
+    if (micEPrefix != null) {
+      // Legacy Kenwood: at most a single trailing byte (`=` for D710/D72A,
+      // `^` for D74, `v` reserved). If it's not one of those, it's user text
+      // and must be left intact.
+      if (comment.endsWith('=') ||
+          comment.endsWith('^') ||
+          comment.endsWith('v')) {
+        comment = comment.substring(0, comment.length - 1);
+      }
+    } else if (comment.endsWith('^') || comment.endsWith('~')) {
+      // Modern Yaesu suffix — single byte.
       comment = comment.substring(0, comment.length - 1);
     } else if (_micEFt3dRe.hasMatch(comment)) {
-      // Strip trailing _\d
+      // Yaesu FT3D series — strip trailing `_\d`.
       comment = comment.substring(0, comment.length - 2);
     }
     // Note: no generic `>IDENT` suffix branch. Per aprs.org/aprs12/mic-e-types.txt

--- a/lib/core/packet/device_resolver.dart
+++ b/lib/core/packet/device_resolver.dart
@@ -137,12 +137,23 @@ class DeviceResolver {
   /// [tocall] is the destination field from the APRS header (e.g. "APDR16",
   /// "APK004"). Used for non-Mic-E packets.
   ///
-  /// [micECommentSuffix] is the raw comment suffix extracted from a Mic-E
-  /// packet AFTER stripping the telemetry prefix. Pass null for non-Mic-E
-  /// packets.
-  static String? resolve({String? tocall, String? micECommentSuffix}) {
-    if (micECommentSuffix != null) {
-      return _resolveMicESuffix(micECommentSuffix);
+  /// For Mic-E packets, pass either or both of:
+  /// - [micEPrefix] — the single manufacturer-code byte at info position 9
+  ///   (the byte right after the symbol-table char), if it is `>` or `]`.
+  ///   These mark the legacy Kenwood family and combine with [micECommentSuffix]
+  ///   to disambiguate D7A / D72A / D74 / D700 / D710 per APRS 1.0.1 ch.10
+  ///   and aprs.org/aprs12/mic-e-types.txt.
+  /// - [micECommentSuffix] — the comment text (with any trailing model byte
+  ///   still attached) AFTER stripping telemetry/altitude. Used for the
+  ///   modern Yaesu/Anytone suffix-anchored match (`^`, `~`, `_\d`) and as
+  ///   the trailing-byte input for legacy Kenwood matching.
+  static String? resolve({
+    String? tocall,
+    String? micEPrefix,
+    String? micECommentSuffix,
+  }) {
+    if (micEPrefix != null || micECommentSuffix != null) {
+      return _resolveMicE(prefix: micEPrefix, comment: micECommentSuffix ?? '');
     }
     if (tocall != null && tocall.isNotEmpty) {
       return _resolveTocall(tocall);
@@ -170,20 +181,36 @@ class DeviceResolver {
     return null;
   }
 
-  static String? _resolveMicESuffix(String comment) {
-    if (comment.isEmpty) return null;
+  // Two-pass Mic-E device resolution.
+  //
+  // Pass 1 — legacy Kenwood (prefix + optional trailing byte):
+  //   per aprs.org/aprs12/mic-e-types.txt, the Kenwood family identifies
+  //   itself with a leading byte at info[9] and an optional trailing byte
+  //   at the end of the comment. Both must agree.
+  //
+  // Pass 2 — modern (Yaesu/Anytone/Byonics) suffix-anchored matching.
+  //   These radios all use the `\x60` (backtick) leading byte uniformly
+  //   and discriminate purely on the trailing byte(s).
+  static String? _resolveMicE({
+    required String? prefix,
+    required String comment,
+  }) {
+    // Pass 1 — Kenwood legacy.
+    if (prefix == '>') {
+      if (comment.endsWith('=')) return 'Kenwood TH-D72A';
+      if (comment.endsWith('^')) return 'Kenwood TH-D74';
+      return 'Kenwood TH-D7A';
+    }
+    if (prefix == ']') {
+      if (comment.endsWith('=')) return 'Kenwood TM-D710';
+      return 'Kenwood TM-D700';
+    }
 
-    // Check in order — longest/most-specific suffixes first.
-    if (comment.endsWith(']=')) return 'Kenwood TH-D72A';
-    if (comment.endsWith(']\x22')) return 'Kenwood TM-D710';
-    if (comment.endsWith(']')) return 'Kenwood (TH-D7x/TM-D7x)';
+    // Pass 2 — Yaesu / Anytone / Byonics suffix matching.
+    if (comment.isEmpty) return null;
     if (comment.endsWith('^')) return 'Yaesu VX-8';
     if (comment.endsWith('~')) return 'Yaesu FT2D';
     if (_ft3dRe.hasMatch(comment)) return 'Yaesu FT3D series';
-
-    // Note: no generic `>IDENT` suffix resolver. Per aprs.org mic-e-types.txt
-    // and aprs-deviceid/tocalls.yaml, `>` is a device-identifier *prefix*
-    // (Kenwood TH-D7x series), never a suffix.
     return null;
   }
 

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -790,51 +790,121 @@ void main() {
 
     // Backtick 2-channel telemetry: flag + exactly 4 hex digits → strip 5 bytes.
     // Per APRS 1.0.1 ch.10: 2 channels × 2 hex digits = "a1b2" here.
+    // The trailing `]` is NOT a Kenwood model marker — per
+    // aprs.org/aprs12/mic-e-types.txt, `]` is a *leading* prefix, never
+    // a suffix. Without a `]` prefix at info[9] this is just user text
+    // and must be left intact.
     test(
-      'strips backtick 2-channel telemetry (4 hex digits) and detects ] suffix',
+      'strips backtick 2-channel telemetry (4 hex digits); bare trailing ] is left as user text',
       () {
         // comment field: \x60 + "a1b2" (valid hex) + "comment]"
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2comment]';
         final packet = parser.parse(rawLine);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
-          expect(packet.comment, equals('comment'));
-          expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
+          expect(packet.comment, equals('comment]'));
+          expect(packet.device, isNull);
         }
       },
     );
 
-    // Apostrophe 5-channel telemetry: flag + exactly 10 hex digits → strip 11 bytes.
-    // Per APRS 1.0.1 ch.10: 5 channels × 2 hex digits = "a1b2c3d4e5" here.
-    // Followed by ]" (Kenwood TM-D710 suffix).
+    // Real Kenwood TM-D710 signature (per APRS 1.0.1 ch.10 +
+    // aprs.org/aprs12/mic-e-types.txt): leading `]` manufacturer prefix at
+    // info[9], optional base-91 altitude, optional user comment, trailing `=`
+    // model byte.
     test(
-      'strips apostrophe 5-channel telemetry (10 hex digits) and detects ]" suffix (TM-D710)',
+      'TM-D710 (`]` prefix + altitude + `=` suffix): altitude parses, suffix stripped',
       () {
-        final rawLine =
-            'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]\x22';
+        // After the 9-byte fixed Mic-E block, the comment field is:
+        // ']' + '"4"}' (altitude) + 'hello' + '='
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/]\x224\x22}hello=';
         final packet = parser.parse(rawLine);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
-          expect(packet.comment, equals('comment'));
+          expect(packet.comment, equals('hello'));
           expect(packet.device, equals('Kenwood TM-D710'));
+          // altitude = (0x22-33)*91² + (0x34-33)*91 + (0x22-33) - 10000
+          //          = 8281 + 1729 + 1 - 10000 = 11
+          expect(packet.altitude, closeTo(11.0, 1.0));
         }
       },
     );
 
-    // Apostrophe 5-channel telemetry + ]= suffix (Kenwood TH-D72A).
+    // Real Kenwood TM-D700 signature: leading `]` prefix, no trailing model byte.
     test(
-      'strips apostrophe 5-channel telemetry (10 hex digits) and detects ]= suffix',
+      'TM-D700 (`]` prefix, no suffix): altitude parses, no suffix to strip',
       () {
-        final rawLine =
-            'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x27a1b2c3d4e5comment]=';
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/]\x224\x22}hello';
         final packet = parser.parse(rawLine);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
-          expect(packet.comment, equals('comment'));
-          expect(packet.device, equals('Kenwood TH-D72A'));
+          expect(packet.comment, equals('hello'));
+          expect(packet.device, equals('Kenwood TM-D700'));
+          expect(packet.altitude, closeTo(11.0, 1.0));
         }
       },
     );
+
+    // Real Kenwood TH-D72A signature: leading `>` prefix, trailing `=` suffix.
+    test('TH-D72A (`>` prefix + `=` suffix)', () {
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>\x224\x22}user=';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals('user'));
+        expect(packet.device, equals('Kenwood TH-D72A'));
+        expect(packet.altitude, closeTo(11.0, 1.0));
+      }
+    });
+
+    // Real Kenwood TH-D74 signature: leading `>` prefix, trailing `^` suffix.
+    // Regression guard: `^` alone (no `>` prefix) is Yaesu VX-8, but with
+    // a `>` prefix it is a Kenwood TH-D74.
+    test(
+      'TH-D74 (`>` prefix + `^` suffix) — not misclassified as Yaesu VX-8',
+      () {
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>hello^';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('hello'));
+          expect(packet.device, equals('Kenwood TH-D74'));
+        }
+      },
+    );
+
+    // Real-world capture from KM4TJO-9 (user-owned TM-D710): the radio sent
+    // an empty user comment, so the extension is just the prefix + altitude
+    // + suffix. Earlier the parser surfaced "]\"4\"}=" as the comment.
+    test('TM-D710 with empty user comment renders as empty comment', () {
+      final rawLine =
+          'KM4TJO-9>S6TW3Q,KE4KDY-5,WIDE1,WIDE2-1:\x60h_} *p>/]\x224\x22}=';
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals(''));
+        expect(packet.device, equals('Kenwood TM-D710'));
+        expect(packet.altitude, closeTo(11.0, 1.0));
+      }
+    });
+
+    // Real-world capture from KM4TJO-9: TM-D710 with a frequency-object-style
+    // comment ('146.520MHz Toff Eric\'s D710G'). The comment itself does not
+    // end in `=` — only the model marker does. Verifies the suffix-strip
+    // does not over-eat the user's text.
+    test('TM-D710 with frequency-object comment preserves user text', () {
+      final rawLine =
+          "KM4TJO-9>S6TV7S,KE4KDY-5,WIDE1,WIDE2-1:\x60h]nmJ\x14>/]\x223r}146.520MHz Toff Eric's D710G=";
+      final packet = parser.parse(rawLine);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, equals("146.520MHz Toff Eric's D710G"));
+        expect(packet.device, equals('Kenwood TM-D710'));
+        // altitude = (34-33)*8281 + (51-33)*91 + (114-33) - 10000
+        //          = 8281 + 1638 + 81 - 10000 = 0
+        expect(packet.altitude, closeTo(0.0, 1.0));
+      }
+    });
 
     // Real-world Yaesu FT3D packet: "`"3x}_0"
     // Backtick followed by '"' (0x22) — not a hex digit → strip only 1 byte.
@@ -890,16 +960,21 @@ void main() {
     );
 
     // Actual 2-channel telemetry: backtick + 4 hex digits + remaining comment.
-    // "a1b2" are valid hex → strip flag + 4 hex = 5 bytes.
-    test('backtick + 4 hex digits = telemetry stripped, remainder kept', () {
-      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
-      final packet = parser.parse(rawLine);
-      expect(packet, isA<MicEPacket>());
-      if (packet is MicEPacket) {
-        expect(packet.comment, equals('rest'));
-        expect(packet.device, equals('Kenwood (TH-D7x/TM-D7x)'));
-      }
-    });
+    // "a1b2" are valid hex → strip flag + 4 hex = 5 bytes. The trailing `]`
+    // is NOT a Kenwood model marker (per aprs.org/aprs12/mic-e-types.txt
+    // `]` is a leading prefix, never a suffix), so it remains as user text.
+    test(
+      'backtick + 4 hex digits = telemetry stripped, bare trailing ] kept',
+      () {
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
+        final packet = parser.parse(rawLine);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('rest]'));
+          expect(packet.device, isNull);
+        }
+      },
+    );
 
     test('comment with no prefix and no suffix is unchanged', () {
       final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';

--- a/test/core/packet/device_resolver_test.dart
+++ b/test/core/packet/device_resolver_test.dart
@@ -55,21 +55,55 @@ void main() {
     });
   });
 
-  group('DeviceResolver.resolve — Mic-E suffix', () {
-    test('suffix ] → Kenwood (TH-D7x/TM-D7x)', () {
+  group('DeviceResolver.resolve — Mic-E legacy Kenwood (prefix + suffix)', () {
+    // Per APRS 1.0.1 ch.10 + aprs.org/aprs12/mic-e-types.txt, the Kenwood
+    // family identifies via the leading byte at info[9] plus an optional
+    // trailing model byte at the end of the comment.
+
+    test('prefix `>` alone → TH-D7A', () {
       expect(
-        DeviceResolver.resolve(micECommentSuffix: 'some comment]'),
-        equals('Kenwood (TH-D7x/TM-D7x)'),
+        DeviceResolver.resolve(micEPrefix: '>', micECommentSuffix: 'hi'),
+        equals('Kenwood TH-D7A'),
       );
     });
 
-    test('suffix ]= → Kenwood TH-D72A', () {
+    test('prefix `>` + suffix `=` → TH-D72A', () {
       expect(
-        DeviceResolver.resolve(micECommentSuffix: 'some comment]='),
+        DeviceResolver.resolve(micEPrefix: '>', micECommentSuffix: 'hi='),
         equals('Kenwood TH-D72A'),
       );
     });
 
+    test('prefix `>` + suffix `^` → TH-D74 (not Yaesu VX-8)', () {
+      expect(
+        DeviceResolver.resolve(micEPrefix: '>', micECommentSuffix: 'hi^'),
+        equals('Kenwood TH-D74'),
+      );
+    });
+
+    test('prefix `]` alone → TM-D700', () {
+      expect(
+        DeviceResolver.resolve(micEPrefix: ']', micECommentSuffix: 'hi'),
+        equals('Kenwood TM-D700'),
+      );
+    });
+
+    test('prefix `]` + suffix `=` → TM-D710', () {
+      expect(
+        DeviceResolver.resolve(micEPrefix: ']', micECommentSuffix: 'hi='),
+        equals('Kenwood TM-D710'),
+      );
+    });
+
+    test('prefix `]` with empty comment → TM-D700', () {
+      expect(
+        DeviceResolver.resolve(micEPrefix: ']', micECommentSuffix: ''),
+        equals('Kenwood TM-D700'),
+      );
+    });
+  });
+
+  group('DeviceResolver.resolve — Mic-E modern (suffix-anchored)', () {
     test('suffix ^ → Yaesu VX-8', () {
       expect(
         DeviceResolver.resolve(micECommentSuffix: 'comment^'),
@@ -98,9 +132,10 @@ void main() {
       );
     });
 
-    // `>` is a Kenwood TH-D7x *prefix* per aprs-deviceid, never a suffix.
-    // Trailing `>IDENT` must not be interpreted as a device identifier —
-    // this used to false-positive on any in-comment callsign mention.
+    // `>` is a Kenwood prefix per aprs.org/aprs12/mic-e-types.txt, never
+    // a suffix. A trailing `>IDENT` in the comment must not be interpreted
+    // as a device identifier — this used to false-positive on any
+    // in-comment callsign mention.
     test('trailing `>FT3DR` does NOT resolve as a device', () {
       expect(
         DeviceResolver.resolve(micECommentSuffix: 'comment>FT3DR'),
@@ -112,6 +147,24 @@ void main() {
       expect(DeviceResolver.resolve(micECommentSuffix: 'hi>AB'), isNull);
     });
 
+    // Without a `]` prefix, a bare trailing `]` is just user text per spec.
+    // (The previous "Kenwood (TH-D7x/TM-D7x)" mapping was incorrect.)
+    test('bare trailing `]` (no prefix) → null', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'some comment]'),
+        isNull,
+      );
+    });
+
+    // Likewise `]=` without a `]` prefix: this used to be misclassified as
+    // TH-D72A. The real D72A signature is `>` prefix + `=` suffix.
+    test('bare trailing `]=` (no prefix) → null', () {
+      expect(
+        DeviceResolver.resolve(micECommentSuffix: 'some comment]='),
+        isNull,
+      );
+    });
+
     test('no known pattern → null', () {
       expect(
         DeviceResolver.resolve(micECommentSuffix: 'just a plain comment'),
@@ -121,17 +174,6 @@ void main() {
 
     test('empty suffix → null', () {
       expect(DeviceResolver.resolve(micECommentSuffix: ''), isNull);
-    });
-
-    test('generic > suffix that is too long (>10 chars) → null', () {
-      expect(
-        DeviceResolver.resolve(micECommentSuffix: 'comment>TOOLONGDEVICENAME'),
-        isNull,
-      );
-    });
-
-    test('generic > suffix that is 1 char → null (too short)', () {
-      expect(DeviceResolver.resolve(micECommentSuffix: 'comment>X'), isNull);
     });
   });
 


### PR DESCRIPTION
## Summary

- Mic-E parser now strips the leading Kenwood manufacturer byte (`>` for TH-D7 family, `]` for TM-D700 family) before altitude parsing, and strips a single trailing model byte (`=`/`^`/`v`) when a Kenwood prefix was present. Real-world TM-D710 packets like `` `h_} *p>/]"4"}= `` previously surfaced `Comment: ]"4"}=`; they now show empty comment + 11 m altitude + `Device: Kenwood TM-D710`.
- `DeviceResolver` gains a `micEPrefix` parameter and splits Mic-E detection into a legacy Kenwood (prefix, suffix) table and a modern Yaesu suffix-only matcher per `aprs.org/aprs12/mic-e-types.txt` + `aprs-deviceid/tocalls.yaml`. Fixes three misclassifications:
  - `>…=` is now correctly `TH-D72A` (was `null`)
  - `>…^` is now correctly `TH-D74` (was mis-tagged as Yaesu VX-8)
  - `]…=` is now correctly `TM-D710` (was mis-tagged as TH-D72A)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 644 passing (added 6 Kenwood fixtures including two real captures from a user-owned TM-D710, corrected 4 tests that asserted buggy suffix-only behaviour)
- [x] Real-device verification: TM-D710 beacon over RF received via second radio shows correct comment + altitude + device

🤖 Generated with [Claude Code](https://claude.com/claude-code)