### PR TITLE
fix(android): recover background notification after FGS death (#99)

### DIFF
--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -33,6 +33,11 @@ abstract interface class ForegroundServiceApi {
   });
 
   Future<ServiceRequestResult> stopService();
+
+  /// True when the OS reports the foreground service is alive. Used by BSM
+  /// to detect cases where Android killed the service (or the user swiped
+  /// the notification away) without notifying the main isolate.
+  Future<bool> isRunningService();
 }
 
 class _DefaultForegroundServiceApi implements ForegroundServiceApi {
@@ -63,6 +68,9 @@ class _DefaultForegroundServiceApi implements ForegroundServiceApi {
   @override
   Future<ServiceRequestResult> stopService() =>
       FlutterForegroundTask.stopService();
+
+  @override
+  Future<bool> isRunningService() => FlutterForegroundTask.isRunningService;
 }
 
 /// State of the Android foreground service keepalive.
@@ -361,6 +369,14 @@ class BackgroundServiceManager extends ChangeNotifier
       case AppLifecycleState.resumed:
         _isInBackground = false;
 
+        // Reconcile BSM state against the OS first. If Android killed the
+        // FGS overnight or the user swiped the notification away, _state
+        // can still be `running` even though no service exists — every
+        // subsequent action (auto-start short-circuit, updateService no-ops)
+        // breaks until we resync. Real-time swipe detection isn't reliable
+        // across Android versions; resume is the load-bearing recovery hook.
+        _reconcileWithOs(); // ignore: unawaited_futures
+
         // Cancel all pending reconnect timers — foreground handles reconnect.
         for (final id in _reconnectTimers.keys.toList()) {
           _reconnectTimers[id]?.cancel();
@@ -499,6 +515,41 @@ class BackgroundServiceManager extends ChangeNotifier
   // Auto-start / auto-stop
   // ---------------------------------------------------------------------------
 
+  /// Resyncs `_state` against the OS's view of the foreground service.
+  ///
+  /// Android can terminate the FGS without notifying the main isolate (Doze,
+  /// memory pressure, OEM throttling), and on Android 14+ swiping the
+  /// notification stops the service the same way. When that happens, BSM's
+  /// in-memory state stays `running`, which:
+  ///   - Short-circuits `_maybeAutoStart()` so no auto-restart happens.
+  ///   - Makes `_pushNotificationUpdate()` call `updateService` on a dead
+  ///     service (silent no-op).
+  ///
+  /// Callers gate this on `isRunning == true` to avoid polling the OS on
+  /// every listener tick. When the OS reports the service is gone, we
+  /// transition to `stopped` and let the normal auto-start path recreate
+  /// everything from scratch — including the notification.
+  Future<void> _reconcileWithOs() async {
+    if (!isRunning) return;
+    final running = await _taskApi.isRunningService();
+    if (running) return;
+    debugPrint(
+      'BackgroundServiceManager: OS reports FGS not running while _state='
+      '$_state — resyncing to stopped and re-attempting auto-start.',
+    );
+    _autoStarted = false;
+    _setState(BackgroundServiceState.stopped);
+    if (_shouldBeRunning) {
+      _maybeAutoStart(); // ignore: unawaited_futures
+    }
+  }
+
+  /// Test-only entrypoint for the OS-reconciliation path. The production
+  /// callers are platform-guarded (`Platform.isAndroid`), so unit tests on
+  /// Linux can't reach `_reconcileWithOs` through them.
+  @visibleForTesting
+  Future<void> debugReconcileWithOs() => _reconcileWithOs();
+
   Future<void> _maybeAutoStart() async {
     if (!Platform.isAndroid) return;
     if (isRunning || !_backgroundActivityEnabled) return;
@@ -550,6 +601,15 @@ class BackgroundServiceManager extends ChangeNotifier
   // ---------------------------------------------------------------------------
 
   void _onServiceStateChanged() {
+    // Defense-in-depth desync check: registry/beaconing events fire often,
+    // so guard the OS poll behind the cheap `isRunning` check — we only
+    // care about the case where BSM thinks the FGS is alive. The main
+    // recovery hook is on `AppLifecycleState.resumed`; this catches events
+    // that arrive before the next resume.
+    if (!kIsWeb && Platform.isAndroid && isRunning) {
+      _reconcileWithOs(); // ignore: unawaited_futures
+    }
+
     if (isRunning) {
       final anyIssue = _registry.all.any((c) {
         if (!c.isAvailable) return false;

--- a/lib/services/beaconing_service.dart
+++ b/lib/services/beaconing_service.dart
@@ -227,13 +227,17 @@ class BeaconingService extends ChangeNotifier {
   Future<void> startBeaconing() async {
     if (_isActive) return;
     _isActive = true;
+    // Reset _lastBeaconAt on every inactive→active transition so the
+    // notification body doesn't lie with a stale "Last beacon: 22m ago"
+    // value carried over from before the user disabled beaconing. Done
+    // before notifyListeners so the very first BSM rebuild sees a fresh
+    // timestamp. beaconNow() will overwrite this with the real send time
+    // on success.
+    _lastBeaconAt = DateTime.now();
     // Notify immediately so UI and BackgroundServiceManager update the
     // notification before the first beacon send (which may take several
     // seconds waiting for a GPS fix).
     notifyListeners();
-    // Seed _lastBeaconAt so the turn trigger is unblocked from the start.
-    // beaconNow() will overwrite this with the real send time on success.
-    _lastBeaconAt ??= DateTime.now();
     await _startPositionStream();
     await _restartTimer();
     // Send an immediate first beacon (standard APRS practice). On success this

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -89,7 +89,11 @@ class MeridianConnectionTask extends TaskHandler {
 
     // Also refreshes the "last beacon: Xm ago" notification text so it stays
     // current while the phone is locked (the main isolate cannot do this
-    // because its event loop is throttled when backgrounded).
+    // because its event loop is throttled when backgrounded). The body is
+    // only refreshed when this isolate is actually scheduling beacons —
+    // otherwise BSM on the main isolate is authoritative for the body
+    // (e.g. "Beaconing off" while only a connection is keeping the FGS up).
+    if (_beaconTimer == null) return;
     final ts = _lastBeaconTs;
     if (ts == null) return;
     final diffMs = DateTime.now().millisecondsSinceEpoch - ts;

--- a/test/services/background_service_manager_test.dart
+++ b/test/services/background_service_manager_test.dart
@@ -20,11 +20,16 @@ class FakeForegroundServiceApi implements ForegroundServiceApi {
   int startCallCount = 0;
   int updateCallCount = 0;
   int stopCallCount = 0;
+  int isRunningCallCount = 0;
 
   String? lastTitle;
   String? lastBody;
 
   bool startReturnsSuccess;
+
+  /// What `isRunningService()` should return — toggled in tests to simulate
+  /// Android killing the FGS without notifying the main isolate.
+  bool runningOverride = true;
 
   FakeForegroundServiceApi({this.startReturnsSuccess = true});
 
@@ -58,6 +63,12 @@ class FakeForegroundServiceApi implements ForegroundServiceApi {
   Future<ServiceRequestResult> stopService() async {
     stopCallCount++;
     return ServiceRequestSuccess();
+  }
+
+  @override
+  Future<bool> isRunningService() async {
+    isRunningCallCount++;
+    return runningOverride;
   }
 }
 
@@ -448,5 +459,163 @@ void main() {
       expect(manager.state, BackgroundServiceState.stopped);
       manager.dispose();
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #99 — state-desync recovery
+  // ---------------------------------------------------------------------------
+  group('BackgroundServiceManager — OS state reconciliation (Issue #99)', () {
+    test(
+      'reconcile transitions running → stopped when OS reports FGS gone',
+      () async {
+        final deps = await _buildDeps();
+        final fake = FakeForegroundServiceApi();
+        final manager = BackgroundServiceManager(
+          registry: deps.registry,
+          beaconing: deps.beaconing,
+          tx: deps.tx,
+          taskApi: fake,
+        );
+
+        // Simulate the bug: BSM thinks the FGS is alive, but the OS killed it.
+        manager.setStateForTest(BackgroundServiceState.running);
+        fake.runningOverride = false;
+
+        await manager.debugReconcileWithOs();
+
+        expect(fake.isRunningCallCount, 1);
+        expect(manager.state, BackgroundServiceState.stopped);
+        manager.dispose();
+      },
+    );
+
+    test('reconcile leaves state alone when OS confirms FGS running', () async {
+      final deps = await _buildDeps();
+      final fake = FakeForegroundServiceApi();
+      final manager = BackgroundServiceManager(
+        registry: deps.registry,
+        beaconing: deps.beaconing,
+        tx: deps.tx,
+        taskApi: fake,
+      );
+
+      manager.setStateForTest(BackgroundServiceState.running);
+      fake.runningOverride = true;
+
+      await manager.debugReconcileWithOs();
+
+      expect(fake.isRunningCallCount, 1);
+      expect(manager.state, BackgroundServiceState.running);
+      manager.dispose();
+    });
+
+    test(
+      'reconcile is a no-op (and does not poll OS) when state is stopped',
+      () async {
+        final deps = await _buildDeps();
+        final fake = FakeForegroundServiceApi();
+        final manager = BackgroundServiceManager(
+          registry: deps.registry,
+          beaconing: deps.beaconing,
+          tx: deps.tx,
+          taskApi: fake,
+        );
+
+        // _state starts as stopped — reconcile should short-circuit before
+        // polling the OS, so listener-tick churn doesn't drive isRunningService
+        // calls in the common case.
+        fake.runningOverride = false;
+
+        await manager.debugReconcileWithOs();
+
+        expect(fake.isRunningCallCount, 0);
+        expect(manager.state, BackgroundServiceState.stopped);
+        manager.dispose();
+      },
+    );
+
+    test(
+      'reconcile transitions reconnecting → stopped when OS reports FGS gone',
+      () async {
+        final deps = await _buildDeps();
+        final fake = FakeForegroundServiceApi();
+        final manager = BackgroundServiceManager(
+          registry: deps.registry,
+          beaconing: deps.beaconing,
+          tx: deps.tx,
+          taskApi: fake,
+        );
+
+        // `reconnecting` is also covered by `isRunning` — the bug was reported
+        // against this state too (the FGS could die mid-reconnect retry).
+        manager.setStateForTest(BackgroundServiceState.reconnecting);
+        fake.runningOverride = false;
+
+        await manager.debugReconcileWithOs();
+
+        expect(manager.state, BackgroundServiceState.stopped);
+        manager.dispose();
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #99 — BeaconingService.startBeaconing refreshes lastBeaconAt
+  // ---------------------------------------------------------------------------
+  group('BeaconingService — startBeaconing refreshes lastBeaconAt', () {
+    test(
+      'startBeaconing overwrites a stale _lastBeaconAt (Bug C)',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final settings = StationSettingsService(
+          prefs,
+          store: FakeSecureCredentialStore(),
+        );
+        // Manual location source so beaconNow does not need GPS — the test
+        // platform has no geolocator implementation.
+        await settings.setLocationSource(LocationSource.manual);
+        await settings.setManualPosition(40.0, -74.0);
+        await settings.setCallsign('NOCALL');
+
+        final registry = ConnectionRegistry();
+        final tx = TxService(registry, settings);
+        final beaconing = BeaconingService(settings, tx);
+        await beaconing.setMode(BeaconMode.auto);
+
+        // Set up the bug precondition: a stale _lastBeaconAt from a prior
+        // session. The cleanest way to plant one without exposing internals
+        // is to send a beacon, stop, then verify the stale timestamp persists
+        // until the next startBeaconing() call.
+        await beaconing.beaconNow();
+        final firstBeaconAt = beaconing.lastBeaconAt;
+        expect(firstBeaconAt, isNotNull);
+
+        // Simulate time passing — yield enough microtasks that DateTime.now()
+        // advances past `firstBeaconAt` in millisecond resolution.
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+
+        // startBeaconing must reset _lastBeaconAt to "now" so the notification
+        // body does not lie with a stale "22m ago" value carried over from
+        // before the previous stop.
+        // ignore: unawaited_futures
+        beaconing.startBeaconing();
+        // Yield so the synchronous notifyListeners + assignment chain settles
+        // (the await on _startPositionStream comes after our line of interest).
+        await Future<void>.delayed(Duration.zero);
+
+        final afterStart = beaconing.lastBeaconAt;
+        expect(afterStart, isNotNull);
+        expect(
+          afterStart!.isAfter(firstBeaconAt!),
+          isTrue,
+          reason:
+              'startBeaconing must reset _lastBeaconAt so the notification '
+              'body does not lie about the pre-disable timestamp.',
+        );
+
+        await beaconing.stopBeaconing();
+      },
+    );
   });
 }

--- a/test/services/background_service_manager_test.dart
+++ b/test/services/background_service_manager_test.dart
@@ -563,59 +563,56 @@ void main() {
   // Issue #99 — BeaconingService.startBeaconing refreshes lastBeaconAt
   // ---------------------------------------------------------------------------
   group('BeaconingService — startBeaconing refreshes lastBeaconAt', () {
-    test(
-      'startBeaconing overwrites a stale _lastBeaconAt (Bug C)',
-      () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final settings = StationSettingsService(
-          prefs,
-          store: FakeSecureCredentialStore(),
-        );
-        // Manual location source so beaconNow does not need GPS — the test
-        // platform has no geolocator implementation.
-        await settings.setLocationSource(LocationSource.manual);
-        await settings.setManualPosition(40.0, -74.0);
-        await settings.setCallsign('NOCALL');
+    test('startBeaconing overwrites a stale _lastBeaconAt (Bug C)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final settings = StationSettingsService(
+        prefs,
+        store: FakeSecureCredentialStore(),
+      );
+      // Manual location source so beaconNow does not need GPS — the test
+      // platform has no geolocator implementation.
+      await settings.setLocationSource(LocationSource.manual);
+      await settings.setManualPosition(40.0, -74.0);
+      await settings.setCallsign('NOCALL');
 
-        final registry = ConnectionRegistry();
-        final tx = TxService(registry, settings);
-        final beaconing = BeaconingService(settings, tx);
-        await beaconing.setMode(BeaconMode.auto);
+      final registry = ConnectionRegistry();
+      final tx = TxService(registry, settings);
+      final beaconing = BeaconingService(settings, tx);
+      await beaconing.setMode(BeaconMode.auto);
 
-        // Set up the bug precondition: a stale _lastBeaconAt from a prior
-        // session. The cleanest way to plant one without exposing internals
-        // is to send a beacon, stop, then verify the stale timestamp persists
-        // until the next startBeaconing() call.
-        await beaconing.beaconNow();
-        final firstBeaconAt = beaconing.lastBeaconAt;
-        expect(firstBeaconAt, isNotNull);
+      // Set up the bug precondition: a stale _lastBeaconAt from a prior
+      // session. The cleanest way to plant one without exposing internals
+      // is to send a beacon, stop, then verify the stale timestamp persists
+      // until the next startBeaconing() call.
+      await beaconing.beaconNow();
+      final firstBeaconAt = beaconing.lastBeaconAt;
+      expect(firstBeaconAt, isNotNull);
 
-        // Simulate time passing — yield enough microtasks that DateTime.now()
-        // advances past `firstBeaconAt` in millisecond resolution.
-        await Future<void>.delayed(const Duration(milliseconds: 5));
+      // Simulate time passing — yield enough microtasks that DateTime.now()
+      // advances past `firstBeaconAt` in millisecond resolution.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
 
-        // startBeaconing must reset _lastBeaconAt to "now" so the notification
-        // body does not lie with a stale "22m ago" value carried over from
-        // before the previous stop.
-        // ignore: unawaited_futures
-        beaconing.startBeaconing();
-        // Yield so the synchronous notifyListeners + assignment chain settles
-        // (the await on _startPositionStream comes after our line of interest).
-        await Future<void>.delayed(Duration.zero);
+      // startBeaconing must reset _lastBeaconAt to "now" so the notification
+      // body does not lie with a stale "22m ago" value carried over from
+      // before the previous stop.
+      // ignore: unawaited_futures
+      beaconing.startBeaconing();
+      // Yield so the synchronous notifyListeners + assignment chain settles
+      // (the await on _startPositionStream comes after our line of interest).
+      await Future<void>.delayed(Duration.zero);
 
-        final afterStart = beaconing.lastBeaconAt;
-        expect(afterStart, isNotNull);
-        expect(
-          afterStart!.isAfter(firstBeaconAt!),
-          isTrue,
-          reason:
-              'startBeaconing must reset _lastBeaconAt so the notification '
-              'body does not lie about the pre-disable timestamp.',
-        );
+      final afterStart = beaconing.lastBeaconAt;
+      expect(afterStart, isNotNull);
+      expect(
+        afterStart!.isAfter(firstBeaconAt!),
+        isTrue,
+        reason:
+            'startBeaconing must reset _lastBeaconAt so the notification '
+            'body does not lie about the pre-disable timestamp.',
+      );
 
-        await beaconing.stopBeaconing();
-      },
-    );
+      await beaconing.stopBeaconing();
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #99. After Android kills the foreground service overnight (or the user swipes the persistent notification away), `BackgroundServiceManager` never learned that the service died and the notification could not be recreated until the user fully cycled disable→reconnect→re-enable. Even then the body was stuck on a stale `Last beacon: 22m ago` until the next real beacon fired.

Three small, testable changes:

- **BSM state reconciliation** — `ForegroundServiceApi` now exposes `isRunningService`. New `_reconcileWithOs()` resyncs `_state` to `stopped` and re-runs `_maybeAutoStart` when the OS reports the FGS is dead. Wired into `AppLifecycleState.resumed` (load-bearing) and at the top of `_onServiceStateChanged` (defense-in-depth, gated on `isRunning` to avoid per-tick OS polls).
- **Fresh `_lastBeaconAt`** — `BeaconingService.startBeaconing()` now unconditionally sets `_lastBeaconAt = DateTime.now()` *before* `notifyListeners`, so the very first BSM rebuild after the toggle sees a fresh timestamp instead of leaking the stale pre-disable value into the debounced notification update.
- **Heartbeat gate** — `MeridianConnectionTask.onRepeatEvent` now refreshes the body only when `_beaconTimer != null`, so BSM remains authoritative when beaconing is off (e.g. APRS-IS-only sessions).

Real-time swipe-dismiss detection is explicitly out of scope — the plugin doesn't expose a clean signal across all Android versions, and `reconcile-on-resume` covers the user-visible symptom.

## Test plan

- [x] Unit tests: `flutter test test/services/background_service_manager_test.dart` — 25/25 including 4 new reconciliation tests + 1 strengthened Bug-C test.
- [x] Full suite: `flutter test` — 657/657 passing.
- [x] `dart format` clean, `flutter analyze` clean.
- [x] On-device repro A — `adb shell am stopservice` while backgrounded → foreground app → notification recreates within ~1s; logcat shows `BackgroundServiceManager: OS reports FGS not running … resyncing to stopped`.
- [x] On-device repro B — swipe-dismiss notification → foreground app → notification recreates.
- [x] On-device repro C — disable → wait → re-enable beaconing → body shows `Last beacon: just now` (not the stale value).
- [ ] Existing FGS heartbeat APRS-IS liveness recycle still trips (Issue #76 / ADR-061) — covered by inspection (the `aprs_is_liveness_check` IPC stays unconditional in `onRepeatEvent`).