### PR TITLE
test(services): cover TxService routing hierarchy + beacon fan-out (#60)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,7 +156,8 @@ Protocol-complete APRS messaging — group messages (`CQ`, `QST`, `ALL`, custom 
 Architecture, testing, and dependency foundations that unblock the subsequent performance, polish, and launch work. Nothing here is user-visible on its own; all of it removes friction or risk from later milestones.
 
 - ✅ Inject `Clock` abstraction so time-dependent logic is deterministic in tests (#43)
-- Service-level test coverage for `BeaconingService` (#52) and `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
+- Service-level test coverage for `BeaconingService` (#52)
+- ✅ Service-level test coverage for `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)
 - ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)

--- a/test/services/tx_service_routing_test.dart
+++ b/test/services/tx_service_routing_test.dart
@@ -1,0 +1,135 @@
+/// Tests that [TxService] routes outgoing TX correctly when licensed.
+///
+/// `sendLine` follows the unconditional Serial > BLE > APRS-IS hierarchy
+/// (ADR-029) with an optional `forceVia` per-message override. `sendBeacon`
+/// fans out to every connected connection where `beaconingEnabled` is true.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../helpers/fake_meridian_connection.dart';
+import '../helpers/fake_secure_credential_store.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late StationSettingsService settings;
+  late ConnectionRegistry registry;
+  late TxService tx;
+
+  Future<void> baseSetUp() async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1AW',
+      'user_ssid': 9,
+      'user_is_licensed': true,
+    });
+    prefs = await SharedPreferences.getInstance();
+    settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    registry = ConnectionRegistry();
+  }
+
+  FakeMeridianConnection makeConn({
+    required String id,
+    required ConnectionType type,
+    bool connected = true,
+  }) {
+    final conn = FakeMeridianConnection(id: id, displayName: id, type: type);
+    registry.register(conn);
+    if (connected) conn.setStatus(ConnectionStatus.connected);
+    return conn;
+  }
+
+  group('TxService — sendLine routing hierarchy (licensed)', () {
+    setUp(() async {
+      await baseSetUp();
+      tx = TxService(registry, settings);
+    });
+
+    tearDown(() async {
+      tx.dispose();
+      for (final c in registry.all) {
+        await c.dispose();
+      }
+    });
+
+    test('no connections → silent noop', () async {
+      // Empty registry: nothing to send to, nothing throws.
+      await tx.sendLine('TEST');
+      expect(registry.all, isEmpty);
+    });
+
+    test('APRS-IS only → routes to APRS-IS', () async {
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE');
+      expect(aprsIs.lastSentLine, 'LINE');
+    });
+
+    test('Serial + APRS-IS → Serial wins', () async {
+      final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE');
+      expect(serial.lastSentLine, 'LINE');
+      expect(aprsIs.lastSentLine, isNull);
+    });
+
+    test('BLE + APRS-IS → BLE wins', () async {
+      final ble = makeConn(id: 'ble', type: ConnectionType.bleTnc);
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE');
+      expect(ble.lastSentLine, 'LINE');
+      expect(aprsIs.lastSentLine, isNull);
+    });
+
+    test('Serial + BLE + APRS-IS all connected → Serial wins', () async {
+      final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
+      final ble = makeConn(id: 'ble', type: ConnectionType.bleTnc);
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE');
+      expect(serial.lastSentLine, 'LINE');
+      expect(ble.lastSentLine, isNull);
+      expect(aprsIs.lastSentLine, isNull);
+    });
+
+    test('forceVia: ConnectionType.aprsIs overrides hierarchy', () async {
+      final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
+      final ble = makeConn(id: 'ble', type: ConnectionType.bleTnc);
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE', forceVia: ConnectionType.aprsIs);
+      expect(aprsIs.lastSentLine, 'LINE');
+      expect(serial.lastSentLine, isNull);
+      expect(ble.lastSentLine, isNull);
+    });
+  });
+
+  group('TxService — sendBeacon fan-out', () {
+    setUp(() async {
+      await baseSetUp();
+      tx = TxService(registry, settings);
+    });
+
+    tearDown(() async {
+      tx.dispose();
+      for (final c in registry.all) {
+        await c.dispose();
+      }
+    });
+
+    test('beaconingEnabled=false excludes a connection from fan-out', () async {
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
+      await aprsIs.setBeaconingEnabled(false);
+
+      await tx.sendBeacon('=BEACON');
+
+      expect(serial.lastSentLine, '=BEACON');
+      expect(aprsIs.lastSentLine, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds service-level test coverage for `TxService` against its current behavior — no production code changes. Closes the `TxService` half of the v0.18 Foundations bullet (#60); `BeaconingService` (#52) remains open.

## Test cases (all 7)

`TxService — sendLine routing hierarchy (licensed)`:
1. no connections → silent noop
2. APRS-IS only → routes to APRS-IS
3. Serial + APRS-IS → Serial wins
4. BLE + APRS-IS → BLE wins
5. Serial + BLE + APRS-IS all connected → Serial wins
6. `forceVia: ConnectionType.aprsIs` overrides hierarchy

`TxService — sendBeacon fan-out`:

7. `beaconingEnabled=false` excludes a connection from fan-out

Hierarchy = ADR-029 (unconditional Serial > BLE > APRS-IS).

## Test plan

- [x] `dart format .` clean
- [x] `flutter analyze` clean
- [x] `flutter test test/services/tx_service_routing_test.dart` — 7/7 pass
- [x] `flutter test` — full suite green (678 tests)