### PR TITLE
refactor(core): inject Clock typedef; require receivedAt on AprsParser (#43)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,6 +106,14 @@ Inter (weights 400/500/600/700) is bundled offline and registered in `pubspec.ya
 Transport (bytes) → KISS framing → AX.25 frame → APRS parser → Station model → UI
 ```
 
+`AprsParser` is pure: `parse(...)` and `parseFrame(...)` both require a
+`receivedAt: DateTime` argument and contain zero `DateTime.now()` calls. The
+canonical transport-boundary stamp lives in `StationService._handleLine`,
+which calls `_parser.parse(raw, transportSource: source, receivedAt: _clock().toUtc())`.
+This keeps the parser deterministic for the same bytes (replay-friendly) and
+puts arrival-time stamping on the side of the system that actually knows
+when packets arrived.
+
 ## Data Flow (Transmit Path)
 
 ```
@@ -291,7 +299,7 @@ abstract interface class KissTncTransport {
 }
 ```
 
-Both `SerialKissTransport` (USB serial, desktop) and `BleTncTransport` (BLE, mobile) implement this interface. APRS parsing is **not** part of this interface — it is the service layer's responsibility.
+Both `SerialKissTransport` (USB serial, desktop) and `BleTncTransport` (BLE, mobile) implement this interface. APRS parsing is **not** part of this interface — it is the service layer's responsibility, and arrival-time stamping happens at ingestion in `StationService` (see [Data Flow (Receive Path)](#data-flow-receive-path) for the parser/transport boundary contract).
 
 ### `TransportManager`
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1352,3 +1352,43 @@ Compared to the old behaviour (potentially indefinite RX-dead until the user res
 - An opt-in outbound keepalive setting if real-world device verification shows 120 s detection still leaves user-visible gaps. Reassess after a field test pass.
 - Per-platform tuning of the SO_KEEPALIVE option number (Linux/Android `9`, macOS/iOS `8`). The current implementation tries the Linux value and silently catches; macOS / iOS users still get full coverage from the read watchdog.
 - A configurable read-idle window in Settings → Advanced. 120 s was chosen to comfortably exceed the typical server keepalive cadence; surfacing it as a knob is unnecessary unless we encounter servers with materially different behaviour.
+
+
+## ADR-062: Inject `Clock` typedef for deterministic time-dependent logic
+
+**Date:** 2026-04-26
+**Status:** Accepted
+
+### Context
+
+Three independent audits (F-ARCH-006 / F-EXT-002 / F-FLT-009) flagged `DateTime.now()` scattered across the service layer. Concretely it blocks deterministic testing of:
+
+- `BeaconingService` interval / smart-turn / reschedule logic.
+- `MessageService` retry-backoff and pruning.
+- `StationService` / `BulletinService` retention pruning.
+- `BackgroundServiceManager` and `MeridianConnectionTask` liveness / heartbeat / beacon-resume math.
+- `SmartBeaconScheduler` interval-after-beacon and only-shorten reschedule.
+
+It also coupled `AprsParser` to wall-clock — a parser should be a pure function of input bytes, with the received-at stamp supplied at the transport boundary.
+
+### Decision
+
+Introduce `typedef Clock = DateTime Function();` in `lib/core/util/clock.dart` (no external dependency).
+
+- Each affected class accepts `Clock clock = DateTime.now` as a defaulted constructor parameter and stores it as `final Clock _clock`. Body sites call `_clock()` instead of `DateTime.now()`.
+- `AprsParser.parse(...)` and `AprsParser.parseFrame(...)` now take `required DateTime receivedAt`. The parser contains zero `DateTime.now()` calls.
+- `StationService` is the canonical transport-boundary stamp site: `_handleLine` calls `_parser.parse(raw, transportSource: source, receivedAt: _clock().toUtc())`. `BleConnection` and `SerialConnection` also stamp via their own injected clock when reconstructing AX.25 frame text (the timestamp is structurally required but discarded — only `packet.rawLine` is forwarded; `StationService` re-stamps on ingestion).
+- `BulletinScheduler` already followed this pattern with an inline `DateTime Function()? clock` parameter; standardised on the new `Clock` typedef.
+
+### Alternatives considered
+
+- **`package:clock`** — rejected to keep zero-dep posture in the core. The project already had a proven in-house pattern (`BulletinScheduler._MutableClock` test helper), and the typedef is a single line of code. The package is already a *transitive* dependency via `intl`, but we deliberately do not depend on its API surface so future churn there cannot break us.
+- **Per-method `DateTime? now` overrides everywhere** — rejected as too invasive at call sites and inconsistent with `BulletinScheduler`. `SmartBeaconScheduler` retains its existing per-method `now` parameter as a convenience but its fallback now reads `_clock()` instead of `DateTime.now()`.
+
+### Consequences
+
+- UI date/time formatters (`*_screen.dart`, `*_tab.dart`, `chat_bubble.dart`, `station_list_tile.dart`, etc.) intentionally remain on `DateTime.now()` — they want render-time "now" and are out of scope.
+- Tests can fake-advance time per service via the same `_MutableClock` shape used in `bulletin_scheduler_test.dart`. Full per-service coverage is deferred to PR 4 (#60, TxService routing) and PR 5 (#52, BeaconingService).
+- One spot-check test (`test/core/util/clock_injection_test.dart`) covers `StationService` retention pruning end-to-end as proof of the seam.
+- Future replay / golden-frame test flows are now feasible — a recorded packet stream can be played through the parser with a deterministic timeline.
+- The background isolate's `MeridianConnectionTask` accepts a `Clock` too, for unit tests; the production `vm:entry-point` constructs it with the default `DateTime.now`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -155,7 +155,7 @@ Protocol-complete APRS messaging — group messages (`CQ`, `QST`, `ALL`, custom 
 
 Architecture, testing, and dependency foundations that unblock the subsequent performance, polish, and launch work. Nothing here is user-visible on its own; all of it removes friction or risk from later milestones.
 
-- Inject `Clock` abstraction so time-dependent logic is deterministic in tests (#43)
+- ✅ Inject `Clock` abstraction so time-dependent logic is deterministic in tests (#43)
 - Service-level test coverage for `BeaconingService` (#52) and `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)

--- a/lib/core/beaconing/smart_beacon_scheduler.dart
+++ b/lib/core/beaconing/smart_beacon_scheduler.dart
@@ -11,6 +11,7 @@ library;
 
 import 'package:geolocator/geolocator.dart';
 
+import '../util/clock.dart';
 import 'smart_beaconing.dart';
 
 /// Decision returned by [SmartBeaconScheduler.onPositionUpdate].
@@ -38,10 +39,14 @@ class Keep extends SmartAction {
 }
 
 class SmartBeaconScheduler {
-  SmartBeaconScheduler({required SmartBeaconingParams params})
-    : _params = params;
+  SmartBeaconScheduler({
+    required SmartBeaconingParams params,
+    Clock clock = DateTime.now,
+  }) : _params = params,
+       _clock = clock;
 
   SmartBeaconingParams _params;
+  final Clock _clock;
   Position? _lastPosition;
   double? _lastHeading;
   DateTime? _lastBeaconAt;
@@ -78,7 +83,7 @@ class SmartBeaconScheduler {
   ///
   /// If no GPS fix is available yet, falls back to the slowRate.
   Duration intervalAfterBeacon({DateTime? now}) {
-    final stamp = now ?? DateTime.now();
+    final stamp = now ?? _clock();
     final speedKmh = _speedKmhFromLast();
     final intervalS = SmartBeaconing.computeInterval(_params, speedKmh);
     _currentTimerStartedAt = stamp;
@@ -91,7 +96,7 @@ class SmartBeaconScheduler {
   /// Mirrors [BeaconingService._onPositionUpdate] exactly — turn trigger
   /// check first (gated on minTurnTimeS), then only-shorten reschedule.
   SmartAction onPositionUpdate(Position position, {DateTime? now}) {
-    final stamp = now ?? DateTime.now();
+    final stamp = now ?? _clock();
     final speedKmh = (position.speed * 3.6).clamp(0.0, double.infinity);
     final heading = position.heading;
 

--- a/lib/core/connection/ble_connection_impl.dart
+++ b/lib/core/connection/ble_connection_impl.dart
@@ -10,6 +10,7 @@ import '../ax25/ax25_encoder.dart';
 import '../packet/aprs_parser.dart';
 import '../transport/ble_tnc_transport.dart';
 import '../transport/kiss_tnc_transport.dart';
+import '../util/clock.dart';
 import 'meridian_connection.dart';
 import 'reconnectable_mixin.dart';
 
@@ -26,7 +27,9 @@ import 'reconnectable_mixin.dart';
 /// Call [connectToDevice] to initiate a session with a specific BLE device.
 /// Calling [connect] after [connectToDevice] re-uses the stored device.
 class BleConnection extends MeridianConnection with ReconnectableMixin {
-  BleConnection();
+  BleConnection({Clock clock = DateTime.now}) : _clock = clock;
+
+  final Clock _clock;
 
   static const _kBeaconingKey = 'beacon_enabled_ble_tnc';
 
@@ -293,7 +296,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   }
 
   void _onFrame(Uint8List frameBytes) {
-    final packet = _parser.parseFrame(frameBytes);
+    final packet = _parser.parseFrame(frameBytes, receivedAt: _clock().toUtc());
     if (packet.rawLine.isNotEmpty && !_linesController.isClosed) {
       _linesController.add(packet.rawLine);
     }

--- a/lib/core/connection/ble_connection_stub.dart
+++ b/lib/core/connection/ble_connection_stub.dart
@@ -3,11 +3,12 @@ library;
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import '../transport/kiss_tnc_transport.dart';
+import '../util/clock.dart';
 import 'meridian_connection.dart';
 
 /// Stub [BleConnection] for platforms where BLE is not supported (web, desktop).
 class BleConnection extends MeridianConnection {
-  BleConnection();
+  BleConnection({Clock clock = DateTime.now});
 
   @visibleForTesting
   KissTncTransport Function(dynamic)? transportFactory;

--- a/lib/core/connection/serial_connection_impl.dart
+++ b/lib/core/connection/serial_connection_impl.dart
@@ -10,6 +10,7 @@ import '../packet/aprs_parser.dart';
 import '../transport/kiss_tnc_transport.dart';
 import '../transport/serial_kiss_transport.dart';
 import '../transport/tnc_config.dart';
+import '../util/clock.dart';
 import 'meridian_connection.dart';
 import 'reconnectable_mixin.dart';
 
@@ -28,7 +29,9 @@ import 'reconnectable_mixin.dart';
 /// SharedPreferences so it survives app restarts; [loadPersistedSettings]
 /// restores it on startup without connecting.
 class SerialConnection extends MeridianConnection with ReconnectableMixin {
-  SerialConnection();
+  SerialConnection({Clock clock = DateTime.now}) : _clock = clock;
+
+  final Clock _clock;
 
   static const _kBeaconingKey = 'beacon_enabled_serial_tnc';
 
@@ -302,7 +305,7 @@ class SerialConnection extends MeridianConnection with ReconnectableMixin {
   }
 
   void _onFrame(Uint8List frameBytes) {
-    final packet = _parser.parseFrame(frameBytes);
+    final packet = _parser.parseFrame(frameBytes, receivedAt: _clock().toUtc());
     if (packet.rawLine.isNotEmpty && !_linesController.isClosed) {
       _linesController.add(packet.rawLine);
     }

--- a/lib/core/connection/serial_connection_stub.dart
+++ b/lib/core/connection/serial_connection_stub.dart
@@ -4,11 +4,12 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import '../transport/kiss_tnc_transport.dart';
 import '../transport/tnc_config.dart';
+import '../util/clock.dart';
 import 'meridian_connection.dart';
 
 /// Stub [SerialConnection] for platforms where serial is not supported (web).
 class SerialConnection extends MeridianConnection {
-  SerialConnection();
+  SerialConnection({Clock clock = DateTime.now});
 
   @visibleForTesting
   KissTncTransport Function(TncConfig)? transportFactory;

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -34,12 +34,13 @@ class AprsParser {
   ///
   /// Format: `SOURCE>DEST,PATH:INFO`
   ///
-  /// Supply [receivedAt] to override the default of [DateTime.now]. Useful
-  /// when restoring persisted packets that already have a known receive time.
+  /// [receivedAt] stamps the moment the packet arrived. The parser is pure
+  /// w.r.t. wall-clock — callers (typically [StationService] at the transport
+  /// boundary) supply the timestamp so tests can inject deterministic time.
   AprsPacket parse(
     String line, {
+    required DateTime receivedAt,
     PacketSource transportSource = PacketSource.aprsIs,
-    DateTime? receivedAt,
   }) {
     // Ignore blank lines and server comment lines.
     if (line.isEmpty || line.startsWith('#')) {
@@ -49,6 +50,7 @@ class AprsParser {
         '',
         [],
         'Server comment or empty line',
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -62,6 +64,7 @@ class AprsParser {
         '',
         [],
         'No colon separator found',
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -78,6 +81,7 @@ class AprsParser {
         '',
         [],
         'No > in header',
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -94,12 +98,12 @@ class AprsParser {
         destination,
         path,
         'Empty info field',
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
 
     final dti = info[0];
-    final now = receivedAt ?? DateTime.now().toUtc();
 
     try {
       return _dispatch(
@@ -109,7 +113,7 @@ class AprsParser {
         source: source,
         destination: destination,
         path: path,
-        receivedAt: now,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     } catch (_) {
@@ -119,7 +123,7 @@ class AprsParser {
         source: source,
         destination: destination,
         path: path,
-        receivedAt: now,
+        receivedAt: receivedAt,
         transportSource: transportSource,
         reason: 'Unhandled parse exception',
         rawInfo: info,
@@ -129,10 +133,11 @@ class AprsParser {
 
   /// Parse raw AX.25 frame bytes.
   ///
-  /// Stub implementation — returns [UnknownPacket] until AX.25 framing support
-  /// is added in a future milestone.
+  /// [receivedAt] stamps the moment the frame arrived. See [parse] for the
+  /// rationale.
   AprsPacket parseFrame(
     Uint8List frameBytes, {
+    required DateTime receivedAt,
     PacketSource transportSource = PacketSource.aprsIs,
   }) {
     final result = const Ax25Parser().parseFrame(frameBytes);
@@ -142,7 +147,7 @@ class AprsParser {
         source: '',
         destination: '',
         path: const [],
-        receivedAt: DateTime.now().toUtc(),
+        receivedAt: receivedAt,
         transportSource: transportSource,
         reason: 'AX.25 decode failed: ${result.reason}',
       );
@@ -155,7 +160,11 @@ class AprsParser {
     final pathStr = frame.pathString.isEmpty ? '' : ',${frame.pathString}';
     final reconstructed =
         '${frame.source}>${frame.destination}$pathStr:$infoStr';
-    return parse(reconstructed, transportSource: transportSource);
+    return parse(
+      reconstructed,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -292,6 +301,7 @@ class AprsParser {
           path,
           'Unrecognised DTI: $dti',
           rawInfo: info,
+          receivedAt: receivedAt,
           transportSource: transportSource,
         );
     }
@@ -354,6 +364,7 @@ class AprsParser {
           path,
           'Timestamped position too short',
           rawInfo: info,
+          receivedAt: receivedAt,
           transportSource: transportSource,
         );
       }
@@ -372,6 +383,7 @@ class AprsParser {
         path,
         'No position data after DTI/timestamp',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -452,6 +464,7 @@ class AprsParser {
         path,
         'Uncompressed position regex did not match',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -532,6 +545,7 @@ class AprsParser {
         path,
         'Compressed position string too short',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -553,6 +567,7 @@ class AprsParser {
         path,
         'Invalid base-91 encoding in compressed position',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -681,6 +696,7 @@ class AprsParser {
         path,
         'Object packet too short',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -698,6 +714,7 @@ class AprsParser {
         path,
         'Object packet missing timestamp/position',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -722,6 +739,7 @@ class AprsParser {
           path,
           'Object uncompressed position regex did not match',
           rawInfo: info,
+          receivedAt: receivedAt,
           transportSource: transportSource,
         );
       }
@@ -782,6 +800,7 @@ class AprsParser {
         path,
         'Object compressed position too short',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -801,6 +820,7 @@ class AprsParser {
         path,
         'Object compressed position decode failed',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -849,6 +869,7 @@ class AprsParser {
         path,
         'Item packet too short',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -872,6 +893,7 @@ class AprsParser {
         path,
         'Item name delimiter not found',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -888,6 +910,7 @@ class AprsParser {
         path,
         'Item position parse failed',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -940,6 +963,7 @@ class AprsParser {
         path,
         'Message format invalid (need :XXXXXXXXX:)',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -1179,6 +1203,7 @@ class AprsParser {
         path,
         'Mic-E packet too short',
         rawInfo: info,
+        receivedAt: receivedAt,
         transportSource: transportSource,
       );
     }
@@ -1556,6 +1581,7 @@ class AprsParser {
     String destination,
     List<String> path,
     String reason, {
+    required DateTime receivedAt,
     String rawInfo = '',
     PacketSource transportSource = PacketSource.aprsIs,
   }) {
@@ -1564,7 +1590,7 @@ class AprsParser {
       source: source,
       destination: destination,
       path: path,
-      receivedAt: DateTime.now().toUtc(),
+      receivedAt: receivedAt,
       transportSource: transportSource,
       reason: reason,
       rawInfo: rawInfo,

--- a/lib/core/transport/aprs_is_transport.dart
+++ b/lib/core/transport/aprs_is_transport.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart'
     show debugPrint, kIsWeb, visibleForTesting;
 
+import '../util/clock.dart';
 import 'aprs_transport.dart';
 
 // TODO(web): replace with WebSocketTransport — see ADR-004
@@ -19,10 +20,14 @@ class AprsIsTransport implements AprsTransport {
     int port = 14580,
     required String loginLine,
     String? filterLine,
+    Clock clock = DateTime.now,
   }) : _host = host,
        _port = port,
        _loginLine = loginLine,
-       _filterLine = filterLine;
+       _filterLine = filterLine,
+       _clock = clock;
+
+  final Clock _clock;
 
   String get host => _host;
   int get port => _port;
@@ -152,7 +157,7 @@ class AprsIsTransport implements AprsTransport {
           .transform(const LineSplitter())
           .listen(
             (line) {
-              _lastLineAt = DateTime.now();
+              _lastLineAt = _clock();
               _resetReadWatchdog();
               if (!_controller.isClosed) _controller.add(line);
             },

--- a/lib/core/util/clock.dart
+++ b/lib/core/util/clock.dart
@@ -1,0 +1,6 @@
+/// Injectable wall-clock seam for time-dependent logic.
+///
+/// Default = `DateTime.now`. Tests pass a closure that returns a controllable
+/// `DateTime`. UI date/time formatters intentionally do not use this — they
+/// want render-time "now".
+typedef Clock = DateTime Function();

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/connection/aprs_is_connection.dart';
 import '../core/connection/connection_registry.dart';
+import '../core/util/clock.dart';
 import 'beaconing_service.dart';
 import 'meridian_connection_task.dart';
 import 'tx_service.dart';
@@ -122,11 +123,13 @@ class BackgroundServiceManager extends ChangeNotifier
     required TxService tx,
     ForegroundServiceApi? taskApi,
     void Function(String line)? onPacketLogged,
+    Clock clock = DateTime.now,
   }) : _registry = registry,
        _beaconing = beaconing,
        _tx = tx,
        _taskApi = taskApi ?? const _DefaultForegroundServiceApi(),
-       _onPacketLogged = onPacketLogged {
+       _onPacketLogged = onPacketLogged,
+       _clock = clock {
     _registry.addListener(_onServiceStateChanged);
     _beaconing.addListener(_onServiceStateChanged);
     if (!kIsWeb && Platform.isAndroid) {
@@ -143,6 +146,7 @@ class BackgroundServiceManager extends ChangeNotifier
   final BeaconingService _beaconing;
   final TxService _tx;
   final ForegroundServiceApi _taskApi;
+  final Clock _clock;
 
   /// Invoked when the background isolate reports a transmitted line
   /// (`beacon_sent` / `bulletin_sent` IPC). Wire this to
@@ -414,7 +418,7 @@ class BackgroundServiceManager extends ChangeNotifier
         // stale — otherwise we'd flash "Disconnected" on every resume even
         // though the FGS heartbeat kept the link healthy through the lock
         // period (Issue #76).
-        final now = DateTime.now();
+        final now = _clock();
         for (final id in _reconnectIds) {
           final conn = _registry.byId(id);
           if (conn == null) continue;
@@ -450,7 +454,7 @@ class BackgroundServiceManager extends ChangeNotifier
         final bgTs = DateTime.fromMillisecondsSinceEpoch(bgTsMs);
         ts = (mainTs != null && mainTs.isAfter(bgTs)) ? mainTs : bgTs;
       } else {
-        ts = mainTs ?? DateTime.now();
+        ts = mainTs ?? _clock();
       }
       _beaconing.resumeFromBackground(ts);
     });
@@ -502,7 +506,7 @@ class BackgroundServiceManager extends ChangeNotifier
   /// Driven by the FGS heartbeat (~60 s cadence) so detection works even when
   /// Android Doze has frozen the in-isolate read watchdog.
   void _checkAprsIsLiveness() {
-    final now = DateTime.now();
+    final now = _clock();
     for (final conn in _registry.all) {
       if (conn is! AprsIsConnection) continue;
       if (conn.status != ConnectionStatus.connected) continue;

--- a/lib/services/beaconing_service.dart
+++ b/lib/services/beaconing_service.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/beaconing/smart_beaconing.dart';
 import '../core/packet/aprs_encoder.dart';
+import '../core/util/clock.dart';
 import 'station_settings_service.dart';
 import 'tx_service.dart';
 
@@ -39,10 +40,16 @@ enum BeaconError {
 }
 
 class BeaconingService extends ChangeNotifier {
-  BeaconingService(this._settings, this._tx, {this.onBeaconSent});
+  BeaconingService(
+    this._settings,
+    this._tx, {
+    this.onBeaconSent,
+    Clock clock = DateTime.now,
+  }) : _clock = clock;
 
   final StationSettingsService _settings;
   final TxService _tx;
+  final Clock _clock;
 
   /// Called after every successful beacon with the raw APRS-IS line.
   ///
@@ -217,7 +224,7 @@ class BeaconingService extends ChangeNotifier {
     // does not echo the packet back.
     onBeaconSent?.call(aprsLine);
     await _tx.sendBeacon(aprsLine);
-    _lastBeaconAt = DateTime.now();
+    _lastBeaconAt = _clock();
 
     if (_isActive) await _restartTimer();
     notifyListeners();
@@ -233,7 +240,7 @@ class BeaconingService extends ChangeNotifier {
     // before notifyListeners so the very first BSM rebuild sees a fresh
     // timestamp. beaconNow() will overwrite this with the real send time
     // on success.
-    _lastBeaconAt = DateTime.now();
+    _lastBeaconAt = _clock();
     // Notify immediately so UI and BackgroundServiceManager update the
     // notification before the first beacon send (which may take several
     // seconds waiting for a GPS fix).
@@ -282,7 +289,7 @@ class BeaconingService extends ChangeNotifier {
     _timer?.cancel();
     _lastBeaconAt = ts;
     if (_isActive) {
-      final elapsed = DateTime.now().difference(ts).inSeconds;
+      final elapsed = _clock().difference(ts).inSeconds;
       final remaining = (_autoIntervalS - elapsed).clamp(0, _autoIntervalS);
       _timerStartedAt = ts;
       _timerIntervalS = _autoIntervalS;
@@ -378,7 +385,7 @@ class BeaconingService extends ChangeNotifier {
         _lastBeaconAt != null &&
         _lastHeading != null) {
       final headingDelta = _angleDiff(heading, _lastHeading!);
-      final timeSinceLast = DateTime.now().difference(_lastBeaconAt!);
+      final timeSinceLast = _clock().difference(_lastBeaconAt!);
       if (SmartBeaconing.shouldTriggerTurn(
         _smartParams,
         speedKmh,
@@ -418,7 +425,7 @@ class BeaconingService extends ChangeNotifier {
   Future<void> _restartTimer() async {
     _timer?.cancel();
     final intervalS = await _resolveCurrentInterval();
-    _timerStartedAt = DateTime.now();
+    _timerStartedAt = _clock();
     _timerIntervalS = intervalS;
     _timer = Timer(Duration(seconds: intervalS), _onTimerFired);
   }
@@ -428,13 +435,13 @@ class BeaconingService extends ChangeNotifier {
   /// the timer and delaying beacons indefinitely.
   void _rescheduleSmartTimer(int intervalS) {
     if (_timerStartedAt != null && _timerIntervalS != null) {
-      final elapsed = DateTime.now().difference(_timerStartedAt!).inSeconds;
+      final elapsed = _clock().difference(_timerStartedAt!).inSeconds;
       final remaining = _timerIntervalS! - elapsed;
       // Only shorten — never push the beacon further out.
       if (intervalS >= remaining) return;
     }
     _timer?.cancel();
-    _timerStartedAt = DateTime.now();
+    _timerStartedAt = _clock();
     _timerIntervalS = intervalS;
     _timer = Timer(Duration(seconds: intervalS), _onTimerFired);
   }

--- a/lib/services/bulletin_scheduler.dart
+++ b/lib/services/bulletin_scheduler.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../core/packet/aprs_encoder.dart';
+import '../core/util/clock.dart';
 import '../models/outgoing_bulletin.dart';
 import 'bulletin_service.dart';
 import 'messaging_settings_service.dart';
@@ -48,20 +49,20 @@ class BulletinScheduler extends ChangeNotifier {
     required MessagingSettingsService messagingSettings,
     required StationSettingsService stationSettings,
     Duration tickInterval = const Duration(seconds: 30),
-    DateTime Function()? clock,
+    Clock clock = DateTime.now,
   }) : _bulletins = bulletins,
        _tx = tx,
        _messagingSettings = messagingSettings,
        _stationSettings = stationSettings,
        _tickInterval = tickInterval,
-       _clock = clock ?? DateTime.now;
+       _clock = clock;
 
   final BulletinService _bulletins;
   final TxService _tx;
   final MessagingSettingsService _messagingSettings;
   final StationSettingsService _stationSettings;
   final Duration _tickInterval;
-  final DateTime Function() _clock;
+  final Clock _clock;
 
   final _eventController = StreamController<Object>.broadcast();
   Timer? _timer;

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -19,6 +19,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/packet/aprs_packet.dart';
+import '../core/util/clock.dart';
 import '../models/bulletin.dart';
 import '../models/outgoing_bulletin.dart';
 import 'bulletin_subscription_service.dart';
@@ -40,11 +41,14 @@ class BulletinService extends ChangeNotifier {
   BulletinService({
     required BulletinSubscriptionService subscriptions,
     SharedPreferences? prefs,
+    Clock clock = DateTime.now,
   }) : _subscriptions = subscriptions,
-       _prefsOverride = prefs;
+       _prefsOverride = prefs,
+       _clock = clock;
 
   final BulletinSubscriptionService _subscriptions;
   final SharedPreferences? _prefsOverride;
+  final Clock _clock;
 
   static const _keyBulletins = 'bulletins_v1';
   static const _keyNextId = 'bulletins_next_id_v1';
@@ -347,7 +351,7 @@ class BulletinService extends ChangeNotifier {
         'invalid bulletin addressee — must be BLN[0-9A-Z][NAME]',
       );
     }
-    final now = DateTime.now();
+    final now = _clock();
     final ob = OutgoingBulletin(
       id: _outgoingNextId++,
       addressee: normalized,
@@ -469,7 +473,7 @@ class BulletinService extends ChangeNotifier {
   /// Call from a periodic sweeper (added in PR 5 along with the notification
   /// pipeline).
   Future<void> pruneOlderThan(Duration retention) async {
-    final cutoff = DateTime.now().subtract(retention);
+    final cutoff = _clock().subtract(retention);
     final before = _bulletins.length;
     _bulletins.removeWhere((_, b) => b.lastHeardAt.isBefore(cutoff));
     if (_bulletins.length == before) return;

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -12,6 +12,7 @@ import '../core/beaconing/smart_beaconing.dart';
 import '../core/credentials/credential_key.dart';
 import '../core/credentials/secure_credential_store.dart';
 import '../core/packet/aprs_encoder.dart';
+import '../core/util/clock.dart';
 import '../models/outgoing_bulletin.dart';
 import 'beaconing_service.dart' show BeaconMode;
 import 'bulletin_service.dart';
@@ -46,6 +47,10 @@ void startMeridianConnectionTask() {
 /// `rotate.aprs2.net:14580`, logs in, sends the packet, and closes. This is
 /// independent of the main isolate's APRS-IS socket.
 class MeridianConnectionTask extends TaskHandler {
+  MeridianConnectionTask({Clock clock = DateTime.now}) : _clock = clock;
+
+  final Clock _clock;
+
   Timer? _beaconTimer;
   Timer? _bulletinTimer;
   int? _lastBeaconTs; // ms since epoch; null until first beacon this session
@@ -104,7 +109,7 @@ class MeridianConnectionTask extends TaskHandler {
     // unable to fire (Issue #76).
     FlutterForegroundTask.sendDataToMain({
       'type': 'aprs_is_liveness_check',
-      'now_ms': DateTime.now().millisecondsSinceEpoch,
+      'now_ms': _clock().millisecondsSinceEpoch,
     });
 
     // Also refreshes the "last beacon: Xm ago" notification text so it stays
@@ -116,7 +121,7 @@ class MeridianConnectionTask extends TaskHandler {
     if (_beaconTimer == null) return;
     final ts = _lastBeaconTs;
     if (ts == null) return;
-    final diffMs = DateTime.now().millisecondsSinceEpoch - ts;
+    final diffMs = _clock().millisecondsSinceEpoch - ts;
     final minutes = diffMs ~/ 60000;
     final ago = minutes < 1 ? 'just now' : '${minutes}m ago';
     FlutterForegroundTask.updateService(
@@ -181,7 +186,7 @@ class MeridianConnectionTask extends TaskHandler {
       if (_activeMode == BeaconMode.manual) return;
 
       final intervalS = _resolveInitialIntervalS(prefs);
-      final elapsedMs = DateTime.now().millisecondsSinceEpoch - lastBeaconTsMs;
+      final elapsedMs = _clock().millisecondsSinceEpoch - lastBeaconTsMs;
       final elapsedS = elapsedMs ~/ 1000;
       final remainingS = (intervalS - elapsedS).clamp(0, intervalS);
       _beaconTimer = Timer(Duration(seconds: remainingS), _onBeaconTimer);
@@ -195,14 +200,14 @@ class MeridianConnectionTask extends TaskHandler {
           DateTime.fromMillisecondsSinceEpoch(
             lastBeaconTsMs > 0
                 ? lastBeaconTsMs
-                : DateTime.now().millisecondsSinceEpoch,
+                : _clock().millisecondsSinceEpoch,
           ),
         );
         smart.seedCurrentTimer(
           startedAt: DateTime.fromMillisecondsSinceEpoch(
             lastBeaconTsMs > 0
                 ? lastBeaconTsMs
-                : DateTime.now().millisecondsSinceEpoch,
+                : _clock().millisecondsSinceEpoch,
           ),
           intervalS: intervalS,
         );
@@ -458,7 +463,7 @@ class MeridianConnectionTask extends TaskHandler {
 
     if (!anySent) return;
 
-    final tsMs = DateTime.now().millisecondsSinceEpoch;
+    final tsMs = _clock().millisecondsSinceEpoch;
     _lastBeaconTs = tsMs;
 
     // Reset the smart scheduler's turn-trigger window so the next sharp turn
@@ -584,7 +589,7 @@ class MeridianConnectionTask extends TaskHandler {
     }
 
     var mutated = false;
-    final now = DateTime.now();
+    final now = _clock();
     for (var i = 0; i < outgoing.length; i++) {
       final ob = outgoing[i];
       if (!ob.enabled) continue;

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -20,6 +20,7 @@ import '../core/callsign/callsign_utils.dart';
 import '../core/callsign/message_classification.dart';
 import '../core/packet/aprs_encoder.dart';
 import '../core/packet/aprs_packet.dart';
+import '../core/util/clock.dart';
 import '../models/group_subscription.dart';
 import '../models/message_category.dart';
 import 'bulletin_service.dart';
@@ -112,11 +113,15 @@ class MessageService extends ChangeNotifier {
     StationService stations, {
     required GroupSubscriptionService groupSubscriptions,
     required BulletinService bulletins,
+    Clock clock = DateTime.now,
   }) : _stations = stations,
        _groupSubscriptions = groupSubscriptions,
-       _bulletins = bulletins {
+       _bulletins = bulletins,
+       _clock = clock {
     _incomingSub = stations.packetStream.listen(_onPacket);
   }
+
+  final Clock _clock;
 
   final StationSettingsService _settings;
   final TxService _tx;
@@ -320,12 +325,12 @@ class MessageService extends ChangeNotifier {
     // their own send in the channel view. No wireId, no retry loop.
     final localId =
         'group_${normalized}_'
-        '${DateTime.now().millisecondsSinceEpoch}';
+        '${_clock().millisecondsSinceEpoch}';
     final entry = MessageEntry(
       localId: localId,
       wireId: null,
       text: text,
-      timestamp: DateTime.now(),
+      timestamp: _clock(),
       isOutgoing: true,
       category: MessageCategory.group,
       groupName: normalized,
@@ -344,20 +349,19 @@ class MessageService extends ChangeNotifier {
   Future<void> sendMessage(String toCallsign, String text) async {
     final peer = toCallsign.trim().toUpperCase();
     final wireId = await _nextMessageId();
-    final localId =
-        '${peer}_${wireId}_${DateTime.now().millisecondsSinceEpoch}';
+    final localId = '${peer}_${wireId}_${_clock().millisecondsSinceEpoch}';
 
     final entry = MessageEntry(
       localId: localId,
       wireId: wireId,
       text: text,
-      timestamp: DateTime.now(),
+      timestamp: _clock(),
       isOutgoing: true,
     );
 
     final conv = _getOrCreateConversation(peer);
     conv.messages.add(entry);
-    conv.lastActivity = DateTime.now();
+    conv.lastActivity = _clock();
 
     await _transmitMessage(peer, text, wireId);
     _scheduleRetry(entry, peer, attempt: 0);
@@ -791,7 +795,7 @@ class MessageService extends ChangeNotifier {
   /// Returns true if [dt] is within [days] days of now.
   bool _withinAge(DateTime dt, int days) {
     if (days == forever) return true;
-    return DateTime.now().difference(dt).inDays < days;
+    return _clock().difference(dt).inDays < days;
   }
 
   MessageEntry _entryFromJson(Map<String, dynamic> json) {

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -9,6 +9,7 @@ import '../core/packet/aprs_packet.dart';
 import '../core/packet/aprs_parser.dart';
 import '../core/packet/station.dart';
 import '../core/transport/aprs_transport.dart' show ConnectionStatus;
+import '../core/util/clock.dart';
 
 /// Service that ingests APRS text lines, decodes them with [AprsParser], and
 /// exposes two streams:
@@ -101,7 +102,9 @@ class StationService extends ChangeNotifier {
   SharedPreferences? _prefs;
   Timer? _persistTimer;
 
-  StationService();
+  StationService({Clock clock = DateTime.now}) : _clock = clock;
+
+  final Clock _clock;
 
   // ---------------------------------------------------------------------------
   // Backward-compat stubs (removed in Phase 6 when UI is updated)
@@ -338,7 +341,7 @@ class StationService extends ChangeNotifier {
           final tsMs = map['ts'] as int?;
           final receivedAt = tsMs != null
               ? DateTime.fromMillisecondsSinceEpoch(tsMs, isUtc: true)
-              : null;
+              : _clock().toUtc();
           final packet = _parser.parse(
             raw,
             transportSource: src,
@@ -403,8 +406,11 @@ class StationService extends ChangeNotifier {
 
     if (raw.isEmpty || raw.startsWith('#')) return;
 
-    final packet = _parser.parse(raw, transportSource: source)
-      ..isOutgoing = isOutgoing;
+    final packet = _parser.parse(
+      raw,
+      transportSource: source,
+      receivedAt: _clock().toUtc(),
+    )..isOutgoing = isOutgoing;
 
     // Add to rolling in-session buffer, capped for performance.
     _recentPackets.insert(0, packet);
@@ -566,7 +572,7 @@ class StationService extends ChangeNotifier {
 
   bool _withinAge(DateTime dt, int days) {
     if (days == forever) return true;
-    return DateTime.now().difference(dt).inDays < days;
+    return _clock().difference(dt).inDays < days;
   }
 
   void _schedulePersist() {

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -37,6 +37,7 @@ Uint8List _buildAprsFrame({
 }
 
 void main() {
+  final kTestReceivedAt = DateTime.utc(2026, 1, 1, 12, 0, 0);
   late AprsParser parser;
 
   setUp(() {
@@ -48,7 +49,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   T expectPacketType<T extends AprsPacket>(String line) {
-    final packet = parser.parse(line);
+    final packet = parser.parse(line, receivedAt: kTestReceivedAt);
     expect(
       packet,
       isA<T>(),
@@ -107,20 +108,12 @@ void main() {
       expect(p.path, containsAll(['TCPIP*', 'qAC', 'T2MCI']));
     });
 
-    test('receivedAt is a recent UTC time', () {
-      final before = DateTime.now().toUtc();
+    test('receivedAt is the injected timestamp (UTC)', () {
       final p = expectPacketType<PositionPacket>(
         'N0CALL>APRS:!4903.50N/07201.75W-Test',
       );
-      final after = DateTime.now().toUtc();
-      expect(
-        p.receivedAt.isAfter(before) || p.receivedAt.isAtSameMomentAs(before),
-        isTrue,
-      );
-      expect(
-        p.receivedAt.isBefore(after) || p.receivedAt.isAtSameMomentAs(after),
-        isTrue,
-      );
+      expect(p.receivedAt, equals(kTestReceivedAt));
+      expect(p.receivedAt.isUtc, isTrue);
     });
 
     test('rawLine is preserved exactly', () {
@@ -312,7 +305,10 @@ void main() {
 
     test('returns PositionPacket not UnknownPacket for compressed', () {
       // Validate we don't fall through to UnknownPacket.
-      final packet = parser.parse('N0CALL>APRS:=/5L!!<*e7>7P[Test compressed');
+      final packet = parser.parse(
+        'N0CALL>APRS:=/5L!!<*e7>7P[Test compressed',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<PositionPacket>());
     });
   });
@@ -503,7 +499,10 @@ void main() {
     // Real-world Mic-E packet: WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`
     // WB4APR is the inventor of APRS; his beacon is a good test vector.
     test('parses Mic-E packet (backtick DTI)', () {
-      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+        receivedAt: kTestReceivedAt,
+      );
       // The destination T2SR6Y encodes Mic-E data; packet should be MicEPacket
       // or at minimum not crash. In some edge cases the destination may not
       // be a valid Mic-E encoding and will return UnknownPacket — that is also
@@ -512,7 +511,10 @@ void main() {
     });
 
     test('Mic-E lat is in valid range', () {
-      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+        receivedAt: kTestReceivedAt,
+      );
       if (packet is MicEPacket) {
         expect(packet.lat, greaterThanOrEqualTo(-90));
         expect(packet.lat, lessThanOrEqualTo(90));
@@ -522,7 +524,10 @@ void main() {
     });
 
     test('Mic-E micEMessage is populated', () {
-      final packet = parser.parse('WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`');
+      final packet = parser.parse(
+        'WB4APR-14>T2SR6Y,WIDE2-2:`(_fn"Oj/`',
+        receivedAt: kTestReceivedAt,
+      );
       if (packet is MicEPacket) {
         expect(packet.micEMessage, isNotEmpty);
       }
@@ -532,6 +537,7 @@ void main() {
       // Single-quote DTI variant
       final packet = parser.parse(
         "KD0ABC-9>S3QRYU,WIDE1-1,WIDE2-1:'(_fn\"Oj/`",
+        receivedAt: kTestReceivedAt,
       );
       expect(packet, anyOf(isA<MicEPacket>(), isA<UnknownPacket>()));
     });
@@ -556,7 +562,10 @@ void main() {
     // positions 0-2 only; A-K at positions 3-5 is not defined.
     test('P-Y destination decodes lat, lon, hemisphere, and message type', () {
       // All printable ASCII; info field is exactly 9 bytes.
-      final packet = parser.parse('N0CALL-9>SX5Y0Y,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>SX5Y0Y,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       final p = packet as MicEPacket;
       expect(p.lat, closeTo(38.9848, 0.001));
@@ -582,7 +591,10 @@ void main() {
     //   lat = 38°84.00' — latMin=84 is out of range; that is fine, the parser
     //   does no range validation on lat.  We only check micEMessage here.
     test('messageBits=7 decodes to Off Duty', () {
-      final packet = parser.parse('N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Off Duty'));
     });
@@ -592,7 +604,10 @@ void main() {
     //   '3', '8', '5' → bits 0,0,0
     //   North: 'E', no offset: '0', West: 'A'  → Destination: 385E0A
     test('messageBits=0 decodes to Emergency', () {
-      final packet = parser.parse('N0CALL-9>385E0A,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>385E0A,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Emergency'));
     });
@@ -602,7 +617,10 @@ void main() {
     //   'S'(P+3), '8', 'T'(P+4) → bits 1,0,1 = 0b101 = 5
     //   Destination: S8TE0A
     test('messageBits=5 decodes to In Service', () {
-      final packet = parser.parse('N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('In Service'));
     });
@@ -614,38 +632,65 @@ void main() {
 
   group('UnknownPacket and malformed input', () {
     test('blank line returns UnknownPacket', () {
-      expect(parser.parse(''), isA<UnknownPacket>());
+      expect(
+        parser.parse('', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('server comment line returns UnknownPacket', () {
-      expect(parser.parse('# logresp NOCALL unverified'), isA<UnknownPacket>());
+      expect(
+        parser.parse(
+          '# logresp NOCALL unverified',
+          receivedAt: kTestReceivedAt,
+        ),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('line with no colon returns UnknownPacket', () {
-      expect(parser.parse('GARBAGE LINE WITH NO COLON'), isA<UnknownPacket>());
+      expect(
+        parser.parse('GARBAGE LINE WITH NO COLON', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('line with no > in header returns UnknownPacket', () {
-      expect(parser.parse('BADCALL>:info'), isA<UnknownPacket>());
+      expect(
+        parser.parse('BADCALL>:info', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('completely garbage input returns UnknownPacket', () {
-      expect(parser.parse(':::'), isA<UnknownPacket>());
+      expect(
+        parser.parse(':::', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('empty info field returns UnknownPacket', () {
       // Header OK but nothing after the colon.
-      expect(parser.parse('N0CALL>APRS:'), isA<UnknownPacket>());
+      expect(
+        parser.parse('N0CALL>APRS:', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('unrecognised DTI returns UnknownPacket', () {
       // DTI 'Z' is not defined.
-      expect(parser.parse('N0CALL>APRS:Znot a packet'), isA<UnknownPacket>());
+      expect(
+        parser.parse('N0CALL>APRS:Znot a packet', receivedAt: kTestReceivedAt),
+        isA<UnknownPacket>(),
+      );
     });
 
     test('telemetry packet (T) returns UnknownPacket', () {
       expect(
-        parser.parse('N0CALL>APRS:T#001,100,200,050,000,255,00000001'),
+        parser.parse(
+          'N0CALL>APRS:T#001,100,200,050,000,255,00000001',
+          receivedAt: kTestReceivedAt,
+        ),
         isA<UnknownPacket>(),
       );
     });
@@ -664,12 +709,16 @@ void main() {
         'a' * 1000,
       ];
       for (final s in inputs) {
-        expect(() => parser.parse(s), returnsNormally, reason: 'Input: $s');
+        expect(
+          () => parser.parse(s, receivedAt: kTestReceivedAt),
+          returnsNormally,
+          reason: 'Input: $s',
+        );
       }
     });
 
     test('UnknownPacket has reason field', () {
-      final p = parser.parse('') as UnknownPacket;
+      final p = parser.parse('', receivedAt: kTestReceivedAt) as UnknownPacket;
       expect(p.reason, isNotEmpty);
     });
   });
@@ -779,7 +828,7 @@ void main() {
       () {
         // Build raw line: 9-byte info prefix + '"4G}' (Yaesu block) + 'comment_0'
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x224G}comment_0';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('comment'));
@@ -799,7 +848,7 @@ void main() {
       () {
         // comment field: \x60 + "a1b2" (valid hex) + "comment]"
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2comment]';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('comment]'));
@@ -818,7 +867,7 @@ void main() {
         // After the 9-byte fixed Mic-E block, the comment field is:
         // ']' + '"4"}' (altitude) + 'hello' + '='
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/]\x224\x22}hello=';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('hello'));
@@ -835,7 +884,7 @@ void main() {
       'TM-D700 (`]` prefix, no suffix): altitude parses, no suffix to strip',
       () {
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/]\x224\x22}hello';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('hello'));
@@ -848,7 +897,7 @@ void main() {
     // Real Kenwood TH-D72A signature: leading `>` prefix, trailing `=` suffix.
     test('TH-D72A (`>` prefix + `=` suffix)', () {
       final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>\x224\x22}user=';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
         expect(packet.comment, equals('user'));
@@ -864,7 +913,7 @@ void main() {
       'TH-D74 (`>` prefix + `^` suffix) — not misclassified as Yaesu VX-8',
       () {
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>hello^';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('hello'));
@@ -879,7 +928,7 @@ void main() {
     test('TM-D710 with empty user comment renders as empty comment', () {
       final rawLine =
           'KM4TJO-9>S6TW3Q,KE4KDY-5,WIDE1,WIDE2-1:\x60h_} *p>/]\x224\x22}=';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
         expect(packet.comment, equals(''));
@@ -895,7 +944,7 @@ void main() {
     test('TM-D710 with frequency-object comment preserves user text', () {
       final rawLine =
           "KM4TJO-9>S6TV7S,KE4KDY-5,WIDE1,WIDE2-1:\x60h]nmJ\x14>/]\x223r}146.520MHz Toff Eric's D710G=";
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
         expect(packet.comment, equals("146.520MHz Toff Eric's D710G"));
@@ -920,7 +969,7 @@ void main() {
         // = backtick + '"' + '3' + 'x' + '}' + '_' + '0'
         final rawLine =
             'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60\x22\x33\x78\x7D\x5F\x30';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals(''));
@@ -950,7 +999,7 @@ void main() {
       () {
         final rawLine =
             "N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60Eric's FT3DR_0 ";
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals("Eric's FT3DR"));
@@ -967,7 +1016,7 @@ void main() {
       'backtick + 4 hex digits = telemetry stripped, bare trailing ] kept',
       () {
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x60a1b2rest]';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         if (packet is MicEPacket) {
           expect(packet.comment, equals('rest]'));
@@ -978,7 +1027,7 @@ void main() {
 
     test('comment with no prefix and no suffix is unchanged', () {
       final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
         expect(packet.comment, equals('plain comment'));
@@ -1011,7 +1060,7 @@ void main() {
         srcSsid: 9,
         info: infoBytes,
       );
-      final packet = parser.parseFrame(frame);
+      final packet = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).lon, inInclusiveRange(-180.0, 180.0));
     });
@@ -1019,7 +1068,7 @@ void main() {
     test('parseFrame and parse produce consistent lat/lon for latin1 0xB7', () {
       // APRS-IS string with same destination/info using latin1 char 0xB7.
       const rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60\xB7LPN Ol>/';
-      final fromString = parser.parse(rawLine);
+      final fromString = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(fromString, isA<MicEPacket>());
 
       final infoBytes = [0x60, 0xB7, 0x4C, 0x50, 0x20, 0x4C, 0x6C, 0x3E, 0x2F];
@@ -1029,7 +1078,7 @@ void main() {
         srcSsid: 9,
         info: infoBytes,
       );
-      final fromFrame = parser.parseFrame(frame);
+      final fromFrame = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(fromFrame, isA<MicEPacket>());
 
       final p1 = fromString as MicEPacket;
@@ -1057,7 +1106,7 @@ void main() {
         srcSsid: 7,
         info: infoBytes,
       );
-      final packet = parser.parseFrame(frame);
+      final packet = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(packet, isA<MessagePacket>());
       final mp = packet as MessagePacket;
       expect(mp.isAck, isTrue);
@@ -1069,7 +1118,7 @@ void main() {
           .map((c) => c & 0xFF)
           .toList();
       final frame = _buildAprsFrame(dst: 'APRS', src: 'W1AW', info: infoBytes);
-      final packet = parser.parseFrame(frame);
+      final packet = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(packet, isA<MessagePacket>());
       final mp = packet as MessagePacket;
       expect(mp.messageId, equals('005'));
@@ -1083,7 +1132,10 @@ void main() {
 
   group('ItemPacket — minimum name length', () {
     test('2-char item name (delimiter at index 2) is rejected', () {
-      final packet = parser.parse('W1ABC>APRS:)AB!4903.50N/07201.75W-');
+      final packet = parser.parse(
+        'W1ABC>APRS:)AB!4903.50N/07201.75W-',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<UnknownPacket>());
     });
 
@@ -1109,7 +1161,7 @@ void main() {
         pid: 0xF0,
         info: infoBytes,
       );
-      final packet = parser.parseFrame(frame);
+      final packet = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(packet, isA<UnknownPacket>());
       expect((packet as UnknownPacket).reason, contains('Not a UI/APRS frame'));
     });
@@ -1123,7 +1175,7 @@ void main() {
         pid: 0xCF,
         info: infoBytes,
       );
-      final packet = parser.parseFrame(frame);
+      final packet = parser.parseFrame(frame, receivedAt: kTestReceivedAt);
       expect(packet, isA<UnknownPacket>());
       expect((packet as UnknownPacket).reason, contains('Not a UI/APRS frame'));
     });
@@ -1200,7 +1252,7 @@ void main() {
     //   (Custom table reverses the bit-to-label mapping vs. Standard.)
     test('Mic-E Custom message bits (A-J) decode to Custom-0', () {
       final rawLine = 'N0CALL-9>ABJE0A,WIDE1-1:\x60i<N Ol>/';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Custom-0'));
     });
@@ -1212,27 +1264,36 @@ void main() {
     //   custBits=0b100≠0, stdBits=0b011≠0 → mixed → 'Unknown'
     test('Mic-E mixed Standard+Custom bits decode to Unknown', () {
       final rawLine = 'N0CALL-9>ASRE0A,WIDE1-1:\x60i<N Ol>/';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Unknown'));
     });
 
     // Regression: P-Y only → stdBits → standard table (Off Duty, In Service)
     test('regression: Off Duty still decodes correctly', () {
-      final packet = parser.parse('N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>SXTE0A,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Off Duty'));
     });
 
     test('regression: In Service still decodes correctly', () {
-      final packet = parser.parse('N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>S8TE0A,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('In Service'));
     });
 
     // All digits → stdBits=0, custBits=0 → Emergency
     test('regression: Emergency (all digits) still decodes correctly', () {
-      final packet = parser.parse('N0CALL-9>385Y0Y,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>385Y0Y,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Emergency'));
     });
@@ -1247,7 +1308,10 @@ void main() {
     //   'Y' pos 3 → North, '0' pos 4 → no offset, 'Y' pos 5 → West
     //   → _micECustomMessages[7] = 'Custom-0'
     test('K ambiguity at positions 0-2 sets Custom bit (not Emergency)', () {
-      final packet = parser.parse('N0CALL-9>KKKY0Y,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>KKKY0Y,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       final p = packet as MicEPacket;
       expect(
@@ -1262,7 +1326,10 @@ void main() {
     // 0-2. Similar regression: an all-Z destination must decode to Off Duty
     // (stdBits=0b111=7), not Emergency.
     test('Z ambiguity at positions 0-2 sets Standard bit (not Emergency)', () {
-      final packet = parser.parse('N0CALL-9>ZZZY0Y,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>ZZZY0Y,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).micEMessage, equals('Off Duty'));
     });
@@ -1275,7 +1342,10 @@ void main() {
     // Destination SX5Y0Z:
     //   'Y' pos 3 → North, '0' pos 4 → no offset, 'Z' pos 5 → West (ambiguous)
     test('Z at position 5 decodes as West (not East)', () {
-      final packet = parser.parse('N0CALL-9>SX5Y0Z,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>SX5Y0Z,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect(
         (packet as MicEPacket).lon,
@@ -1286,7 +1356,10 @@ void main() {
 
     // Z at position 3 = ambiguous N/S with North flag.
     test('Z at position 3 decodes as North (not South)', () {
-      final packet = parser.parse('N0CALL-9>SX5Z0Y,WIDE1-1:`i<N Ol>/');
+      final packet = parser.parse(
+        'N0CALL-9>SX5Z0Y,WIDE1-1:`i<N Ol>/',
+        receivedAt: kTestReceivedAt,
+      );
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).lat, isPositive);
     });
@@ -1303,14 +1376,14 @@ void main() {
     // in-comment callsign mentions with no spec basis.
     test('mixed-case prose containing ` > ` is NOT stripped', () {
       final rawLine = 'N0CALL-9>SX5Y0Y,WIDE1-1:`i<N Ol>/Driving > Fast';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).comment, equals('Driving > Fast'));
     });
 
     test('lowercase `a>B` is NOT stripped', () {
       final rawLine = 'N0CALL-9>SX5Y0Y,WIDE1-1:`i<N Ol>/a>B';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).comment, equals('a>B'));
     });
@@ -1319,7 +1392,7 @@ void main() {
     // basis; the in-comment callsign mention must be preserved.
     test('space + `>CALLSIGN` is NOT stripped', () {
       final rawLine = 'N0CALL-9>SX5Y0Y,WIDE1-1:`i<N Ol>/My Car >VE3ABC';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).comment, equals('My Car >VE3ABC'));
     });
@@ -1336,7 +1409,7 @@ void main() {
     //   c1 is '#' (0x23), not '"' (0x22), so the Yaesu stripper is not triggered.
     test('base-91 altitude 10000 ft decoded from comment', () {
       final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/\x23Fh}';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).altitude, closeTo(10000.0, 0.5));
     });
@@ -1350,7 +1423,7 @@ void main() {
       () {
         // info comment bytes: '!' '{' '{' '}' = 0x21 0x7B 0x7B 0x7D
         final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/!\x7B\x7B\x7D';
-        final packet = parser.parse(rawLine);
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
         expect(packet, isA<MicEPacket>());
         expect((packet as MicEPacket).altitude, closeTo(-1720.0, 0.5));
       },
@@ -1358,7 +1431,7 @@ void main() {
 
     test('comment with no altitude prefix leaves altitude null', () {
       final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/plain comment';
-      final packet = parser.parse(rawLine);
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       expect((packet as MicEPacket).altitude, isNull);
     });

--- a/test/core/transport/serial_kiss_pipeline_test.dart
+++ b/test/core/transport/serial_kiss_pipeline_test.dart
@@ -89,7 +89,10 @@ void main() {
       final ax25Result = const Ax25Parser().parseFrame(frames[0]);
       expect(ax25Result, isA<Ax25Ok>());
 
-      final packet = AprsParser().parseFrame(frames[0]);
+      final packet = AprsParser().parseFrame(
+        frames[0],
+        receivedAt: DateTime.utc(2026, 1, 1),
+      );
       expect(packet, isA<PositionPacket>());
 
       final pos = packet as PositionPacket;
@@ -109,7 +112,10 @@ void main() {
 
       expect(frames, hasLength(1));
 
-      final packet = AprsParser().parseFrame(frames[0]);
+      final packet = AprsParser().parseFrame(
+        frames[0],
+        receivedAt: DateTime.utc(2026, 1, 1),
+      );
       expect(packet, isA<StatusPacket>());
       expect(packet.source, equals('KD9ABC'));
     });
@@ -127,7 +133,10 @@ void main() {
 
         expect(frames, hasLength(1));
 
-        final packet = AprsParser().parseFrame(frames[0]);
+        final packet = AprsParser().parseFrame(
+          frames[0],
+          receivedAt: DateTime.utc(2026, 1, 1),
+        );
         expect(packet, isA<UnknownPacket>());
       },
     );

--- a/test/core/transport/serial_kiss_transport_test.dart
+++ b/test/core/transport/serial_kiss_transport_test.dart
@@ -174,7 +174,10 @@ void main() {
 
         // The frame arrived and can be parsed into an APRS packet.
         expect(frames, isNotEmpty);
-        final packet = AprsParser().parseFrame(frames.first);
+        final packet = AprsParser().parseFrame(
+          frames.first,
+          receivedAt: DateTime.utc(2026, 1, 1),
+        );
         expect(packet.rawLine, contains('W1AW'));
       },
     );

--- a/test/core/util/clock_injection_test.dart
+++ b/test/core/util/clock_injection_test.dart
@@ -1,0 +1,51 @@
+// Spot-check that an injected `Clock` advances service-level retention logic
+// deterministically. Full per-service coverage lands in PR 4 (#60) and PR 5
+// (#52); this test exists to prove the seam works end-to-end.
+//
+// Picks `StationService._withinAge` because it's the simplest reachable
+// retention probe — `setPacketHistoryDays(1)` triggers `_withinAge` against
+// the rolling buffer using the injected clock, so we can drive packet
+// pruning by advancing time without sleeping.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MutableClock {
+  _MutableClock(this._now);
+  DateTime _now;
+  DateTime call() => _now;
+  void advance(Duration d) => _now = _now.add(d);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'StationService prunes the packet buffer using the injected clock',
+    () async {
+      final clock = _MutableClock(DateTime.utc(2026, 1, 1, 12));
+      SharedPreferences.setMockInitialValues({});
+
+      final service = StationService(clock: clock.call);
+      await service.loadPersistedHistory(await SharedPreferences.getInstance());
+
+      service.ingestLine(
+        'N0CALL>APRS:!4903.50N/07201.75W-clock-injection-test',
+      );
+
+      // Buffer is fresh at the injected `now`.
+      expect(service.recentPackets, isNotEmpty);
+      expect(service.recentPackets.first, isA<PositionPacket>());
+
+      // Advance 2 days, then narrow the retention window to 1 day.
+      // `_withinAge` uses _clock(); after the advance, the entry is stale.
+      clock.advance(const Duration(days: 2));
+      await service.setPacketHistoryDays(1);
+
+      expect(service.recentPackets, isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Introduces `typedef Clock = DateTime Function();` in `lib/core/util/clock.dart` (zero external dep) and threads it through every audited time-dependent service constructor as `Clock clock = DateTime.now`.
- Makes `AprsParser.parse(...)` and `parseFrame(...)` require `receivedAt`. The parser now contains zero `DateTime.now()` calls.
- Establishes `StationService._handleLine` as the canonical transport-boundary stamp site (`_clock().toUtc()`).

Closes #43.

## Services touched

- `BeaconingService`, `MessageService`, `BulletinService`, `StationService`
- `BackgroundServiceManager`, `MeridianConnectionTask` (background isolate)
- `AprsIsTransport`, `SmartBeaconScheduler`
- `BleConnection` / `SerialConnection` (impl + stub) — stamp at frame-text reconstruction
- `BulletinScheduler` standardised on the new typedef (was an inline `DateTime Function()?` closure)

Every `AprsParser.parse(` and `AprsParser.parseFrame(` call site has been updated to pass `receivedAt` explicitly (production: `station_service.dart`, `ble_connection_impl.dart`, `serial_connection_impl.dart`; tests: `aprs_parser_test.dart`, `serial_kiss_pipeline_test.dart`, `serial_kiss_transport_test.dart`).

## Out of scope (intentional)

- UI date/time formatters in `lib/screens/` and `lib/ui/` — they correctly want render-time "now".
- `Conversation` factory `lastActivity = DateTime.now()` default (model factory default, per scope decision).
- Debug `print` in `AprsIsTransport.connect()` (diagnostic-only).
- `package:clock` — explicitly rejected to keep the core dep-free.
- Per-service test coverage expansion — deferred to PR 4 (#60) and PR 5 (#52). This PR's test bar is "existing suite stays green plus one spot-check."

See ADR-062 for full rationale and alternatives considered.

## Docs

- `docs/DECISIONS.md` — ADR-062 added.
- `docs/ARCHITECTURE.md` — Receive Path section now documents the parser/transport boundary contract; TNC Transport section cross-references it.
- `docs/ROADMAP.md` — v0.18 #43 bullet ticked.

## Test plan

- [x] All 667 pre-existing tests pass after threading `receivedAt` through the parser test fixtures
- [x] New spot-check `test/core/util/clock_injection_test.dart` proves the seam end-to-end (StationService retention pruning advances under an injected fake clock)
- [x] `flutter analyze` clean
- [x] `dart format .` clean
- [x] APRS-IS connect → packets arrive in Packet Log with correct timestamps (manual smoke)
- [x] BLE TNC connect → frames decode and appear (manual smoke)
- [x] Beaconing auto/smart fires on interval; "Last beacon: Xm ago" refreshes (manual smoke)
- [x] Android background isolate keeps beaconing under screen-lock (manual smoke)