### PR TITLE
test(services): cover BeaconingService timer + GPS + handoff (#52)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1429,3 +1429,36 @@ The result was duplicate listener machinery for every transport, dead broadcast 
 - `StationService.attach` enforces a single-attach contract via `assert`; calling it twice is a programming error.
 - `_packetSourceFor` is now a private static helper on `StationService`; `main.dart` no longer carries transport-tagging logic.
 - Future consumers of `registry.lines` need only `registry.lines.listen(...)` — no plumbing changes required.
+
+---
+
+## ADR-064: Inject `GeolocatorAdapter` for testable GPS access in `BeaconingService`
+
+**Date:** 2026-04-26
+**Status:** Accepted
+
+### Context
+
+`BeaconingService` (`lib/services/beaconing_service.dart`) had no service-level test coverage despite owning the timer state machine, mode transitions, smart-mode reschedule logic, and the `MissingPluginException → BeaconError.locationUnsupported` translation. PR 2 (#43) had already injected the `Clock` typedef so timer fires can be driven deterministically with `fake_async`, but five static `Geolocator.*` calls remained — `isLocationServiceEnabled`, `checkPermission`, `requestPermission`, `getCurrentPosition`, `getPositionStream` — and `package:geolocator` has no in-tree mocking helper that would work in a Dart-only `flutter test` (no platform channels, no method channel mocker).
+
+### Decision
+
+Introduce `lib/services/geolocator_adapter.dart`:
+
+```dart
+abstract class GeolocatorAdapter { /* the 5 methods above, signatures verbatim */ }
+class RealGeolocatorAdapter implements GeolocatorAdapter { /* delegates 1:1 */ }
+```
+
+`BeaconingService` accepts `GeolocatorAdapter geo = const RealGeolocatorAdapter()` as a defaulted constructor parameter and replaces every `Geolocator.X(...)` call with `_geo.X(...)`. No translation, no remapping — the adapter is a thin pass-through. `MissingPluginException` continues to bubble up from each method exactly as it did from the static calls; the existing `try/catch` blocks in `_requestPosition` and `_startPositionStream` continue to translate it into `BeaconError.locationUnsupported`. Tests pass `FakeGeolocatorAdapter` (in `test/helpers/`) with controllable `serviceEnabled` / `permission` / `throwMissingPlugin` flags and a stream the test can `emitPosition(...)` into.
+
+### Alternatives considered
+
+- **`mockito` / `mocktail` over the geolocator API.** Rejected: the project is mock-free in services today (`test/services/bulletin_scheduler_test.dart` uses a hand-rolled fixture + recording subclass), and adding `mockito` for one service would create a stylistic inconsistency. A small hand-rolled adapter mirrors the `KissTncTransport` / `SecureCredentialStore` pattern already established.
+- **Method-channel mock via `TestDefaultBinaryMessengerBinding`.** Rejected: would re-implement geolocator's wire protocol and bind us to its internal channel codec. Higher maintenance and lower clarity than a Dart-level seam.
+
+### Consequences
+
+- `BeaconingService` is now fully covered by `test/services/beaconing_service_test.dart` (12 cases): mode transitions, smart-mode reschedule (shorten-only), suspend/resume handoff, `onBeaconSent` fan-out, and `locationUnsupported` (single-attempt bounded, no retry storm).
+- The `FakeGeolocatorAdapter` helper is the natural template for v0.20's wider widget-test sweep when GPS-dependent UI gets covered.
+- No production wiring change — `lib/main.dart` continues to construct `BeaconingService(settings, tx, onBeaconSent: ...)` and the default `RealGeolocatorAdapter()` preserves identical runtime behavior.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -156,7 +156,7 @@ Protocol-complete APRS messaging — group messages (`CQ`, `QST`, `ALL`, custom 
 Architecture, testing, and dependency foundations that unblock the subsequent performance, polish, and launch work. Nothing here is user-visible on its own; all of it removes friction or risk from later milestones.
 
 - ✅ Inject `Clock` abstraction so time-dependent logic is deterministic in tests (#43)
-- Service-level test coverage for `BeaconingService` (#52)
+- ✅ Service-level test coverage for `BeaconingService` (#52)
 - ✅ Service-level test coverage for `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)

--- a/lib/services/beaconing_service.dart
+++ b/lib/services/beaconing_service.dart
@@ -22,6 +22,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../core/beaconing/smart_beaconing.dart';
 import '../core/packet/aprs_encoder.dart';
 import '../core/util/clock.dart';
+import 'geolocator_adapter.dart';
 import 'station_settings_service.dart';
 import 'tx_service.dart';
 
@@ -45,11 +46,14 @@ class BeaconingService extends ChangeNotifier {
     this._tx, {
     this.onBeaconSent,
     Clock clock = DateTime.now,
-  }) : _clock = clock;
+    GeolocatorAdapter geo = const RealGeolocatorAdapter(),
+  }) : _clock = clock,
+       _geo = geo;
 
   final StationSettingsService _settings;
   final TxService _tx;
   final Clock _clock;
+  final GeolocatorAdapter _geo;
 
   /// Called after every successful beacon with the raw APRS-IS line.
   ///
@@ -317,15 +321,15 @@ class BeaconingService extends ChangeNotifier {
 
   Future<Position?> _requestPosition() async {
     try {
-      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      bool serviceEnabled = await _geo.isLocationServiceEnabled();
       if (!serviceEnabled) {
         _lastError = BeaconError.locationServiceDisabled;
         return null;
       }
 
-      LocationPermission permission = await Geolocator.checkPermission();
+      LocationPermission permission = await _geo.checkPermission();
       if (permission == LocationPermission.denied) {
-        permission = await Geolocator.requestPermission();
+        permission = await _geo.requestPermission();
       }
       if (permission == LocationPermission.denied ||
           permission == LocationPermission.deniedForever) {
@@ -333,7 +337,7 @@ class BeaconingService extends ChangeNotifier {
         return null;
       }
 
-      return await Geolocator.getCurrentPosition(
+      return await _geo.getCurrentPosition(
         locationSettings: const LocationSettings(
           accuracy: LocationAccuracy.best,
         ),
@@ -354,19 +358,21 @@ class BeaconingService extends ChangeNotifier {
     if (_mode != BeaconMode.smart) return;
 
     try {
-      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      bool serviceEnabled = await _geo.isLocationServiceEnabled();
       if (!serviceEnabled) return;
-      LocationPermission permission = await Geolocator.checkPermission();
+      LocationPermission permission = await _geo.checkPermission();
       if (permission == LocationPermission.denied ||
           permission == LocationPermission.deniedForever) {
         return;
       }
 
-      _positionSub = Geolocator.getPositionStream(
-        locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.best,
-        ),
-      ).listen(_onPositionUpdate);
+      _positionSub = _geo
+          .getPositionStream(
+            locationSettings: const LocationSettings(
+              accuracy: LocationAccuracy.best,
+            ),
+          )
+          .listen(_onPositionUpdate);
     } on MissingPluginException {
       _gpsUnsupported = true;
       _lastError = BeaconError.locationUnsupported;

--- a/lib/services/geolocator_adapter.dart
+++ b/lib/services/geolocator_adapter.dart
@@ -1,0 +1,39 @@
+/// Testability seam over the static `Geolocator` API.
+///
+/// `BeaconingService` calls platform GPS through this interface so tests can
+/// substitute a fake without binding to platform channels. Production wires
+/// [RealGeolocatorAdapter], which delegates one-for-one to `geolocator`.
+library;
+
+import 'package:geolocator/geolocator.dart';
+
+abstract class GeolocatorAdapter {
+  Future<bool> isLocationServiceEnabled();
+  Future<LocationPermission> checkPermission();
+  Future<LocationPermission> requestPermission();
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings});
+  Stream<Position> getPositionStream({LocationSettings? locationSettings});
+}
+
+class RealGeolocatorAdapter implements GeolocatorAdapter {
+  const RealGeolocatorAdapter();
+
+  @override
+  Future<bool> isLocationServiceEnabled() =>
+      Geolocator.isLocationServiceEnabled();
+
+  @override
+  Future<LocationPermission> checkPermission() => Geolocator.checkPermission();
+
+  @override
+  Future<LocationPermission> requestPermission() =>
+      Geolocator.requestPermission();
+
+  @override
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings}) =>
+      Geolocator.getCurrentPosition(locationSettings: locationSettings);
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) =>
+      Geolocator.getPositionStream(locationSettings: locationSettings);
+}

--- a/test/helpers/fake_geolocator_adapter.dart
+++ b/test/helpers/fake_geolocator_adapter.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart' show MissingPluginException;
+import 'package:geolocator/geolocator.dart';
+import 'package:meridian_aprs/services/geolocator_adapter.dart';
+
+/// In-memory [GeolocatorAdapter] for tests.
+///
+/// Defaults to a happy path (service enabled, permission `always`, a fixed
+/// stationary fix). Tweak the public flags before invoking the system under
+/// test to drive failure paths. Use [emitPosition] / [position] to drive the
+/// position stream that smart-mode subscribes to.
+class FakeGeolocatorAdapter implements GeolocatorAdapter {
+  bool serviceEnabled = true;
+  LocationPermission permission = LocationPermission.always;
+  bool throwMissingPlugin = false;
+
+  /// Returned by [getCurrentPosition]; defaults to a fixed Austin TX fix.
+  Position currentPosition = position();
+
+  /// Counts of each entry point — useful for asserting "no infinite retry".
+  int isLocationServiceEnabledCalls = 0;
+  int checkPermissionCalls = 0;
+  int requestPermissionCalls = 0;
+  int getCurrentPositionCalls = 0;
+  int getPositionStreamCalls = 0;
+
+  final _streamController = StreamController<Position>.broadcast(sync: true);
+
+  /// Push a position into the stream returned by [getPositionStream].
+  void emitPosition(Position p) => _streamController.add(p);
+
+  /// Convenience factory — most fields don't matter for these tests.
+  static Position position({
+    double lat = 30.27,
+    double lon = -97.74,
+    double speed = 0,
+    double heading = 0,
+  }) => Position(
+    latitude: lat,
+    longitude: lon,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+    accuracy: 5,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: heading,
+    headingAccuracy: 0,
+    speed: speed,
+    speedAccuracy: 0,
+  );
+
+  @override
+  Future<bool> isLocationServiceEnabled() async {
+    isLocationServiceEnabledCalls++;
+    if (throwMissingPlugin) throw MissingPluginException('no impl');
+    return serviceEnabled;
+  }
+
+  @override
+  Future<LocationPermission> checkPermission() async {
+    checkPermissionCalls++;
+    if (throwMissingPlugin) throw MissingPluginException('no impl');
+    return permission;
+  }
+
+  @override
+  Future<LocationPermission> requestPermission() async {
+    requestPermissionCalls++;
+    if (throwMissingPlugin) throw MissingPluginException('no impl');
+    return permission;
+  }
+
+  @override
+  Future<Position> getCurrentPosition({
+    LocationSettings? locationSettings,
+  }) async {
+    getCurrentPositionCalls++;
+    if (throwMissingPlugin) throw MissingPluginException('no impl');
+    return currentPosition;
+  }
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    getPositionStreamCalls++;
+    if (throwMissingPlugin) {
+      return Stream.error(MissingPluginException('no impl'));
+    }
+    return _streamController.stream;
+  }
+
+  Future<void> close() => _streamController.close();
+}

--- a/test/services/beaconing_service_test.dart
+++ b/test/services/beaconing_service_test.dart
@@ -1,0 +1,445 @@
+/// Service-level tests for BeaconingService (v0.18 PR 5, issue #52).
+///
+/// Pins the timer state machine, GPS plumbing, suspend/resume handoff, the
+/// onBeaconSent callback fan-out, and the locationUnsupported error path.
+/// Pure SmartBeaconing math is covered separately in
+/// `test/core/beaconing/smart_beaconing_test.dart`.
+///
+/// Time control combines `fake_async` (drives Timer + Future scheduling) with
+/// the project's injected [Clock] typedef so wall-clock reads and timer fires
+/// advance in lock-step.
+library;
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/beaconing_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../helpers/fake_geolocator_adapter.dart';
+import '../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Recording TxService — captures sendBeacon lines without touching connections.
+// ---------------------------------------------------------------------------
+
+class _RecordingTxService extends TxService {
+  _RecordingTxService(super.registry, super.settings);
+  final List<String> sentBeacons = [];
+
+  @override
+  Future<void> sendBeacon(String aprsLine) async {
+    sentBeacons.add(aprsLine);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+class _Fixture {
+  _Fixture._({
+    required this.svc,
+    required this.tx,
+    required this.geo,
+    required this.beaconCallbackLines,
+    required this.fakeNow,
+  });
+
+  final BeaconingService svc;
+  final _RecordingTxService tx;
+  final FakeGeolocatorAdapter geo;
+  final List<String> beaconCallbackLines;
+  final DateTime Function() fakeNow;
+
+  /// Build the fixture inside a `fakeAsync` zone. The returned `Clock` reads
+  /// `async.elapsed` so it advances in step with `async.elapse(...)`.
+  static Future<_Fixture> build(
+    FakeAsync async, {
+    Map<String, Object> prefs = const {},
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1ABC',
+      'user_ssid': 7,
+      'user_is_licensed': true,
+      'user_symbol_table': '/',
+      'user_symbol_code': '>',
+      ...prefs,
+    });
+    final p = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      p,
+      store: FakeSecureCredentialStore(),
+    );
+    final registry = ConnectionRegistry();
+    final tx = _RecordingTxService(registry, settings);
+    final geo = FakeGeolocatorAdapter();
+
+    final start = DateTime(2026, 4, 26, 12, 0, 0);
+    DateTime fakeNow() => start.add(async.elapsed);
+
+    final callbackLines = <String>[];
+    final svc = BeaconingService(
+      settings,
+      tx,
+      onBeaconSent: callbackLines.add,
+      clock: fakeNow,
+      geo: geo,
+    );
+
+    return _Fixture._(
+      svc: svc,
+      tx: tx,
+      geo: geo,
+      beaconCallbackLines: callbackLines,
+      fakeNow: fakeNow,
+    );
+  }
+}
+
+/// Build the fixture and run [body] inside a `fakeAsync` zone.
+///
+/// Wraps the boilerplate so individual tests stay focused on their assertions.
+void _runFakeAsync(Future<void> Function(_Fixture f, FakeAsync async) body) {
+  fakeAsync((async) {
+    late _Fixture f;
+    _Fixture.build(async).then((built) => f = built);
+    async.flushMicrotasks();
+    body(f, async);
+    async.flushMicrotasks();
+  });
+}
+
+/// Position with `speedKmh` (geolocator's [Position.speed] is in m/s).
+Position _pos({
+  double lat = 30.27,
+  double lon = -97.74,
+  double speedKmh = 0,
+  double heading = 0,
+}) => FakeGeolocatorAdapter.position(
+  lat: lat,
+  lon: lon,
+  speed: speedKmh / 3.6,
+  heading: heading,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // ---------------------------------------------------------------------------
+  // 1. Mode transitions: timer start/stop on each transition.
+  // ---------------------------------------------------------------------------
+
+  group('mode transitions', () {
+    test('setMode while inactive does not start a timer', () {
+      _runFakeAsync((f, async) async {
+        await f.svc.setMode(BeaconMode.auto);
+        async.flushMicrotasks();
+        async.elapse(const Duration(hours: 2));
+        expect(f.tx.sentBeacons, isEmpty);
+        expect(f.svc.isActive, isFalse);
+      });
+    });
+
+    test(
+      'startBeaconing in auto schedules at autoIntervalS and fires immediately',
+      () {
+        _runFakeAsync((f, async) async {
+          await f.svc.setMode(BeaconMode.auto);
+          await f.svc.setAutoInterval(120);
+          unawaited(f.svc.startBeaconing());
+          async.flushMicrotasks();
+          // Immediate first beacon (standard APRS practice — see
+          // beaconing_service.dart:250-252).
+          expect(f.tx.sentBeacons, hasLength(1));
+
+          async.elapse(const Duration(seconds: 119));
+          expect(f.tx.sentBeacons, hasLength(1));
+          async.elapse(const Duration(seconds: 1));
+          expect(f.tx.sentBeacons, hasLength(2));
+        });
+      },
+    );
+
+    test('stopBeaconing cancels the timer — no further beacons fire', () {
+      _runFakeAsync((f, async) async {
+        await f.svc.setMode(BeaconMode.auto);
+        await f.svc.setAutoInterval(120);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        expect(f.tx.sentBeacons, hasLength(1));
+
+        await f.svc.stopBeaconing();
+        async.flushMicrotasks();
+        expect(f.svc.isActive, isFalse);
+
+        async.elapse(const Duration(seconds: 600));
+        expect(f.tx.sentBeacons, hasLength(1));
+      });
+    });
+
+    test('setMode while active stops beaconing (current behavior)', () {
+      _runFakeAsync((f, async) async {
+        await f.svc.setMode(BeaconMode.auto);
+        await f.svc.setAutoInterval(120);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        expect(f.svc.isActive, isTrue);
+
+        await f.svc.setMode(BeaconMode.smart);
+        async.flushMicrotasks();
+        expect(
+          f.svc.isActive,
+          isFalse,
+          reason:
+              'setMode calls stopBeaconing — see beaconing_service.dart:136',
+        );
+
+        // After the mode change there should be no spurious beacons either.
+        final countAtSwitch = f.tx.sentBeacons.length;
+        async.elapse(const Duration(seconds: 600));
+        expect(f.tx.sentBeacons, hasLength(countAtSwitch));
+      });
+    });
+
+    test('startBeaconing in smart subscribes to the position stream', () {
+      _runFakeAsync((f, async) async {
+        await f.svc.setMode(BeaconMode.smart);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        // Auto mode skips the position stream; smart mode subscribes.
+        expect(
+          f.geo.getPositionStreamCalls,
+          1,
+          reason: 'smart mode opens the GPS stream once',
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Smart-mode interval rescheduling.
+  // ---------------------------------------------------------------------------
+
+  group('smart interval rescheduling', () {
+    test('shortens the interval when speed increases mid-flight', () {
+      _runFakeAsync((f, async) async {
+        // Start with stationary GPS → slow rate (1800s).
+        f.geo.currentPosition = _pos(speedKmh: 0);
+        await f.svc.setMode(BeaconMode.smart);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        expect(f.tx.sentBeacons, hasLength(1));
+
+        // Stream emits a fast fix. SmartBeaconing.computeInterval(60kmh) ≈ 300s.
+        f.geo.emitPosition(_pos(speedKmh: 60));
+        async.flushMicrotasks();
+
+        // Advance 300s — the original 1800s timer would not have fired.
+        async.elapse(const Duration(seconds: 305));
+        expect(
+          f.tx.sentBeacons.length,
+          greaterThanOrEqualTo(2),
+          reason:
+              'fast-speed reschedule should shorten the timer well below 1800s',
+        );
+      });
+    });
+
+    test('does NOT extend the interval when speed decreases', () {
+      _runFakeAsync((f, async) async {
+        // Start with fast GPS → ~300s rate.
+        f.geo.currentPosition = _pos(speedKmh: 60);
+        await f.svc.setMode(BeaconMode.smart);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        expect(f.tx.sentBeacons, hasLength(1));
+
+        // Stream emits a slow fix. New interval = 1800s. Per
+        // _rescheduleSmartTimer (beaconing_service.dart:441), only shorten —
+        // never push the beacon further out.
+        f.geo.emitPosition(_pos(speedKmh: 5));
+        async.flushMicrotasks();
+
+        // The original ~300s timer should still fire on schedule.
+        async.elapse(const Duration(seconds: 305));
+        expect(
+          f.tx.sentBeacons.length,
+          greaterThanOrEqualTo(2),
+          reason: 'slow-speed update must not push the timer out',
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Suspend/resume handoff (the "persistence round-trip" pathway).
+  // ---------------------------------------------------------------------------
+
+  group('background handoff', () {
+    test(
+      'resumeFromBackground restores lastBeaconAt and reschedules the timer',
+      () {
+        _runFakeAsync((f, async) async {
+          await f.svc.setMode(BeaconMode.auto);
+          await f.svc.setAutoInterval(600);
+          unawaited(f.svc.startBeaconing());
+          async.flushMicrotasks();
+          expect(f.tx.sentBeacons, hasLength(1));
+
+          // Hand off to the background isolate. Main-isolate timer cancels;
+          // isActive remains true.
+          f.svc.suspendTimerForBackground();
+          expect(f.svc.isActive, isTrue);
+
+          // 200 s of "background" elapse with no main-isolate activity.
+          async.elapse(const Duration(seconds: 200));
+          expect(f.tx.sentBeacons, hasLength(1));
+
+          // Background isolate beaconed at this moment; foreground returns
+          // and replays the last-beacon timestamp.
+          final bgBeaconTime = f.fakeNow();
+          f.svc.resumeFromBackground(bgBeaconTime);
+          expect(f.svc.lastBeaconAt, bgBeaconTime);
+
+          // Timer should be rescheduled to fire 600s after bgBeaconTime.
+          async.elapse(const Duration(seconds: 599));
+          expect(f.tx.sentBeacons, hasLength(1));
+          async.elapse(const Duration(seconds: 1));
+          expect(f.tx.sentBeacons, hasLength(2));
+        });
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. onBeaconSent callback wiring.
+  // ---------------------------------------------------------------------------
+
+  group('onBeaconSent', () {
+    test('fires exactly once per successful beacon', () {
+      _runFakeAsync((f, async) async {
+        await f.svc.setMode(BeaconMode.auto);
+        await f.svc.setAutoInterval(120);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        // Initial beacon.
+        expect(f.beaconCallbackLines, hasLength(1));
+        expect(f.tx.sentBeacons, hasLength(1));
+
+        // Advance through three timer fires.
+        async.elapse(const Duration(seconds: 360));
+        expect(f.beaconCallbackLines, hasLength(4));
+        expect(f.tx.sentBeacons, hasLength(4));
+
+        // Callback line and TX line agree.
+        expect(f.beaconCallbackLines.last, f.tx.sentBeacons.last);
+        expect(f.beaconCallbackLines.last, contains('W1ABC-7'));
+      });
+    });
+
+    test('does NOT fire when manual position is missing', () {
+      _runFakeAsync((f, async) async {
+        // Switch to manual source without setting coordinates.
+        SharedPreferences.setMockInitialValues({
+          'user_callsign': 'W1ABC',
+          'user_ssid': 7,
+          'user_is_licensed': true,
+          'user_location_source': LocationSource.manual.index,
+        });
+        // Rebuild settings/svc with the new prefs. Easiest: reach in via a
+        // fresh service since the existing fixture's settings reads prefs at
+        // construction.
+        final p = await SharedPreferences.getInstance();
+        final settings = StationSettingsService(
+          p,
+          store: FakeSecureCredentialStore(),
+        );
+        final registry = ConnectionRegistry();
+        final tx = _RecordingTxService(registry, settings);
+        final geo = FakeGeolocatorAdapter();
+        final callbackLines = <String>[];
+        final svc = BeaconingService(
+          settings,
+          tx,
+          onBeaconSent: callbackLines.add,
+          clock: f.fakeNow,
+          geo: geo,
+        );
+
+        await svc.beaconNow();
+        async.flushMicrotasks();
+
+        expect(callbackLines, isEmpty);
+        expect(tx.sentBeacons, isEmpty);
+        expect(svc.lastError, BeaconError.noManualPosition);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. BeaconError.locationUnsupported (Linux desktop path).
+  // ---------------------------------------------------------------------------
+
+  group('locationUnsupported', () {
+    test('a single beaconNow does not loop or crash', () {
+      _runFakeAsync((f, async) async {
+        f.geo.throwMissingPlugin = true;
+
+        await f.svc.beaconNow();
+        async.flushMicrotasks();
+
+        expect(f.svc.lastError, BeaconError.locationUnsupported);
+        expect(f.svc.gpsUnsupported, isTrue);
+        expect(f.tx.sentBeacons, isEmpty);
+        expect(f.beaconCallbackLines, isEmpty);
+        expect(
+          f.geo.isLocationServiceEnabledCalls,
+          1,
+          reason:
+              'each beaconNow must perform exactly one entry call — no infinite '
+              'retry inside a single attempt',
+        );
+      });
+    });
+
+    test('failed beacons do not retrigger the timer chain', () {
+      // Each `beaconNow` makes exactly one entry call. When position
+      // resolution fails the early-return path skips `_restartTimer`
+      // (beaconing_service.dart:194-197), so the one-shot timer chain
+      // halts after a single fire. Pinning current behavior — there is
+      // no exponential retry, and there is no infinite "tight loop"
+      // either.
+      _runFakeAsync((f, async) async {
+        f.geo.throwMissingPlugin = true;
+
+        await f.svc.setMode(BeaconMode.auto);
+        await f.svc.setAutoInterval(120);
+        unawaited(f.svc.startBeaconing());
+        async.flushMicrotasks();
+        // Initial beaconNow inside startBeaconing.
+        expect(f.geo.isLocationServiceEnabledCalls, 1);
+
+        // The 120 s one-shot timer scheduled before that first beaconNow
+        // still fires once; it then dies because the failed beacon did
+        // not reschedule.
+        async.elapse(const Duration(seconds: 120));
+        expect(f.geo.isLocationServiceEnabledCalls, 2);
+
+        // No further fires for hours — confirms there is no hidden retry
+        // loop.
+        async.elapse(const Duration(hours: 1));
+        expect(f.geo.isLocationServiceEnabledCalls, 2);
+        expect(f.tx.sentBeacons, isEmpty);
+      });
+    });
+  });
+}
+
+/// Small shim so we can fire-and-forget async functions inside fake_async
+/// blocks without analyzer warnings (no `package:async` import needed).
+void unawaited(Future<void> _) {}


### PR DESCRIPTION
## Summary

Closes #52.

Adds service-level test coverage for `BeaconingService` (#52) — the timer state machine, mode transitions, smart-mode reschedule, suspend/resume handoff, `onBeaconSent` fan-out, and the `locationUnsupported` error path. PR 2's `Clock` injection (#43) is the precondition; this PR also extracts a minimal `GeolocatorAdapter` seam (ADR-064) so the five static `Geolocator.*` call sites can be faked in tests without touching platform channels.

- `lib/services/geolocator_adapter.dart` — new `GeolocatorAdapter` interface + `RealGeolocatorAdapter` (1:1 delegate)
- `lib/services/beaconing_service.dart` — accepts a defaulted `GeolocatorAdapter`; production wiring unchanged
- `test/helpers/fake_geolocator_adapter.dart` — controllable fake (service / permission / missing-plugin flags + position-stream emitter)
- `test/services/beaconing_service_test.dart` — 12 cases combining `fake_async` with the injected `Clock` so timer fires and wall-clock reads advance in lock-step
- `docs/ROADMAP.md` ticks #52 under v0.18
- `docs/DECISIONS.md` adds ADR-064

## Test cases (12)

`mode transitions`:
1. `setMode` while inactive does not start a timer
2. `startBeaconing` in auto schedules at `autoIntervalS` and fires immediately
3. `stopBeaconing` cancels the timer — no further beacons
4. `setMode` while active stops beaconing (current behavior)
5. `startBeaconing` in smart subscribes to the position stream

`smart interval rescheduling`:

6. shortens the interval when speed increases mid-flight
7. does NOT extend the interval when speed decreases (only-shorten rule)

`background handoff`:

8. `resumeFromBackground` restores `lastBeaconAt` and reschedules the timer

`onBeaconSent`:

9. fires exactly once per successful beacon
10. does NOT fire when manual position is missing

`locationUnsupported`:

11. a single `beaconNow` does not loop or crash
12. failed beacons do not retrigger the timer chain

## Behavior pinned worth noting

When `BeaconError.locationUnsupported` fires, a failed `beaconNow` does **not** reschedule the timer — the one-shot timer chain dies after a single fire. Test #12 pins this as current behavior. If we want failure→retry semantics, that's a separate behavior-change PR.

## Test plan

- [x] `dart format .` clean
- [x] `flutter analyze` clean
- [x] `flutter test test/services/beaconing_service_test.dart` — 12/12 pass
- [x] `flutter test` — full suite green (690 tests)
- [x] Linux smoke: `BeaconError.locationUnsupported` UI surface unchanged