### PR TITLE
test(widget): pin BeaconFAB tap dispatch + cooldown + Xm-ago label (#86)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,7 +158,7 @@ Architecture, testing, and dependency foundations that unblock the subsequent pe
 - ✅ Inject `Clock` abstraction so time-dependent logic is deterministic in tests (#43)
 - ✅ Service-level test coverage for `BeaconingService` (#52)
 - ✅ Service-level test coverage for `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
-- BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
+- ✅ BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)
 - ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
 - ✅ Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)

--- a/lib/ui/layout/mobile_scaffold.dart
+++ b/lib/ui/layout/mobile_scaffold.dart
@@ -360,19 +360,14 @@ class _MobileScaffoldState extends State<MobileScaffold> {
                                 !reg.all.any(
                                   (c) => c.beaconingEnabled && c.isConnected,
                                 );
+                            final callbacks = beaconFabCallbacksFor(beaconing);
                             return BeaconFAB(
                               isBeaconing: beaconing.isActive,
                               mode: beaconing.mode,
                               lastBeaconAt: beaconing.lastBeaconAt,
                               noBeaconTarget: noTarget,
-                              onTap: beaconing.mode == BeaconMode.manual
-                                  ? beaconing.beaconNow
-                                  : beaconing.isActive
-                                  ? beaconing.stopBeaconing
-                                  : beaconing.startBeaconing,
-                              onLongPress: beaconing.mode == BeaconMode.manual
-                                  ? beaconing.beaconNow
-                                  : null,
+                              onTap: callbacks.onTap,
+                              onLongPress: callbacks.onLongPress,
                             );
                           },
                         ),

--- a/lib/ui/widgets/beacon_fab.dart
+++ b/lib/ui/widgets/beacon_fab.dart
@@ -7,6 +7,27 @@ import 'package:material_symbols_icons/symbols.dart';
 import '../../services/beaconing_service.dart';
 import '../../theme/meridian_colors.dart';
 
+/// Maps the current [BeaconingService] state to the callbacks a [BeaconFAB]
+/// should fire on tap and long-press.
+///
+/// This dispatch is the regression-prone part of the FAB UX (#86): in
+/// `auto` / `smart` modes a tap must start or stop the timed/SmartBeaconing
+/// loop, **never** trigger a one-shot [BeaconingService.beaconNow]. Encoded
+/// here so the same logic is exercised by both [MobileScaffold] and the
+/// widget test in `test/widget/beacon_fab_test.dart`.
+({Future<void> Function() onTap, Future<void> Function()? onLongPress})
+beaconFabCallbacksFor(BeaconingService beaconing) {
+  if (beaconing.mode == BeaconMode.manual) {
+    return (onTap: beaconing.beaconNow, onLongPress: beaconing.beaconNow);
+  }
+  return (
+    onTap: beaconing.isActive
+        ? beaconing.stopBeaconing
+        : beaconing.startBeaconing,
+    onLongPress: null,
+  );
+}
+
 /// A large FAB that represents the beacon transmit action.
 ///
 /// - Idle/manual: primary blue background, broadcasting icon.

--- a/test/widget/beacon_fab_test.dart
+++ b/test/widget/beacon_fab_test.dart
@@ -1,0 +1,231 @@
+/// Widget regression guard for [BeaconFAB] — pins the tap dispatch in each
+/// [BeaconMode], the long-press cooldown, and the "Xm ago" subtitle (issue #86).
+///
+/// Auto/smart taps must call [BeaconingService.startBeaconing] /
+/// [BeaconingService.stopBeaconing], **not** [BeaconingService.beaconNow] —
+/// regressing that behavior turns the timed/SmartBeaconing loop into a
+/// one-shot transmit. The dispatch lives in [beaconFabCallbacksFor], adopted
+/// by [MobileScaffold]; this test exercises the same helper to keep the
+/// guard load-bearing.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/services/beaconing_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+import 'package:meridian_aprs/ui/widgets/beacon_fab.dart';
+
+import '../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Recording fake — captures invocations of the three methods the FAB might
+// call, and lets each test fix `mode` / `isActive` independently of timers,
+// GPS, or persisted prefs. Mirrors the `_RecordingTxService` shape in
+// `test/services/beaconing_service_test.dart`.
+// ---------------------------------------------------------------------------
+
+class _RecordingBeaconingService extends BeaconingService {
+  _RecordingBeaconingService(
+    super.settings,
+    super.tx, {
+    BeaconMode mode = BeaconMode.manual,
+    bool isActive = false,
+  }) : _testMode = mode,
+       _testIsActive = isActive;
+
+  final BeaconMode _testMode;
+  bool _testIsActive;
+
+  int beaconNowCalls = 0;
+  int startCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  BeaconMode get mode => _testMode;
+
+  @override
+  bool get isActive => _testIsActive;
+
+  @override
+  Future<void> beaconNow() async {
+    beaconNowCalls++;
+  }
+
+  @override
+  Future<void> startBeaconing() async {
+    startCalls++;
+    _testIsActive = true;
+  }
+
+  @override
+  Future<void> stopBeaconing() async {
+    stopCalls++;
+    _testIsActive = false;
+  }
+}
+
+Future<_RecordingBeaconingService> _makeService({
+  required BeaconMode mode,
+  required bool isActive,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final settings = StationSettingsService(
+    prefs,
+    store: FakeSecureCredentialStore(),
+  );
+  final registry = ConnectionRegistry();
+  final tx = TxService(registry, settings);
+  return _RecordingBeaconingService(
+    settings,
+    tx,
+    mode: mode,
+    isActive: isActive,
+  );
+}
+
+Future<void> _pumpFab(
+  WidgetTester tester, {
+  required _RecordingBeaconingService service,
+  DateTime? lastBeaconAt,
+}) async {
+  final callbacks = beaconFabCallbacksFor(service);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: BeaconFAB(
+            isBeaconing: service.isActive,
+            mode: service.mode,
+            lastBeaconAt: lastBeaconAt,
+            onTap: callbacks.onTap,
+            onLongPress: callbacks.onLongPress,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('BeaconFAB tap dispatch — issue #86', () {
+    testWidgets('manual mode tap → beaconNow', (tester) async {
+      final svc = await _makeService(mode: BeaconMode.manual, isActive: false);
+      await _pumpFab(tester, service: svc);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(svc.beaconNowCalls, 1);
+      expect(svc.startCalls, 0);
+      expect(svc.stopCalls, 0);
+    });
+
+    testWidgets('auto mode + idle tap → startBeaconing (NOT beaconNow)', (
+      tester,
+    ) async {
+      final svc = await _makeService(mode: BeaconMode.auto, isActive: false);
+      await _pumpFab(tester, service: svc);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(svc.startCalls, 1);
+      expect(svc.beaconNowCalls, 0, reason: 'regression #86 — must not fire');
+      expect(svc.stopCalls, 0);
+    });
+
+    testWidgets('auto mode + active tap → stopBeaconing (NOT beaconNow)', (
+      tester,
+    ) async {
+      final svc = await _makeService(mode: BeaconMode.auto, isActive: true);
+      await _pumpFab(tester, service: svc);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(svc.stopCalls, 1);
+      expect(svc.beaconNowCalls, 0, reason: 'regression #86 — must not fire');
+      expect(svc.startCalls, 0);
+    });
+
+    testWidgets('smart mode + idle tap → startBeaconing (NOT beaconNow)', (
+      tester,
+    ) async {
+      final svc = await _makeService(mode: BeaconMode.smart, isActive: false);
+      await _pumpFab(tester, service: svc);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(svc.startCalls, 1);
+      expect(svc.beaconNowCalls, 0, reason: 'regression #86 — must not fire');
+      expect(svc.stopCalls, 0);
+    });
+
+    testWidgets('smart mode + active tap → stopBeaconing (NOT beaconNow)', (
+      tester,
+    ) async {
+      final svc = await _makeService(mode: BeaconMode.smart, isActive: true);
+      await _pumpFab(tester, service: svc);
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(svc.stopCalls, 1);
+      expect(svc.beaconNowCalls, 0, reason: 'regression #86 — must not fire');
+      expect(svc.startCalls, 0);
+    });
+  });
+
+  group('BeaconFAB long-press cooldown', () {
+    testWidgets(
+      'manual mode: second long-press inside 30s window is suppressed',
+      (tester) async {
+        final svc = await _makeService(
+          mode: BeaconMode.manual,
+          isActive: false,
+        );
+        await _pumpFab(tester, service: svc);
+
+        await tester.longPress(find.byType(FloatingActionButton));
+        await tester.pumpAndSettle();
+
+        expect(svc.beaconNowCalls, 1);
+
+        await tester.longPress(find.byType(FloatingActionButton));
+        await tester.pumpAndSettle();
+
+        expect(
+          svc.beaconNowCalls,
+          1,
+          reason: 'second long-press within 30s must be suppressed',
+        );
+        expect(
+          find.text('Please wait 30 seconds between manual beacons.'),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+
+  group('BeaconFAB "Xm ago" subtitle', () {
+    testWidgets('renders "5m ago" for a 5-minute-old lastBeaconAt', (
+      tester,
+    ) async {
+      final svc = await _makeService(mode: BeaconMode.manual, isActive: false);
+      // BeaconFAB's _agoText uses DateTime.now() directly (beacon_fab.dart:109);
+      // bucket thresholds are coarse (60s / 60m), so a 5-minute delta is
+      // deterministic regardless of millisecond drift in the test runner.
+      final five = DateTime.now().subtract(const Duration(minutes: 5));
+      await _pumpFab(tester, service: svc, lastBeaconAt: five);
+
+      expect(find.text('5m ago'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Extracts the FAB tap/long-press dispatch out of `MobileScaffold` into a pure `beaconFabCallbacksFor(BeaconingService)` helper next to `BeaconFAB`. `MobileScaffold` adopts the helper — pure refactor, no behavior change.
- Adds `test/widget/beacon_fab_test.dart` (7 cases) that exercise the same helper, pinning the regression history called out in #86: in auto/smart modes a tap must call `startBeaconing` / `stopBeaconing` — never the one-shot `beaconNow`. Also pins the 30 s long-press cooldown SnackBar and the "Xm ago" subtitle formatter.
- Ticks the v0.18 BeaconFAB widget regression guard line in `ROADMAP.md`.

## Cases pinned

| Case | Expected |
|---|---|
| Manual tap | `beaconNow` × 1 |
| Auto, idle, tap | `startBeaconing`; not `beaconNow` |
| Auto, active, tap | `stopBeaconing`; not `beaconNow` |
| Smart, idle, tap | `startBeaconing`; not `beaconNow` |
| Smart, active, tap | `stopBeaconing`; not `beaconNow` |
| Manual, two long-presses < 30 s | second is suppressed; SnackBar shown |
| `lastBeaconAt = now − 5 min` | renders "5m ago" |

## Notes

- The "Xm ago" assertion uses `BeaconFAB`'s existing `DateTime.now()` formatter (coarse 60 s / 60 m buckets) rather than threading the v0.18 `Clock` typedef into `BeaconFAB` — behavior changes to the widget itself are out of scope for the regression guard.
- `_RecordingBeaconingService` is a test-local `extends BeaconingService` mirroring the `_RecordingTxService` pattern from `test/services/beaconing_service_test.dart`. No new helper added under `test/helpers/`.
- This PR closes #86. The umbrella widget-test sweep #53 stays open for v0.20 (#91).

## Test plan

- [x] `dart format .`
- [x] `flutter analyze` — no issues
- [x] `flutter test test/widget/beacon_fab_test.dart` — 7 / 7 pass
- [x] `flutter test` — full suite passes (697 / 697)

Closes #86