### PR TITLE
chore(deps): pin flutter_blue_plus < 2.0 (license incompatibility)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,17 +62,17 @@ See `docs/ARCHITECTURE.md` for full detail.
 | ~~v0.13~~ | ~~Security & connectivity (passcode secure storage, APRS-IS filter config)~~ ✓ |
 | ~~v0.14~~ | ~~Base-callsign message matching (cross-SSID capture, addressee badges, conversation grouping)~~ ✓ |
 | ~~v0.17~~ | ~~Groups & Bulletins — APRS group messaging (CQ/QST/ALL/custom), bulletins (BLN0-9 + named), matcher precedence, messaging tab restructure~~ ✓ |
-| **v0.18** | Foundations — architecture, testing, and dependency foundations |
+| ~~v0.18~~ | ~~Foundations — architecture, testing, and dependency foundations~~ ✓ |
 | **v0.19** | Performance — Selector adoption, MapScreen rebuild fix, ListView hygiene, SQLite spike, battery/memory/throughput baselines |
 | **v0.20** | Polish & A11y — accessibility audit, iOS adaptive widget consistency, screen refactors, remaining widget tests |
 | **v1.0** | Launch — release pipeline, signing, App Group, physical-device validation, store submission |
 
 > **v0.15 and v0.16 numbers are skipped.** They were used historically as the "Battery & Performance" and "Bug Triage" milestones; the 2026-04-25 reorganization split that scope across v0.18/v0.19/v0.20 and the numbers are not reused.
 
-**Current status: v0.17 shipped (Groups & Bulletins). Next: v0.18 — Foundations.**
+**Current status: v0.18 shipped (Foundations). Next: v0.19 — Performance.**
 
 The active milestones are now structured as:
-- **v0.18 — Foundations** — clock injection, service-level tests, double-subscription cleanup, dependency upgrades (`flutter_local_notifications` v21, `flutter_blue_plus` 2.x), CI platform matrix, BeaconFAB widget regression guard.
+- ~~**v0.18 — Foundations**~~ ✓ — clock injection, service-level tests, double-subscription cleanup, dependency upgrades (`flutter_local_notifications` v21; `flutter_blue_plus` pinned to v1.x — v2 is proprietary-licensed and GPL-incompatible, ADR-065), CI platform matrix, BeaconFAB widget regression guard.
 - **v0.19 — Performance** — MapScreen rebuild fix, Selector convention, non-builder ListView sweep, SQLite/drift evaluation, battery drain profiling, memory audit, packet throughput baseline.
 - **v0.20 — Polish & A11y** — Semantics audit, adaptive widget consistency, MapScreen helper extraction, one-per-screen widget tests.
 - **v1.0 — Launch** — Android signing, iOS App Group, release-build CI, physical iPhone 16 Pro validation, Smart Beaconing drive test, store submission.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -4,7 +4,7 @@ A consolidated reference of what Meridian can do today, organized by user-facing
 
 > **Maintenance:** This document is generated and maintained by Claude Code as part of milestone close-out. When a milestone changes user-visible capabilities or platform behavior, update this file alongside `ROADMAP.md` and `DECISIONS.md`. Source of truth is the codebase, not aspiration — partially implemented or untested capabilities are flagged explicitly.
 
-**Last updated:** 2026-04-26 (v0.17 shipped; v0.18 Foundations next)
+**Last updated:** 2026-04-26 (v0.18 Foundations shipped; v0.19 Performance next)
 
 ---
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -26,7 +26,7 @@ Three concurrent transports, each modeled as a `MeridianConnection` and register
 - **Per-connection beaconing toggle:** each connection has its own `beacon_enabled_<id>` preference
 
 ### Explicit non-support
-- Classic Bluetooth SPP — planned v0.21 (not supported on iOS due to platform restriction)
+- Classic Bluetooth SPP — planned v0.22 (not supported on iOS due to platform restriction)
 - TCP KISS TNC (server software TNCs over LAN) — tracked in `FUTURE_FEATURES.md`
 - AFSK soft-modem (audio over phone speaker / mic) — no plans
 - AGW packet engine, KISS-over-IP variants beyond standard KISS-over-TCP
@@ -78,7 +78,7 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 |---|---|
 | Tile rendering | `flutter_map` 8.x with a pluggable `MeridianTileProvider` abstraction |
 | Online tile provider | Stadia Maps (`alidade_smooth` / `alidade_smooth_dark`); requires `STADIA_MAPS_API_KEY` via `--dart-define` |
-| Offline tile provider | Not implemented (planned v0.22) |
+| Offline tile provider | Not implemented (planned v0.23) |
 | Station rendering | One marker per station; APRS symbol via `AprsSymbolWidget` (Material icons today; sprite sheet at v1.0) |
 | Marker clustering | Not implemented (deferred) |
 | Track history | Per-station `TimestampedPosition` list (capped 500); polylines rendered, time-window-bounded |
@@ -250,7 +250,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 | APRS-IS RX | Y | Y | Y | Y | Y | P (proxy not deployed) |
 | BLE TNC | Y | Y | — | — | — | — |
 | USB Serial TNC | — | — | P | P | Y | — |
-| Classic BT SPP | Planned v0.21 | — (platform restriction) | Planned v0.21 | Planned v0.21 | Planned v0.21 | — |
+| Classic BT SPP | Planned v0.22 | — (platform restriction) | Planned v0.22 | Planned v0.22 | Planned v0.22 | — |
 | TX (beacon + message) | Y | Y | Y | Y | Y | P (depends on transport) |
 | Background packet RX | Y | Y | — | — | — | — |
 | Background beaconing | Y | Y | — | — | — | — |
@@ -260,7 +260,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 | Inline reply from notification | Y | Y | — | — | — | — |
 | Dynamic Color | Y (Android 12+) | — | — | — | — | — |
 | Map (online tiles) | Y | Y | Y | Y | Y | Y |
-| Map (offline tiles) | Planned v0.22 | Planned v0.22 | Planned v0.22 | Planned v0.22 | Planned v0.22 | — |
+| Map (offline tiles) | Planned v0.23 | Planned v0.23 | Planned v0.23 | Planned v0.23 | Planned v0.23 | — |
 | Secure credential storage | Y | Y | Y | Y | Y | P (no hardware element) |
 
 ---
@@ -268,8 +268,8 @@ Y = supported, P = partial / pending validation, — = not supported.
 ## 13. Known Limitations / Explicit Non-Support
 
 ### Tracked, planned, deferred
-- **Classic Bluetooth SPP** — v0.21
-- **Offline maps** — v0.22
+- **Classic Bluetooth SPP** — v0.22
+- **Offline maps** — v0.23
 - **TCP KISS TNC** — `FUTURE_FEATURES.md`
 - **Inter-app API** — `FUTURE_FEATURES.md`
 - **NMEA-GPS bridge** for radios with internal TNCs — `FUTURE_FEATURES.md`

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1462,3 +1462,50 @@ class RealGeolocatorAdapter implements GeolocatorAdapter { /* delegates 1:1 */ }
 - `BeaconingService` is now fully covered by `test/services/beaconing_service_test.dart` (12 cases): mode transitions, smart-mode reschedule (shorten-only), suspend/resume handoff, `onBeaconSent` fan-out, and `locationUnsupported` (single-attempt bounded, no retry storm).
 - The `FakeGeolocatorAdapter` helper is the natural template for v0.20's wider widget-test sweep when GPS-dependent UI gets covered.
 - No production wiring change — `lib/main.dart` continues to construct `BeaconingService(settings, tx, onBeaconSent: ...)` and the default `RealGeolocatorAdapter()` preserves identical runtime behavior.
+
+---
+
+## ADR-065: Pin `flutter_blue_plus` to v1.x (license incompatibility)
+
+**Date:** 2026-04-26
+**Status:** Accepted
+
+### Context
+
+`flutter_blue_plus` v2.0.0 (published on pub.dev as part of the 2.x line, current latest 2.2.1) was not an API migration. Its only changelog entry is *"[LICENSE] switch to FlutterBluePlus license."* The new "FlutterBluePlus License v1.3" is dual-tier:
+
+- Free for personal use, registered nonprofits, and accredited educational institutions
+- **Paid commercial license required for any for-profit use**, tiered by employee count (Starter 0–9, Team 10–29, Business 30–99, Enterprise 100+)
+- Treats *"use of the Software during development, testing, or evaluation by a for-profit organization"* as commercial use
+- No open-source-project exemption
+
+Meridian APRS is **GPL v3**. GPL v3 §7 forbids adding restrictions to a covered work beyond GPL's own terms when distributing it as part of a derivative work; a downstream packager or contributor that is a for-profit organization would be required by the FBP license to obtain a paid commercial license, which is precisely the kind of additional restriction GPL v3 forbids. The two licenses cannot co-exist in a redistributed binary.
+
+Issue #55 was filed during the v0.13-pre audit sweep based on the assumption that v2 was a normal API migration. v0.18 was scheduled to absorb that migration. The license discovery during pre-flight investigation reframed the work entirely.
+
+### Decision
+
+Pin `flutter_blue_plus` to `>=1.36.0 <2.0.0` in `pubspec.yaml`. Resolved version stays at `1.36.8` (BSD-3-Clause). Replace the plugin with a permissively licensed alternative in a dedicated pre-1.0 milestone (tracked at #114).
+
+A one-line comment in `pubspec.yaml` references this ADR so the constraint is self-explaining.
+
+### Alternatives considered
+
+- **Migrate to FBP v2 under a paid commercial license.** Rejected. A purchased license authorizes the project's own development but does not relieve downstream recipients of the proprietary terms; GPL v3 redistribution to for-profit recipients remains impossible.
+- **Fork `flutter_blue_plus` at the last BSD-3 commit and maintain it.** Rejected as the v0.18 mitigation. Maintaining a BLE plugin fork is a non-trivial commitment (Android / iOS / desktop platform code, future SDK targets, security fixes). Reserved as a fallback option within the #114 replacement milestone if no maintained alternative meets requirements.
+- **Migrate immediately to `flutter_reactive_ble` (Apache-2.0) or `quick_blue` (MIT).** Rejected for v0.18 — the plugin swap touches the BLE scanner UI, the `BleDeviceAdapter` contract, MTU handling, notify subscription shape, and connect/autoConnect semantics; surface area is larger than the v0.18 budget and warrants its own milestone.
+
+### Consequences
+
+- No upstream fixes (iOS Core Bluetooth backend, Android 14+ permission refinements, security patches) reach Meridian past the v1.36.x line. The risk window grows the longer the pin holds.
+- The `BleDeviceAdapter` interface in `lib/core/transport/ble_tnc_transport_impl.dart` already isolates the bulk of fbp from production code — when the replacement lands, the swap is concentrated there plus `lib/ui/widgets/ble_scanner_sheet.dart` and the `flutter_blue_plus_platform_interface 7.0.0` transitive.
+- Replacement plugin work (#114) is a pre-1.0 blocker. v1.0 cannot ship on a deprecating dependency.
+- This ADR is the canonical reference for any future contributor who notices the upper-bound constraint and wonders why we are not on the latest line.
+
+### References
+
+- Issue #55 (closed by the PR that landed this ADR)
+- Issue #114 (replacement-plugin tracking, pre-1.0 blocker)
+- pub.dev changelog: `https://pub.dev/packages/flutter_blue_plus/changelog`
+- License text: `https://github.com/chipweinberger/flutter_blue_plus/blob/master/LICENSE.md`
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,8 +26,9 @@ Each milestone represents a shippable increment with a focused scope. Features d
 | v0.18 — Foundations | Architecture, testing, and dependency foundations that unblock subsequent performance, polish, and launch work | ✅ Complete |
 | v0.19 — Performance | Performance pass — Selector adoption, MapScreen rebuild fix, ListView hygiene, SQLite spike, battery / memory / throughput baselines | — |
 | v0.20 — Polish & A11y | Pre-launch polish — accessibility audit, iOS adaptive widget consistency, screen refactors, remaining widget tests | — |
-| v0.21 — Classic Bluetooth SPP | Classic Bluetooth SPP transport for KISS TNCs on Android, Linux, Windows, macOS (iOS excluded by platform restriction) | — |
-| v0.22 — Offline Maps | Offline tile caching for portable / field / SAR use without cell service, layered onto the existing `MeridianTileProvider` abstraction | — |
+| v0.21 — BLE Plugin Replacement | Replace `flutter_blue_plus` with a GPL-compatible BLE plugin behind the existing `BleTncTransport` seam (#114, ADR-065) | — |
+| v0.22 — Classic Bluetooth SPP | Classic Bluetooth SPP transport for KISS TNCs on Android, Linux, Windows, macOS (iOS excluded by platform restriction) | — |
+| v0.23 — Offline Maps | Offline tile caching for portable / field / SAR use without cell service, layered onto the existing `MeridianTileProvider` abstraction | — |
 | v1.0 — Launch | Final release pipeline — Android signing, iOS App Group, release-build CI, physical-device validation, tocall bump, store submission | — |
 
 > **v0.15 and v0.16 numbers are skipped.** They were used historically as the "Battery & Performance" and "Bug Triage" milestones; the 2026-04-25 reorganization split that scope across v0.18/v0.19/v0.20 and the numbers are not reused.
@@ -191,7 +192,24 @@ Pre-launch polish. The same surfaces being touched for accessibility and adaptiv
 
 ---
 
-### v0.21 — Classic Bluetooth SPP
+### v0.21 — BLE Plugin Replacement
+
+Replace `flutter_blue_plus` with a GPL-compatible BLE plugin. This is the follow-on to ADR-065 — v0.18 pinned `flutter_blue_plus` to v1.x because v2 switched to a proprietary license incompatible with GPL v3, and that pin must not become permanent before v1.0 ships.
+
+The existing `BleDeviceAdapter` interface in `lib/core/transport/ble_tnc_transport_impl.dart` already isolates the bulk of the plugin from production code; the swap is concentrated there plus `lib/ui/widgets/ble_scanner_sheet.dart`.
+
+Deliverables:
+
+- Audit `flutter_blue_plus` type leaks across the `BleTncTransport` seam — identify any remaining direct fbp imports outside the adapter and the scanner sheet
+- Select replacement plugin from candidates: `universal_ble`, `flutter_reactive_ble`, `bluetooth_low_energy` (or community fork of FBP at last BSD-3 commit as fallback)
+- Implement against existing `BleDeviceAdapter` interface — no public API change for downstream callers
+- Hardware test on Mobilinkd TNC4 across Android and iOS — pair, connect, packet RX, packet TX, background reconnect
+- ADR documenting the chosen plugin and any seam adjustments
+- Tracked at #114; pre-1.0 blocker
+
+---
+
+### v0.22 — Classic Bluetooth SPP
 
 Add Classic Bluetooth SPP as a fourth transport alongside APRS-IS, BLE TNC, and Serial TNC. Unlocks a meaningful slice of installed-base hardware — APRS-capable HTs and mobiles with built-in or add-on classic Bluetooth, and older Bluetooth-equipped TNCs that predate BLE.
 
@@ -218,7 +236,7 @@ Deliverables:
 
 ---
 
-### v0.22 — Offline Maps
+### v0.23 — Offline Maps
 
 Cache map tiles locally for portable / field / SAR use without cell service. The existing `MeridianTileProvider` abstraction was designed forward-looking for this — the current online provider stays as-is and the offline implementation sits alongside it as a separate provider rather than replacing it.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@ Each milestone represents a shippable increment with a focused scope. Features d
 | v0.13 — Security | Passcode secure storage, APRS-IS filter configuration | ✅ Complete |
 | v0.14 — Base-Callsign Matching | Capture-always cross-SSID message matching, addressee badges, conversation grouping | ✅ Complete |
 | v0.17 — Groups & Bulletins | APRS group messaging (CQ/QST/ALL/custom), bulletins (BLN0-9 + named), matcher precedence, messaging tab restructure | ✅ Complete |
-| v0.18 — Foundations | Architecture, testing, and dependency foundations that unblock subsequent performance, polish, and launch work | — |
+| v0.18 — Foundations | Architecture, testing, and dependency foundations that unblock subsequent performance, polish, and launch work | ✅ Complete |
 | v0.19 — Performance | Performance pass — Selector adoption, MapScreen rebuild fix, ListView hygiene, SQLite spike, battery / memory / throughput baselines | — |
 | v0.20 — Polish & A11y | Pre-launch polish — accessibility audit, iOS adaptive widget consistency, screen refactors, remaining widget tests | — |
 | v0.21 — Classic Bluetooth SPP | Classic Bluetooth SPP transport for KISS TNCs on Android, Linux, Windows, macOS (iOS excluded by platform restriction) | — |
@@ -160,7 +160,7 @@ Architecture, testing, and dependency foundations that unblock the subsequent pe
 - ✅ Service-level test coverage for `TxService` Serial > BLE > APRS-IS routing hierarchy (#60)
 - ✅ BeaconFAB widget regression guard — pin start/stop semantics in auto/smart modes, long-press cooldown, "Xm ago" label (#86, split from #53)
 - ✅ Dependency upgrade: `flutter_local_notifications` v18 → v21 paired with `desugar_jdk_libs` refresh (#54, absorbed #66)
-- Dependency upgrade: `flutter_blue_plus` 1.x → 2.x (#55)
+- ✅ Pin `flutter_blue_plus` to v1.x — v2 is proprietary-licensed and GPL-incompatible (ADR-065, #55); replacement plugin tracked as a pre-1.0 blocker (#114)
 - ✅ CI platform matrix — add Android / iOS / macOS / Windows builds alongside the existing Linux-debug build (#50)
 - ✅ Architecture cleanup: remove double subscription to `conn.lines` between `main.dart` and `ConnectionRegistry` (#56)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,8 @@ dependencies:
   flutter_m3shapes: ^1.0.0
   animations: ^2.0.11
   material_symbols_icons: ^4.2906.0
-  flutter_blue_plus: ^1.33.0
+  # v2.x is proprietary-licensed and GPL-incompatible; see ADR-065 (#114)
+  flutter_blue_plus: ">=1.36.0 <2.0.0"
   geolocator: ^13.0.0
   http: ^1.2.0
   flutter_foreground_task: ^8.17.0


### PR DESCRIPTION
## Summary

- `flutter_blue_plus` v2.0.0 is a **license change**, not an API migration. Its only changelog entry is *"[LICENSE] switch to FlutterBluePlus license."* The new "FlutterBluePlus License v1.3" is proprietary, requires a paid commercial license for any for-profit use (tiered by employee count), and offers no open-source-project exemption.
- Meridian APRS is **GPL v3**. GPL v3 forbids redistributing under stricter terms, so v2.x cannot be carried by this project.
- This PR pins `flutter_blue_plus` to `>=1.36.0 <2.0.0` and documents the decision in **ADR-065**. Resolved version is unchanged at `1.36.8` (same sha256 in `pubspec.lock` — zero functional change).
- The eventual GPL-compatible BLE plugin replacement is tracked at **#114** and now has its own dedicated **v0.21 — BLE Plugin Replacement** milestone. Subsequent milestones renumbered (Classic BT SPP → v0.22, Offline Maps → v0.23).
- Closes the v0.18 — Foundations milestone.

Closes #55. Tracking issue: #114. ADR: `docs/DECISIONS.md` ADR-065.

## What changed

- `pubspec.yaml` — constraint `^1.33.0` → `">=1.36.0 <2.0.0"` with one-line comment pointing at ADR-065
- `pubspec.lock` — verified unchanged (same `flutter_blue_plus 1.36.8`, same sha256)
- `docs/DECISIONS.md` — new ADR-065 with context, decision, alternatives, consequences, references
- `docs/ROADMAP.md` — v0.18 marked ✅ Complete; v0.18 fbp bullet rewritten; v0.21 BLE Plugin Replacement slotted; Classic BT SPP / Offline Maps renumbered to v0.22 / v0.23 with new detail section for v0.21
- `docs/CAPABILITIES.md` — "Last updated" line refreshed; planned-version references updated for renumbered milestones
- `CLAUDE.md` — milestone table ticks v0.18 ✅; current status points at v0.19; FBP 2.x note replaced with the pin rationale

No source files in `lib/` were touched.

## Test plan

- [x] `dart format .` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 697 tests pass
- [x] `pubspec.lock` confirmed unchanged after `flutter pub get`
- [ ] CI green on this branch
- No app/device testing required: resolved BLE plugin binary is byte-identical, so BLE pairing / packet RX/TX / reconnect behavior cannot change

## Rollback

Trivial — revert this PR. The `^1.33.0` constraint will resolve back to the same `1.36.8` that's currently locked.