### PR TITLE
infra(ci): add Android/iOS/macOS/Windows debug build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
         with:
           channel: stable
 
+      - name: Install macOS build dependencies
+        # libserialport (transitive native dep of flutter_libserialport) requires
+        # automake + libtool during its CocoaPods prepare step.
+        run: brew install automake libtool
+
       - name: Install dependencies
         run: flutter pub get
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,98 @@ jobs:
       - name: Build (Linux debug)
         run: flutter build linux --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
 
+  build-android:
+    name: Build (Android debug APK)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Build (Android debug APK)
+        run: flutter build apk --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
+
+  build-ios:
+    name: Build (iOS debug, no codesign)
+    runs-on: macos-latest
+    # Info-only until iOS App Group + signing land in v1.0 (#47).
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Build (iOS debug, no codesign)
+        run: flutter build ios --no-codesign --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
+
+  build-macos:
+    name: Build (macOS debug)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Build (macOS debug)
+        run: flutter build macos --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
+
+  build-windows:
+    name: Build (Windows debug)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter (stable)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Build (Windows debug)
+        run: flutter build windows --debug --dart-define=STADIA_MAPS_API_KEY=${{ secrets.STADIA_MAPS_API_KEY }}
+
   check-deviceid-freshness:
     name: Check device-ID snapshot freshness
     if: startsWith(github.ref, 'refs/tags/')

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,7 +159,7 @@ Architecture, testing, and dependency foundations that unblock the subsequent pe
 - Service-level test coverage for `BeaconingService` (#52) and `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)
-- CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
+- ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
 - Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)
 
 ---


### PR DESCRIPTION
## Summary
- Add Android / iOS / macOS / Windows debug-build jobs to `ci.yml` alongside the existing Linux baseline.
- iOS is info-only (`continue-on-error: true`) until App Group + signing land in v1.0 (#47).
- Each platform job runs `pub get` + `analyze` + the platform build; format-check and tests stay in the existing Linux baseline (deliberately not consolidated).
- `STADIA_MAPS_API_KEY` is forwarded via `--dart-define` to every build.
- macOS job installs `automake` + `libtool` via Homebrew so the `libserialport` CocoaPod prepare step succeeds.

Closes #50.

## Matrix run
First green run: https://github.com/meridian-aprs/meridian-aprs/actions/runs/24966970997

| Platform | Status |
|---|---|
| Linux (baseline) | ✅ |
| Android | ✅ |
| iOS (info-only) | ✅ |
| macOS | ✅ |
| Windows | ✅ |

## Test plan
- [x] Existing Linux baseline still green (no regression)
- [x] Android job green
- [x] macOS job green (after `brew install automake libtool` fix)
- [x] Windows job green
- [x] iOS job runs green