### PR TITLE
chore(deps): flutter_local_notifications v18 → v21

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,7 +159,8 @@ Architecture, testing, and dependency foundations that unblock the subsequent pe
 - ✅ Service-level test coverage for `BeaconingService` (#52)
 - ✅ Service-level test coverage for `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - ✅ BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
-- Dependency upgrades: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66); `flutter_blue_plus` 1.x → 2.x (#55)
+- ✅ Dependency upgrade: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66)
+- Dependency upgrade: `flutter_blue_plus` 1.x → 2.x (#55)
 - ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
 - ✅ Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -207,7 +207,7 @@ class NotificationService extends ChangeNotifier {
     );
 
     await _plugin.initialize(
-      settings,
+      settings: settings,
       onDidReceiveNotificationResponse: _onNotificationResponse,
     );
 
@@ -291,7 +291,7 @@ class NotificationService extends ChangeNotifier {
     // Remove pre-v0.12 channels that were registered but never dispatched.
     // Safe on fresh installs — deleteNotificationChannel is a no-op if absent.
     for (final stale in const ['alerts', 'nearby', 'system']) {
-      await androidPlugin.deleteNotificationChannel(stale);
+      await androidPlugin.deleteNotificationChannel(channelId: stale);
     }
   }
 
@@ -324,7 +324,7 @@ class NotificationService extends ChangeNotifier {
             .length;
         if (remaining < 2 && _initialized) {
           _plugin
-              .cancel(_kGroupSummaryId)
+              .cancel(id: _kGroupSummaryId)
               .catchError((_) {}); // ignore: unawaited_futures
         }
 
@@ -364,7 +364,9 @@ class NotificationService extends ChangeNotifier {
   void setActiveThread(String? callsign) {
     if (callsign != null && _initialized) {
       final notifId = callsign.hashCode.abs() % 100000 + 1;
-      _plugin.cancel(notifId).catchError((_) {}); // ignore: unawaited_futures
+      _plugin
+          .cancel(id: notifId)
+          .catchError((_) {}); // ignore: unawaited_futures
       _notifAnchor.remove(callsign);
     }
     _activeThreadCallsign = callsign?.toUpperCase();
@@ -655,10 +657,10 @@ class NotificationService extends ChangeNotifier {
         enableVibration: withVibration,
       );
       await _plugin.show(
-        id,
-        title,
-        preview,
-        NotificationDetails(android: androidDetails),
+        id: id,
+        title: title,
+        body: preview,
+        notificationDetails: NotificationDetails(android: androidDetails),
         payload: payload,
       );
     } else if (Platform.isIOS || Platform.isMacOS) {
@@ -669,10 +671,13 @@ class NotificationService extends ChangeNotifier {
         presentBadge: true,
       );
       await _plugin.show(
-        id,
-        title,
-        preview,
-        NotificationDetails(iOS: darwinDetails, macOS: darwinDetails),
+        id: id,
+        title: title,
+        body: preview,
+        notificationDetails: NotificationDetails(
+          iOS: darwinDetails,
+          macOS: darwinDetails,
+        ),
         payload: payload,
       );
     } else if (Platform.isLinux || Platform.isWindows) {
@@ -846,10 +851,13 @@ class NotificationService extends ChangeNotifier {
 
     final preview = text.length > 80 ? '${text.substring(0, 80)}…' : text;
     await _plugin.show(
-      id,
-      displayTitle ?? callsign,
-      preview,
-      NotificationDetails(iOS: darwinDetails, macOS: darwinDetails),
+      id: id,
+      title: displayTitle ?? callsign,
+      body: preview,
+      notificationDetails: NotificationDetails(
+        iOS: darwinDetails,
+        macOS: darwinDetails,
+      ),
       // payload always carries the raw callsign for navigation routing.
       payload: callsign,
     );
@@ -882,10 +890,10 @@ class NotificationService extends ChangeNotifier {
     );
 
     await _plugin.show(
-      _kGroupSummaryId,
-      'Meridian APRS',
-      '$total new messages',
-      NotificationDetails(android: androidDetails),
+      id: _kGroupSummaryId,
+      title: 'Meridian APRS',
+      body: '$total new messages',
+      notificationDetails: NotificationDetails(android: androidDetails),
       payload: '',
     );
   }
@@ -955,7 +963,7 @@ class NotificationService extends ChangeNotifier {
       if (response.actionId == _kMarkReadActionId && payload.isNotEmpty) {
         _messageService.markRead(payload);
         if (_initialized) {
-          _plugin.cancel(_kGroupSummaryId); // ignore: unawaited_futures
+          _plugin.cancel(id: _kGroupSummaryId); // ignore: unawaited_futures
         }
         return;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -354,26 +354,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1198,10 +1206,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   path_provider: ^2.1.5
   url_launcher: ^6.3.2
   live_activities: ^2.4.7
-  flutter_local_notifications: ^18.0.0
+  flutter_local_notifications: ^21.0.0
   local_notifier: ^0.1.6
   flutter_svg: ^2.2.4
   flutter_secure_storage: ^9.2.2

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -13,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Summary

- Bump `flutter_local_notifications` from `^18.0.0` (resolved 18.0.1) to `^21.0.0` (resolved 21.0.0). Three-major upgrade absorbs Android 14+ channel-behaviour changes, iOS 18 permission-flow improvements, and Darwin action-API fixes.
- Convert positional → named args at all `_plugin.show` / `_plugin.cancel` / `_plugin.initialize` / `_plugin.deleteNotificationChannel` call sites (v20 breaking change). 9 sites in `lib/services/notification_service.dart`.
- `desugar_jdk_libs` is already pinned to `2.1.4` in `android/app/build.gradle.kts:48` — exactly the version the v21 README specifies. No Android build config change needed.
- `windows/flutter/generated_plugins.cmake` auto-refreshed to register the new `flutter_local_notifications_windows` FFI plugin that v21 splits out.
- `ROADMAP.md` v0.18 — split the dependency-upgrade bullet so the notifications portion can be ticked while `flutter_blue_plus` 1.x → 2.x (#55) remains open.

Tooling minima for v21 (AGP 8.11.1, Kotlin 2.2.x, Java 17, iOS 13, Dart 3.10+) are already met by the repo — no Gradle, Podfile, or Info.plist changes required.

## Migration surface — what changed

| Surface | Status |
|---|---|
| `_plugin.initialize(settings, ...)` → `initialize(settings: settings, ...)` | Converted |
| `_plugin.show(id, title, body, details, payload: ...)` → all named (4 sites) | Converted |
| `_plugin.cancel(id)` → `cancel(id: id)` (3 sites) | Converted |
| `androidPlugin.deleteNotificationChannel(id)` → `deleteNotificationChannel(channelId: id)` | Converted |
| `AndroidInitializationSettings('@mipmap/ic_launcher')` | Unchanged (still positional) |
| `DarwinInitializationSettings(notificationCategories: [...])` | Unchanged |
| `DarwinNotificationCategory` / `DarwinNotificationAction.plain` / `.text(buttonTitle:, placeholder:)` | Unchanged |
| `AndroidNotificationChannel(id, name, ...)` | Unchanged |
| `getNotificationAppLaunchDetails()`, `NotificationResponse.input`, `NotificationResponseType.selectedNotificationAction` | Unchanged |

## Channel registration audit (declared values)

The 6 active channels declared in `_registerAndroidChannels()` (lines 224–296). Run `adb shell dumpsys notification --channels com.meridianaprs.meridian_aprs` post-install on an Android 14+ device and confirm the system-reported importance matches `Declared` for each row before merge.

| Channel ID | Declared importance | playSound | enableVibration | System-reported (fill in) |
|---|---|---|---|---|
| `messages` | `defaultImportance` | true | true | _pending device verify_ |
| `groups_builtin` | `low` | false | false | _pending device verify_ |
| `groups_custom` | `defaultImportance` | true | true | _pending device verify_ |
| `bulletins_general` | `low` | false | false | _pending device verify_ |
| `bulletins_subscribed` | `defaultImportance` | true | true | _pending device verify_ |
| `bulletin_expired` | `defaultImportance` | true | true | _pending device verify_ |

Legacy channels (`alerts`, `nearby`, `system`) continue to be deleted on init.

## iOS 18 notes

The v19 / v20 / v21 changelogs do not document any iOS 18-specific permission-flow changes; v21's iOS-side requirement bump is the deployment-target floor (`iOS 13`), already pinned in `ios/Podfile`. No new permission strings are required by the v21 README. iOS roundtrip should still be re-verified on iOS 18 to confirm no regression in `UNTextInputAction` delivery to `_onNotificationResponse`.

## desugar_jdk_libs

| | Before | After |
|---|---|---|
| Pin | `2.1.4` | `2.1.4` (unchanged — matches v21 README) |

## Test plan

Automated:
- [x] `flutter analyze` — clean (was 18 errors before call-site conversion)
- [x] `flutter test` — 697/697 pass
- [ ] CI matrix (Android / iOS / macOS / Windows / Linux debug builds)

Manual (must be completed by reviewer pre-merge):
- [ ] **Android 14+ inline reply roundtrip:** receive APRS message → tap "Reply" in shade → type → Send → confirm APRS message transmits and notification updates.
- [ ] **Android "Mark as Read":** tap action → unread badge clears, group summary cancels when fewer than 2 conversations remain unread.
- [ ] **Android cold-start tap:** tap notification body → app opens to `MessageThreadScreen` for the correct callsign.
- [ ] **iOS 18 text-input action:** long-press notification → Reply → type → Send → APRS message transmits.
- [ ] **iOS "Mark as Read":** long-press → action → badge clears.
- [ ] **iOS cold-start:** tap notification while app is killed → lands on correct thread (exercises `getNotificationAppLaunchDetails`).
- [ ] **iOS 18 permission flow:** confirm no regression on first-run permission prompt.
- [ ] **Channel-importance audit table:** fill in the System-reported column above from `adb shell dumpsys notification --channels com.meridianaprs.meridian_aprs`.

Closes #54
Closes #66