### PR TITLE
refactor(core): consolidate conn.lines ingestion behind StationService.attach (#56)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,6 +114,18 @@ This keeps the parser deterministic for the same bytes (replay-friendly) and
 puts arrival-time stamping on the side of the system that actually knows
 when packets arrived.
 
+### Connection-line ingestion
+
+Each `MeridianConnection` exposes a `Stream<String> lines`. `ConnectionRegistry`
+subscribes once per connection and re-emits each line as a tagged tuple onto
+`registry.lines` (`Stream<({String line, ConnectionType source})>`). A single
+production consumer attaches via `StationService.attach(registry)` at startup,
+which routes each tagged line into `_handleLine` after mapping
+`ConnectionType → PacketSource`. See ADR-063 — the registry remains the
+broadcast hub but does not drive ingestion; future consumers (logging tap, TX
+confirmation observer, replay capture) attach to `registry.lines` without any
+plumbing changes.
+
 ## Data Flow (Transmit Path)
 
 ```

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1392,3 +1392,40 @@ Introduce `typedef Clock = DateTime Function();` in `lib/core/util/clock.dart` (
 - One spot-check test (`test/core/util/clock_injection_test.dart`) covers `StationService` retention pruning end-to-end as proof of the seam.
 - Future replay / golden-frame test flows are now feasible — a recorded packet stream can be played through the parser with a deterministic timeline.
 - The background isolate's `MeridianConnectionTask` accepts a `Clock` too, for unit tests; the production `vm:entry-point` constructs it with the default `DateTime.now`.
+
+---
+
+## ADR-063: `StationService` owns connection-line ingestion via attached `ConnectionRegistry` subscription
+
+**Date:** 2026-04-26
+**Status:** Accepted
+
+### Context
+
+Every `MeridianConnection.lines` stream was being subscribed to twice:
+
+1. `ConnectionRegistry.register` subscribed per-connection and re-emitted each line as a tagged tuple onto `registry.lines` (`Stream<({String line, ConnectionType source})>`). This stream had **zero production consumers** — only two test sites touched it.
+2. `main.dart` subscribed per-connection again and forwarded each line to `StationService.ingestLine(...)` with a hand-mapped `PacketSource` tag.
+
+The result was duplicate listener machinery for every transport, dead broadcast plumbing in the registry, and a per-connection mapping helper living in `main.dart` that should have been internal to the service.
+
+### Decision
+
+`StationService` owns connection-line ingestion. A single subscription is established via `StationService.attach(ConnectionRegistry)` against `registry.lines`, and the `ConnectionType → PacketSource` mapping moves into the service as a private helper. `main.dart` calls `service.attach(registry)` exactly once at startup. The subscription is cancelled in `StationService.stop()`.
+
+`ConnectionRegistry`'s broadcast plumbing is preserved unchanged and is now a real, used seam: `registry.lines` has exactly one production consumer, but the broadcast contract means future consumers (logging tap, TX confirmation observer, replay capture) can attach without touching either layer.
+
+`StationService.ingestLine(...)` remains public unchanged — it is the synchronous direct-injection seam used by ~30 service tests and by the background-isolate packet relay (`BackgroundServiceManager.onPacketLogged`). Both `attach` and `ingestLine` ultimately route through the same `_handleLine`.
+
+### Alternatives considered
+
+- **Delete `registry.lines` entirely.** Rejected: the broadcast hub is a useful future seam for non-decoding consumers (logging taps, TX confirmation observers, future replay capture), and broadcast streams have zero cost when unsubscribed. Deleting it would force any future consumer to either add per-connection subscription loops or reintroduce the registry plumbing later.
+- **Pass a callback into `ConnectionRegistry.register`.** Rejected: it would push ingestion policy into the registry's public API and couple it to the service, defeating the registry's role as a transport-agnostic state hub.
+
+### Consequences
+
+- One subscription chain per connection, end to end. No duplicate parser invocations.
+- Per-connection error context is preserved via an `onError` handler on the registry's per-connection `listen` (logs `[<conn.id>] stream error: ...` with the connection id in scope).
+- `StationService.attach` enforces a single-attach contract via `assert`; calling it twice is a programming error.
+- `_packetSourceFor` is now a private static helper on `StationService`; `main.dart` no longer carries transport-tagging logic.
+- Future consumers of `registry.lines` need only `registry.lines.listen(...)` — no plumbing changes required.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,7 +160,7 @@ Architecture, testing, and dependency foundations that unblock the subsequent pe
 - BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)
 - ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
-- Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)
+- ✅ Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)
 
 ---
 

--- a/lib/core/connection/connection_registry.dart
+++ b/lib/core/connection/connection_registry.dart
@@ -34,11 +34,16 @@ class ConnectionRegistry extends ChangeNotifier {
     _connections.add(conn);
     conn.addListener(notifyListeners);
     _lineSubs.add(
-      conn.lines.listen((line) {
-        if (!_linesController.isClosed) {
-          _linesController.add((line: line, source: conn.type));
-        }
-      }),
+      conn.lines.listen(
+        (line) {
+          if (!_linesController.isClosed) {
+            _linesController.add((line: line, source: conn.type));
+          }
+        },
+        onError: (Object e, StackTrace st) {
+          debugPrint('[${conn.id}] stream error: $e\n$st');
+        },
+      ),
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,13 +50,6 @@ import 'theme/theme_controller.dart';
 /// the widget tree (notification taps, inline reply navigation).
 final navigatorKey = GlobalKey<NavigatorState>();
 
-/// Maps a [ConnectionType] to the [PacketSource] tag used in [StationService].
-PacketSource _packetSourceFor(ConnectionType type) => switch (type) {
-  ConnectionType.aprsIs => PacketSource.aprsIs,
-  ConnectionType.bleTnc => PacketSource.bleTnc,
-  ConnectionType.serialTnc => PacketSource.serialTnc,
-};
-
 /// Resolves the active [Brightness] from [ThemeMode] for [CupertinoApp].
 ///
 /// [ThemeMode.system] reads [WidgetsBinding.instance.platformDispatcher.platformBrightness]
@@ -159,17 +152,7 @@ Future<void> main() async {
 
   final service = StationService();
   await service.loadPersistedHistory(prefs);
-
-  // Wire ingestLine subscriptions: each connection's decoded text lines are
-  // forwarded to StationService with the correct source tag.
-  for (final conn in registry.all) {
-    conn.lines.listen(
-      (line) => service.ingestLine(line, source: _packetSourceFor(conn.type)),
-      onError: (Object e, StackTrace st) {
-        debugPrint('[${conn.id}] stream error: $e\n$st');
-      },
-    );
-  }
+  service.attach(registry);
 
   // Reconnect APRS-IS only if the user chose to connect last session.
   // Defaults to off on first launch so the connection is always opt-in.

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -5,10 +5,10 @@ import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint;
 import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../core/connection/connection_registry.dart';
 import '../core/packet/aprs_packet.dart';
 import '../core/packet/aprs_parser.dart';
 import '../core/packet/station.dart';
-import '../core/transport/aprs_transport.dart' show ConnectionStatus;
 import '../core/util/clock.dart';
 
 /// Service that ingests APRS text lines, decodes them with [AprsParser], and
@@ -18,10 +18,11 @@ import '../core/util/clock.dart';
 ///   - [stationUpdates] — a snapshot of the station map, updated each time a
 ///     position packet is received
 ///
-/// Lines are fed via [ingestLine], which is called from [main.dart] for each
-/// connection registered in [ConnectionRegistry]. This service has no
-/// transport dependency; connection lifecycle is managed by the connection
-/// classes and [ConnectionRegistry].
+/// Lines are normally fed via [attach], which subscribes once to the
+/// multiplexed [ConnectionRegistry.lines] stream and routes each tagged line
+/// to the parser. Tests and one-off callers can also push lines synchronously
+/// via [ingestLine]. This service has no transport dependency; connection
+/// lifecycle is managed by the connection classes and [ConnectionRegistry].
 ///
 /// [recentPackets] holds a rolling buffer of recent packets. The in-session
 /// buffer is capped at [_kMaxInMemoryPackets] for performance; time-based
@@ -102,6 +103,10 @@ class StationService extends ChangeNotifier {
   SharedPreferences? _prefs;
   Timer? _persistTimer;
 
+  // Active subscription to ConnectionRegistry.lines, set by [attach] and
+  // cancelled by [stop]. Null until [attach] is called.
+  StreamSubscription<({String line, ConnectionType source})>? _registrySub;
+
   StationService({Clock clock = DateTime.now}) : _clock = clock;
 
   final Clock _clock;
@@ -125,9 +130,12 @@ class StationService extends ChangeNotifier {
   /// No-op. Line ingestion is wired in main.dart via [ConnectionRegistry].
   Future<void> start() async {}
 
-  /// Closes stream controllers and cancels timers.
+  /// Closes stream controllers, cancels timers, and detaches from any
+  /// [ConnectionRegistry] previously wired via [attach].
   Future<void> stop() async {
     _persistTimer?.cancel();
+    await _registrySub?.cancel();
+    _registrySub = null;
     await _stationController.close();
     await _packetController.close();
   }
@@ -266,12 +274,38 @@ class StationService extends ChangeNotifier {
   // Ingest
   // ---------------------------------------------------------------------------
 
+  /// Subscribe to [registry]'s multiplexed [ConnectionRegistry.lines] stream
+  /// and route every tagged line into the parser. This is the single
+  /// production ingestion seam — [main.dart] calls it once at startup, after
+  /// [loadPersistedHistory].
+  ///
+  /// Calling [attach] more than once is a programming error; the second call
+  /// will throw in debug builds. Use [stop] to cancel the subscription.
+  void attach(ConnectionRegistry registry) {
+    assert(
+      _registrySub == null,
+      'StationService.attach called twice; a single subscription is expected.',
+    );
+    _registrySub = registry.lines.listen(
+      (event) =>
+          _handleLine(event.line, source: _packetSourceFor(event.source)),
+    );
+  }
+
   /// Ingest a pre-formatted APRS line from a connection.
   ///
   /// [source] identifies whether the line came from APRS-IS, a BLE TNC, or a
-  /// serial TNC. Defaults to [PacketSource.aprsIs].
+  /// serial TNC. Defaults to [PacketSource.aprsIs]. Production ingestion goes
+  /// through [attach]; this method remains the synchronous direct-injection
+  /// seam used by tests and the background-isolate packet relay.
   void ingestLine(String raw, {PacketSource source = PacketSource.aprsIs}) =>
       _handleLine(raw, source: source);
+
+  static PacketSource _packetSourceFor(ConnectionType type) => switch (type) {
+    ConnectionType.aprsIs => PacketSource.aprsIs,
+    ConnectionType.bleTnc => PacketSource.bleTnc,
+    ConnectionType.serialTnc => PacketSource.serialTnc,
+  };
 
   /// Record a packet that *we* just transmitted, tagged with the transport
   /// it went out on. Used by [TxService] to surface outgoing traffic in the

--- a/test/services/station_service_test.dart
+++ b/test/services/station_service_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
 import 'package:meridian_aprs/core/packet/aprs_packet.dart';
 import 'package:meridian_aprs/core/packet/station.dart';
 import 'package:meridian_aprs/services/station_service.dart';
+
+import '../helpers/fake_meridian_connection.dart';
 
 void main() {
   late StationService service;
@@ -339,6 +342,98 @@ void main() {
 
       expect(svc.recentPackets.first.transportSource, PacketSource.tnc);
       await svc.stop();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // attach — single subscription against ConnectionRegistry.lines
+  // ---------------------------------------------------------------------------
+
+  group('attach', () {
+    late ConnectionRegistry registry;
+    late FakeMeridianConnection aprsIs;
+    late FakeMeridianConnection bleTnc;
+    late FakeMeridianConnection serial;
+
+    setUp(() {
+      registry = ConnectionRegistry();
+      aprsIs = FakeMeridianConnection(
+        id: 'aprs_is',
+        displayName: 'APRS-IS',
+        type: ConnectionType.aprsIs,
+      );
+      bleTnc = FakeMeridianConnection(
+        id: 'ble_tnc',
+        displayName: 'BLE TNC',
+        type: ConnectionType.bleTnc,
+      );
+      serial = FakeMeridianConnection(
+        id: 'serial_tnc',
+        displayName: 'Serial TNC',
+        type: ConnectionType.serialTnc,
+      );
+      registry.register(aprsIs);
+      registry.register(bleTnc);
+      registry.register(serial);
+    });
+
+    tearDown(() async {
+      await aprsIs.dispose();
+      await bleTnc.dispose();
+      await serial.dispose();
+      registry.dispose();
+    });
+
+    test('routes lines from each connection with the correct source', () async {
+      final packets = <AprsPacket>[];
+      service.packetStream.listen(packets.add);
+
+      service.attach(registry);
+
+      aprsIs.simulateLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>via IS');
+      bleTnc.simulateLine('W2BLE>APMDN0:!4903.50N/07201.75W>via BLE');
+      serial.simulateLine('W3SER>APMDN0:!4903.50N/07201.75W>via Serial');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(packets, hasLength(3));
+      expect(
+        packets.map((p) => p.transportSource),
+        containsAll(<PacketSource>[
+          PacketSource.aprsIs,
+          PacketSource.bleTnc,
+          PacketSource.serialTnc,
+        ]),
+      );
+      final byCallsign = {
+        for (final p in packets) p.rawLine.split('>').first: p.transportSource,
+      };
+      expect(byCallsign['W1AW'], PacketSource.aprsIs);
+      expect(byCallsign['W2BLE'], PacketSource.bleTnc);
+      expect(byCallsign['W3SER'], PacketSource.serialTnc);
+    });
+
+    test('stop() cancels the registry subscription', () async {
+      service.attach(registry);
+
+      // Capture the active line stream before stop closes packetStream.
+      // After stop, simulating a line must not throw and must not produce
+      // any further side effects.
+      await service.stop();
+
+      // No throw is the assertion: the service has detached cleanly and
+      // late-arriving lines from the registry do not hit the closed
+      // packet controller.
+      expect(
+        () => aprsIs.simulateLine(
+          'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>after stop',
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('calling attach twice throws in debug builds', () {
+      service.attach(registry);
+      expect(() => service.attach(registry), throwsA(isA<AssertionError>()));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Eliminates the double subscription on every `MeridianConnection.lines` (registry + `main.dart`) by routing all production ingestion through a single `StationService.attach(ConnectionRegistry)` seam.
- `ConnectionRegistry.lines` (already a tagged broadcast) becomes the one production consumer point; the registry remains the broadcast hub for future non-decoding consumers (logging tap, TX confirmation observer, replay capture) — see ADR-063.
- `ingestLine` stays public and unchanged; it is still the synchronous direct-injection seam used by ~30 service tests and by `BackgroundServiceManager.onPacketLogged`. Both paths land in `_handleLine`.
- `ConnectionRegistry.register` gains an `onError` handler so per-connection `[conn.id]` error context is preserved at the new boundary.
- `_packetSourceFor` moves out of `main.dart` and into `StationService` as a private static helper.

Closes #56.

## Files
- `lib/services/station_service.dart` — `attach`, `_packetSourceFor`, `_registrySub` field, `stop()` cancels.
- `lib/core/connection/connection_registry.dart` — `onError` on per-conn listen.
- `lib/main.dart` — replace per-connection loop + helper with `service.attach(registry)`.
- `test/services/station_service_test.dart` — 3 new tests (routing per source, `stop()` cancels, double-attach asserts).
- `docs/DECISIONS.md` — ADR-063.
- `docs/ARCHITECTURE.md` — Connection-line ingestion subsection.
- `docs/ROADMAP.md` — tick item under v0.18.

## Test plan
- [x] `dart format .` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 671 passing (3 new)
- [x] Manual smoke: APRS-IS + TNC simultaneously; packets from both arrive in packet log with correct source tags; no duplicates; disconnecting one keeps the other ingesting.