### PR TITLE
feat(ui): show direction + transport in packet log and detail sheet

### DIFF
--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -32,13 +32,19 @@ sealed class AprsPacket {
   /// Which transport delivered this packet.
   final PacketSource transportSource;
 
-  const AprsPacket({
+  /// True when this packet was transmitted by *us* and recorded back into
+  /// the log via [StationService.recordOutgoing]. Set after construction
+  /// because the parser is unaware of TX direction.
+  bool isOutgoing;
+
+  AprsPacket({
     required this.rawLine,
     required this.source,
     required this.destination,
     required this.path,
     required this.receivedAt,
     this.transportSource = PacketSource.aprsIs,
+    this.isOutgoing = false,
   });
 }
 
@@ -74,7 +80,7 @@ class PositionPacket extends AprsPacket {
   /// centre of the ambiguity box.
   final int positionAmbiguity;
 
-  const PositionPacket({
+  PositionPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -134,7 +140,7 @@ class WeatherPacket extends AprsPacket {
   /// Rainfall since midnight, in hundredths of an inch (APRS field `P`).
   final double? rainSinceMidnight;
 
-  const WeatherPacket({
+  WeatherPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -184,7 +190,7 @@ class MessagePacket extends AprsPacket {
   /// When true, [messageId] contains the wire ID being rejected.
   final bool isRej;
 
-  const MessagePacket({
+  MessagePacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -227,7 +233,7 @@ class ObjectPacket extends AprsPacket {
   /// sit at the centre of the ambiguity box.
   final int positionAmbiguity;
 
-  const ObjectPacket({
+  ObjectPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -273,7 +279,7 @@ class ItemPacket extends AprsPacket {
   /// sit at the centre of the ambiguity box.
   final int positionAmbiguity;
 
-  const ItemPacket({
+  ItemPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -303,7 +309,7 @@ class StatusPacket extends AprsPacket {
   /// Optional DHM/HMS timestamp encoded in the status field.
   final DateTime? timestamp;
 
-  const StatusPacket({
+  StatusPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -338,7 +344,7 @@ class MicEPacket extends AprsPacket {
   /// suffix (e.g. "Kenwood TH-D72A", "Yaesu FT3D series"), or null if unknown.
   final String? device;
 
-  const MicEPacket({
+  MicEPacket({
     required super.rawLine,
     required super.source,
     required super.destination,
@@ -370,7 +376,7 @@ class UnknownPacket extends AprsPacket {
   final String reason;
   final String rawInfo;
 
-  const UnknownPacket({
+  UnknownPacket({
     required super.rawLine,
     required super.source,
     required super.destination,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -179,14 +179,13 @@ Future<void> main() async {
     });
   }
 
-  final txService = TxService(registry, stationSettings);
-
-  final beaconingService = BeaconingService(
+  final txService = TxService(
+    registry,
     stationSettings,
-    txService,
-    onBeaconSent: (line) =>
-        service.ingestLine(line, source: PacketSource.aprsIs),
+    onSent: (line, src) => service.recordOutgoing(line, source: src),
   );
+
+  final beaconingService = BeaconingService(stationSettings, txService);
   await beaconingService.loadPersistedSettings();
 
   final groupSubscriptions = GroupSubscriptionService(prefs: prefs);

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -244,58 +244,77 @@ class _PacketRow extends StatelessWidget {
     final typeLabel = _typeLabel(packet);
     final summary = _summary(packet);
     final timeStr = timeFmt.format(packet.receivedAt.toLocal());
+    final transportLabel = _transportLabel(packet);
 
     return InkWell(
       onTap: onTap,
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Timestamp
-            SizedBox(
-              width: 68,
-              child: Text(
-                timeStr,
-                style: textTheme.bodySmall?.copyWith(
-                  fontFamily: 'monospace',
-                  color: colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ),
-
-            // Type chip
-            _TypeBadge(label: typeLabel, colorScheme: colorScheme),
-
-            const SizedBox(width: 8),
-
-            // Source badge — only for TNC packets to avoid visual noise
-            if (packet.transportSource == PacketSource.tnc)
-              _SourceBadge(colorScheme: colorScheme),
-            if (packet.transportSource == PacketSource.tnc)
-              const SizedBox(width: 6),
+            // Type chip — leading, color-coded per packet type
+            _TypeBadge(label: typeLabel, brightness: theme.brightness),
+            const SizedBox(width: 10),
 
             // Callsign + summary
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    packet.source,
-                    style: textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: colorScheme.onSurface,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (summary.isNotEmpty)
-                    Text(
-                      summary,
-                      style: textTheme.bodySmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          packet.source,
+                          style: textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colorScheme.onSurface,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                      const SizedBox(width: 8),
+                      Text(
+                        timeStr,
+                        style: textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.baseline,
+                    textBaseline: TextBaseline.alphabetic,
+                    children: [
+                      if (summary.isNotEmpty)
+                        Expanded(
+                          child: Text(
+                            summary,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        )
+                      else
+                        const Spacer(),
+                      const SizedBox(width: 8),
+                      Text(
+                        transportLabel,
+                        style: textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant.withValues(
+                            alpha: 0.75,
+                          ),
+                          letterSpacing: 0.4,
+                        ),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -303,6 +322,14 @@ class _PacketRow extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  static String _transportLabel(AprsPacket p) {
+    final transport = switch (p.transportSource) {
+      PacketSource.aprsIs => 'Internet',
+      PacketSource.bleTnc || PacketSource.serialTnc || PacketSource.tnc => 'RF',
+    };
+    return p.isOutgoing ? 'Sent · $transport' : transport;
   }
 
   static String _typeLabel(AprsPacket p) {
@@ -363,60 +390,48 @@ class _PacketRow extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Type badge
+// Type badge — color-coded per packet type, theme-aware
 // ---------------------------------------------------------------------------
 
 class _TypeBadge extends StatelessWidget {
-  const _TypeBadge({required this.label, required this.colorScheme});
+  const _TypeBadge({required this.label, required this.brightness});
 
   final String label;
-  final ColorScheme colorScheme;
+  final Brightness brightness;
 
   @override
   Widget build(BuildContext context) {
+    final base = _typeBase(label);
+    final isDark = brightness == Brightness.dark;
+    final bg = base.withValues(alpha: isDark ? 0.24 : 0.16);
+    final fg = isDark ? base.shade200 : base.shade800;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      width: 56,
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(vertical: 3),
       decoration: BoxDecoration(
-        color: colorScheme.secondaryContainer,
+        color: bg,
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(
         label,
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-          color: colorScheme.onSecondaryContainer,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.3,
+          color: fg,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.4,
         ),
       ),
     );
   }
-}
 
-// ---------------------------------------------------------------------------
-// Source badge
-// ---------------------------------------------------------------------------
-
-class _SourceBadge extends StatelessWidget {
-  const _SourceBadge({required this.colorScheme});
-
-  final ColorScheme colorScheme;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-      decoration: BoxDecoration(
-        color: colorScheme.tertiaryContainer,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        'RF',
-        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-          color: colorScheme.onTertiaryContainer,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0.3,
-        ),
-      ),
-    );
-  }
+  static MaterialColor _typeBase(String label) => switch (label) {
+    'POS' => Colors.blue,
+    'MSG' => Colors.deepPurple,
+    'WX' => Colors.cyan,
+    'OBJ' => Colors.deepOrange,
+    'ITEM' => Colors.amber,
+    'STATUS' => Colors.green,
+    'MIC-E' => Colors.indigo,
+    _ => Colors.blueGrey,
+  };
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -270,6 +270,12 @@ class StationService extends ChangeNotifier {
   void ingestLine(String raw, {PacketSource source = PacketSource.aprsIs}) =>
       _handleLine(raw, source: source);
 
+  /// Record a packet that *we* just transmitted, tagged with the transport
+  /// it went out on. Used by [TxService] to surface outgoing traffic in the
+  /// packet log alongside received packets.
+  void recordOutgoing(String raw, {required PacketSource source}) =>
+      _handleLine(raw, source: source, isOutgoing: true);
+
   // ---------------------------------------------------------------------------
   // History persistence
   // ---------------------------------------------------------------------------
@@ -388,12 +394,17 @@ class StationService extends ChangeNotifier {
   // Internal
   // ---------------------------------------------------------------------------
 
-  void _handleLine(String raw, {PacketSource source = PacketSource.aprsIs}) {
+  void _handleLine(
+    String raw, {
+    PacketSource source = PacketSource.aprsIs,
+    bool isOutgoing = false,
+  }) {
     debugPrint(raw);
 
     if (raw.isEmpty || raw.startsWith('#')) return;
 
-    final packet = _parser.parse(raw, transportSource: source);
+    final packet = _parser.parse(raw, transportSource: source)
+      ..isOutgoing = isOutgoing;
 
     // Add to rolling in-session buffer, capped for performance.
     _recentPackets.insert(0, packet);

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../core/connection/connection_registry.dart';
+import '../core/packet/aprs_packet.dart';
 import 'station_settings_service.dart';
 
 // ---------------------------------------------------------------------------
@@ -32,13 +33,23 @@ class TxEventTncReconnected extends TxEvent {}
 // ---------------------------------------------------------------------------
 
 class TxService extends ChangeNotifier {
-  TxService(this._registry, this._settings) {
+  TxService(this._registry, this._settings, {this.onSent}) {
     _registry.addListener(_onRegistryChanged);
   }
 
   final ConnectionRegistry _registry;
   final StationSettingsService _settings;
   final _eventController = StreamController<TxEvent>.broadcast();
+
+  /// Invoked once per successful per-connection transmit so outgoing packets
+  /// can be recorded in the packet log tagged with their actual transport.
+  final void Function(String aprsLine, PacketSource source)? onSent;
+
+  static PacketSource _packetSourceFor(ConnectionType t) => switch (t) {
+    ConnectionType.aprsIs => PacketSource.aprsIs,
+    ConnectionType.bleTnc => PacketSource.bleTnc,
+    ConnectionType.serialTnc => PacketSource.serialTnc,
+  };
 
   bool _tncWasConnected = false;
 
@@ -84,6 +95,7 @@ class TxService extends ChangeNotifier {
     final conn = _effectiveConnection(forceVia: forceVia);
     if (conn == null) return;
     await conn.sendLine(aprsLine, digipeaterPath: digipeaterPath);
+    onSent?.call(aprsLine, _packetSourceFor(conn.type));
   }
 
   /// Send a bulletin packet honoring the per-bulletin transport flags. Unlike
@@ -112,6 +124,7 @@ class TxService extends ChangeNotifier {
       if (conn != null) {
         try {
           await conn.sendLine(aprsLine);
+          onSent?.call(aprsLine, _packetSourceFor(conn.type));
         } catch (e) {
           debugPrint('TxService: bulletin via APRS-IS failed: $e');
         }
@@ -129,6 +142,7 @@ class TxService extends ChangeNotifier {
       if (conn != null) {
         try {
           await conn.sendLine(aprsLine, digipeaterPath: rfPath);
+          onSent?.call(aprsLine, _packetSourceFor(conn.type));
         } catch (e) {
           debugPrint('TxService: bulletin via RF (${conn.id}) failed: $e');
         }
@@ -152,6 +166,7 @@ class TxService extends ChangeNotifier {
       if (conn.beaconingEnabled && conn.isConnected) {
         try {
           await conn.sendLine(aprsLine);
+          onSent?.call(aprsLine, _packetSourceFor(conn.type));
         } catch (e) {
           debugPrint('TxService: sendBeacon via ${conn.id} failed: $e');
         }
@@ -178,6 +193,7 @@ class TxService extends ChangeNotifier {
         .firstOrNull;
     if (conn != null) {
       await conn.sendLine(aprsLine, digipeaterPath: digipeaterPath);
+      onSent?.call(aprsLine, _packetSourceFor(conn.type));
     }
   }
 

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -137,7 +137,23 @@ class PacketDetailSheet extends StatelessWidget {
     // Common header fields
     m['Source'] = p.source;
     m['Destination'] = p.destination;
-    if (p.path.isNotEmpty) m['Path'] = p.path.join(', ');
+    m['Direction'] = p.isOutgoing ? 'Outgoing' : 'Incoming';
+    m[p.isOutgoing ? 'Sent via' : 'Received via'] = _transportLabel(
+      p.transportSource,
+    );
+    if (!p.isOutgoing && _isRf(p.transportSource)) {
+      // Show only digipeaters that actually relayed this packet (H-bit set,
+      // i.e. trailing '*' in the reconstructed path). Unused entries describe
+      // the requested route, not the route taken.
+      final usedDigis = p.path.where((d) => d.endsWith('*')).toList();
+      if (usedDigis.isEmpty) {
+        m['Heard'] = 'Direct from ${p.source}';
+      } else {
+        m['Heard via'] = [p.source, ...usedDigis].join(' → ');
+      }
+    } else if (p.path.isNotEmpty) {
+      m['Path'] = p.path.join(', ');
+    }
     m['Received'] = p.receivedAt
         .toUtc()
         .toString()
@@ -247,6 +263,18 @@ class PacketDetailSheet extends StatelessWidget {
     return m;
   }
 }
+
+bool _isRf(PacketSource src) =>
+    src == PacketSource.bleTnc ||
+    src == PacketSource.serialTnc ||
+    src == PacketSource.tnc;
+
+String _transportLabel(PacketSource src) => switch (src) {
+  PacketSource.aprsIs => 'Internet (APRS-IS)',
+  PacketSource.bleTnc => 'RF (BLE TNC)',
+  PacketSource.serialTnc => 'RF (Serial TNC)',
+  PacketSource.tnc => 'RF (TNC)',
+};
 
 String _formatLat(double lat) {
   final dir = lat >= 0 ? 'N' : 'S';


### PR DESCRIPTION
## Summary
- Packet detail sheet gains `Direction` (Incoming/Outgoing) and `Received via` / `Sent via` rows; the RF `Heard via` chain now drops digipeaters whose H-bit was not set, so the path reflects the route the packet actually took.
- Outgoing packets are surfaced in the packet log: `TxService` gained an `onSent(line, source)` callback wired in `main.dart` to `StationService.recordOutgoing`, which tags the packet with `isOutgoing: true` and the actual transport (Internet / BLE TNC / Serial TNC) instead of the prior always-`PacketSource.aprsIs` ingest.
- Packet log row redesign: color-coded type chip per packet type (POS/MSG/WX/OBJ/ITEM/STATUS/MIC-E/???), time moved to the top-right next to the callsign, summary on the second line, and a small dim transport label (`Internet` / `RF`, or `Sent · X` for outgoing) replaces the prior NET/RF chip.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` (667 tests pass)
- [ ] Manual: APRS-IS packets show `Internet` and existing path
- [ ] Manual: RF packets show `Heard via <source> → DIGI*` with only used digis (no trailing unused WIDE2-1)
- [ ] Manual: RF packet with no used digis shows `Heard: Direct from <CALL>`
- [ ] Manual: outgoing beacon over both APRS-IS and TNC produces two log entries, each labeled `Sent · Internet` and `Sent · RF`
- [ ] Manual: packet log row visually cleaner — type chip color-coded, time top-right, transport as small text

🤖 Generated with [Claude Code](https://claude.com/claude-code)