### PR TITLE
BLE TNC background reliability: diagnostics, link-quality fixes, battery-opt prompt

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,13 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"
         android:minSdkVersion="33" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Lets the user opt Meridian out of Doze battery optimization. Required
+         on Android 14+ to keep the BLE TNC reconnect timers + keepalive firing
+         when the screen is off for an extended drive. The permission is only
+         meaningful when the user grants it via the system Settings → Apps →
+         Battery prompt; declaring it here is the gate that allows the prompt
+         to be raised. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <application
         android:label="Meridian APRS"
         android:name="${applicationName}"

--- a/lib/core/connection/ble_connection_impl.dart
+++ b/lib/core/connection/ble_connection_impl.dart
@@ -173,7 +173,10 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
         'BleConnection: no device set — call connectToDevice() first',
       );
     }
-    await _tearDownTransport();
+    // Internal: a fresh connect() supersedes any prior session — the teardown
+    // is plumbing, not a user-initiated disconnect, and the diagnostics log
+    // should reflect that.
+    await _tearDownTransport(internal: true);
     _buildAndAttachTransport(device);
     await _transport!.connect();
   }
@@ -182,7 +185,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   Future<void> disconnect() async {
     cancelReconnect();
     _device = null;
-    await _tearDownTransport();
+    await _tearDownTransport(internal: false);
     _emitStatus(ConnectionStatus.disconnected);
     notifyListeners();
   }
@@ -190,7 +193,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   @override
   Future<void> dispose() async {
     cancelReconnect();
-    await _tearDownTransport();
+    await _tearDownTransport(internal: true);
     await _linesController.close();
     await _stateController.close();
     super.dispose();
@@ -217,7 +220,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
       BleEventKind.reconnectAttempt,
       'device=${device.platformName}',
     );
-    await _tearDownTransport();
+    await _tearDownTransport(internal: true);
     if (_device == null) return; // disconnect() called during teardown
 
     _buildAndAttachTransport(device);
@@ -243,12 +246,12 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
       BleEventKind.waitingPhase,
       'device=${device.platformName}',
     );
-    await _tearDownTransport();
+    await _tearDownTransport(internal: true);
     if (_device == null) return;
 
     _buildAndAttachTransport(device);
     if (_device == null) {
-      await _tearDownTransport();
+      await _tearDownTransport(internal: true);
       return;
     }
 
@@ -280,11 +283,17 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
     _frameSub = t.frameStream.listen(_onFrame);
   }
 
-  Future<void> _tearDownTransport() async {
+  Future<void> _tearDownTransport({required bool internal}) async {
     await _transportStateSub?.cancel();
     _transportStateSub = null;
     await _frameSub?.cancel();
     _frameSub = null;
+    final t = _transport;
+    if (internal && t is BleTncTransport) {
+      // Tag the next disconnect as an internal teardown so the diagnostics
+      // log distinguishes reconnect cycles from a real user disconnect.
+      t.markInternalTeardown();
+    }
     try {
       await _transport?.disconnect();
     } catch (_) {}

--- a/lib/core/connection/ble_connection_impl.dart
+++ b/lib/core/connection/ble_connection_impl.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../ax25/ax25_encoder.dart';
 import '../packet/aprs_parser.dart';
+import '../transport/ble_diagnostics.dart';
 import '../transport/ble_tnc_transport.dart';
 import '../transport/kiss_tnc_transport.dart';
 import '../util/clock.dart';
@@ -212,6 +213,10 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
     if (device == null) return; // disconnect() was called
 
     debugPrint('BleConnection: attempting reconnect to ${device.platformName}');
+    BleDiagnostics.I.log(
+      BleEventKind.reconnectAttempt,
+      'device=${device.platformName}',
+    );
     await _tearDownTransport();
     if (_device == null) return; // disconnect() called during teardown
 
@@ -233,6 +238,10 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
 
     debugPrint(
       'BleConnection: entering OS auto-connect waiting phase for ${device.platformName}',
+    );
+    BleDiagnostics.I.log(
+      BleEventKind.waitingPhase,
+      'device=${device.platformName}',
     );
     await _tearDownTransport();
     if (_device == null) return;
@@ -287,10 +296,12 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
     notifyListeners();
 
     if (s == ConnectionStatus.connected) {
+      BleDiagnostics.I.log(BleEventKind.sessionConnected);
       markSessionConnected();
     } else if (s == ConnectionStatus.error &&
         shouldAttemptReconnect() &&
         _device != null) {
+      BleDiagnostics.I.log(BleEventKind.reconnectScheduled);
       scheduleReconnect(_emitStatus);
     }
   }

--- a/lib/core/transport/ble_diagnostics.dart
+++ b/lib/core/transport/ble_diagnostics.dart
@@ -94,6 +94,11 @@ class BleEvent {
 /// a static [I] singleton for write access. Tests construct fresh instances
 /// directly to avoid global state.
 ///
+/// Capture is **off by default** — users opt in from Settings → Advanced →
+/// BLE Diagnostics. While disabled, [log] is a no-op (the call site cost is
+/// a single boolean check), nothing is persisted, and existing buffered
+/// events are not displayed in the UI.
+///
 /// Persistence: events are written to SharedPreferences on a ~1 s debounce so
 /// a crash mid-session doesn't lose the log, but we don't pay a write per
 /// event during a flurry of state changes.
@@ -109,6 +114,7 @@ class BleDiagnostics extends ChangeNotifier {
 
   static const _defaultMaxEvents = 200;
   static const _prefsKey = 'ble_diagnostics_log_v1';
+  static const _enabledPrefsKey = 'ble_diagnostics_enabled_v1';
 
   /// Process-wide instance. Wired in `main.dart`. Tests should NOT use this —
   /// construct a fresh [BleDiagnostics] directly.
@@ -120,31 +126,52 @@ class BleDiagnostics extends ChangeNotifier {
 
   SharedPreferences? _prefs;
   Timer? _persistTimer;
+  bool _enabled = false;
 
   final Queue<BleEvent> _events = Queue<BleEvent>();
+
+  /// Whether event capture is currently enabled. Defaults to false; the user
+  /// flips this from the BLE Diagnostics screen.
+  bool get enabled => _enabled;
 
   /// Snapshot of all events, oldest first. Cheap (bounded by [maxEvents]).
   List<BleEvent> get events => List.unmodifiable(_events);
 
-  /// Restores any previously-persisted log. Safe to call before [SharedPreferences]
-  /// is otherwise initialised — re-reads on first call.
+  /// Restores any previously-persisted log AND the enabled flag. Safe to call
+  /// before [SharedPreferences] is otherwise initialised — re-reads on first
+  /// call.
   Future<void> hydrate() async {
     _prefs ??= await SharedPreferences.getInstance();
+    _enabled = _prefs!.getBool(_enabledPrefsKey) ?? false;
     final lines = _prefs!.getStringList(_prefsKey);
-    if (lines == null || lines.isEmpty) return;
-    _events.clear();
-    for (final line in lines) {
-      final ev = BleEvent.tryDecode(line);
-      if (ev != null) _events.add(ev);
-    }
-    while (_events.length > maxEvents) {
-      _events.removeFirst();
+    if (lines != null && lines.isNotEmpty) {
+      _events.clear();
+      for (final line in lines) {
+        final ev = BleEvent.tryDecode(line);
+        if (ev != null) _events.add(ev);
+      }
+      while (_events.length > maxEvents) {
+        _events.removeFirst();
+      }
     }
     notifyListeners();
   }
 
-  /// Append a new event. Trims the oldest entry if the buffer is full.
+  /// Toggles event capture. When turning capture off, any buffered events are
+  /// preserved (the user can still copy what was already captured) but no
+  /// further events accumulate.
+  Future<void> setEnabled(bool value) async {
+    if (_enabled == value) return;
+    _enabled = value;
+    notifyListeners();
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledPrefsKey, value);
+  }
+
+  /// Append a new event. No-op when capture is disabled — the buffer is left
+  /// untouched, no listeners notified, no persistence scheduled.
   void log(BleEventKind kind, [String detail = '']) {
+    if (!_enabled) return;
     final event = BleEvent(timestamp: _clock(), kind: kind, detail: detail);
     _events.addLast(event);
     while (_events.length > maxEvents) {

--- a/lib/core/transport/ble_diagnostics.dart
+++ b/lib/core/transport/ble_diagnostics.dart
@@ -1,0 +1,192 @@
+library;
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Categorical kind of a [BleEvent].
+///
+/// Names are short on purpose so the resulting log line stays readable when
+/// the user copies it to chat / email.
+enum BleEventKind {
+  connectStart,
+  connectSuccess,
+  connectFailed,
+  disconnectUser,
+  disconnectUnexpected,
+  disconnectKeepaliveFailed,
+  bleStateChanged,
+  serviceDiscoveryRetry,
+  keepaliveSent,
+  keepaliveFailed,
+  reconnectScheduled,
+  reconnectAttempt,
+  waitingPhase,
+  sessionConnected,
+  note,
+}
+
+/// One entry in the BLE diagnostics log.
+@immutable
+class BleEvent {
+  const BleEvent({
+    required this.timestamp,
+    required this.kind,
+    this.detail = '',
+  });
+
+  final DateTime timestamp;
+  final BleEventKind kind;
+  final String detail;
+
+  /// Encodes this event as a single pipe-delimited line.
+  ///
+  /// Format: `<ms-epoch-utc>|<kind-index>|<detail>`. Detail is allowed to
+  /// contain pipes — only the first two are treated as delimiters.
+  String encode() =>
+      '${timestamp.toUtc().millisecondsSinceEpoch}|${kind.index}|$detail';
+
+  /// Decodes a previously [encode]d line. Returns `null` for malformed input
+  /// so a corrupted prefs blob never crashes startup.
+  static BleEvent? tryDecode(String line) {
+    final firstPipe = line.indexOf('|');
+    if (firstPipe <= 0) return null;
+    final secondPipe = line.indexOf('|', firstPipe + 1);
+    if (secondPipe <= firstPipe) return null;
+
+    final ms = int.tryParse(line.substring(0, firstPipe));
+    final kindIdx = int.tryParse(line.substring(firstPipe + 1, secondPipe));
+    if (ms == null || kindIdx == null) return null;
+    if (kindIdx < 0 || kindIdx >= BleEventKind.values.length) return null;
+
+    return BleEvent(
+      timestamp: DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true),
+      kind: BleEventKind.values[kindIdx],
+      detail: line.substring(secondPipe + 1),
+    );
+  }
+
+  /// Human-readable single-line representation suitable for the diagnostics UI
+  /// and for clipboard export. Format: `HH:mm:ss.SSS  <kind>  <detail>`.
+  String formatHuman() {
+    final t = timestamp.toLocal();
+    final hh = t.hour.toString().padLeft(2, '0');
+    final mm = t.minute.toString().padLeft(2, '0');
+    final ss = t.second.toString().padLeft(2, '0');
+    final ms = t.millisecond.toString().padLeft(3, '0');
+    final detailSuffix = detail.isEmpty ? '' : '  $detail';
+    return '$hh:$mm:$ss.$ms  ${kind.name}$detailSuffix';
+  }
+}
+
+/// Ring-buffered diagnostics log for BLE TNC events.
+///
+/// One per process. The deepest instrumentation sites (inside
+/// [BleTncTransport] etc.) cannot reasonably reach a Provider, so this exposes
+/// a static [I] singleton for write access. Tests construct fresh instances
+/// directly to avoid global state.
+///
+/// Persistence: events are written to SharedPreferences on a ~1 s debounce so
+/// a crash mid-session doesn't lose the log, but we don't pay a write per
+/// event during a flurry of state changes.
+class BleDiagnostics extends ChangeNotifier {
+  BleDiagnostics({
+    SharedPreferences? prefs,
+    this.maxEvents = _defaultMaxEvents,
+    Duration persistDebounce = const Duration(seconds: 1),
+    DateTime Function() clock = DateTime.now,
+  }) : _prefs = prefs,
+       _persistDebounce = persistDebounce,
+       _clock = clock;
+
+  static const _defaultMaxEvents = 200;
+  static const _prefsKey = 'ble_diagnostics_log_v1';
+
+  /// Process-wide instance. Wired in `main.dart`. Tests should NOT use this —
+  /// construct a fresh [BleDiagnostics] directly.
+  static BleDiagnostics I = BleDiagnostics();
+
+  final int maxEvents;
+  final Duration _persistDebounce;
+  final DateTime Function() _clock;
+
+  SharedPreferences? _prefs;
+  Timer? _persistTimer;
+
+  final Queue<BleEvent> _events = Queue<BleEvent>();
+
+  /// Snapshot of all events, oldest first. Cheap (bounded by [maxEvents]).
+  List<BleEvent> get events => List.unmodifiable(_events);
+
+  /// Restores any previously-persisted log. Safe to call before [SharedPreferences]
+  /// is otherwise initialised — re-reads on first call.
+  Future<void> hydrate() async {
+    _prefs ??= await SharedPreferences.getInstance();
+    final lines = _prefs!.getStringList(_prefsKey);
+    if (lines == null || lines.isEmpty) return;
+    _events.clear();
+    for (final line in lines) {
+      final ev = BleEvent.tryDecode(line);
+      if (ev != null) _events.add(ev);
+    }
+    while (_events.length > maxEvents) {
+      _events.removeFirst();
+    }
+    notifyListeners();
+  }
+
+  /// Append a new event. Trims the oldest entry if the buffer is full.
+  void log(BleEventKind kind, [String detail = '']) {
+    final event = BleEvent(timestamp: _clock(), kind: kind, detail: detail);
+    _events.addLast(event);
+    while (_events.length > maxEvents) {
+      _events.removeFirst();
+    }
+    if (kDebugMode) {
+      debugPrint('[BLE] ${event.formatHuman()}');
+    }
+    notifyListeners();
+    _schedulePersist();
+  }
+
+  /// Clears the log immediately and persists the empty state.
+  Future<void> clear() async {
+    _events.clear();
+    notifyListeners();
+    _persistTimer?.cancel();
+    _persistTimer = null;
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.remove(_prefsKey);
+  }
+
+  /// Forces a synchronous persistence write. Used at app pause so we never
+  /// lose the last few events to a process kill.
+  Future<void> flush() async {
+    _persistTimer?.cancel();
+    _persistTimer = null;
+    final prefs = _prefs ??= await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _prefsKey,
+      _events.map((e) => e.encode()).toList(),
+    );
+  }
+
+  void _schedulePersist() {
+    _persistTimer?.cancel();
+    _persistTimer = Timer(_persistDebounce, () {
+      _persistTimer = null;
+      // Fire and forget — persistence failure is non-fatal and the in-memory
+      // log is the source of truth for the current session.
+      flush();
+    });
+  }
+
+  @override
+  void dispose() {
+    _persistTimer?.cancel();
+    _persistTimer = null;
+    super.dispose();
+  }
+}

--- a/lib/core/transport/ble_diagnostics.dart
+++ b/lib/core/transport/ble_diagnostics.dart
@@ -26,6 +26,12 @@ enum BleEventKind {
   waitingPhase,
   sessionConnected,
   note,
+  // Append-only — adding values above shifts persisted-log indices and breaks
+  // hydration from prior builds.
+  connectionPriorityRequested,
+  connectionPriorityFailed,
+  keepaliveRetried,
+  disconnectInternal,
 }
 
 /// One entry in the BLE diagnostics log.

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -133,9 +133,13 @@ class BleTncTransport extends KissTncTransport {
   int _mtu = 20;
 
   // Keepalive: reset on every write; fires if the link is idle for too long.
-  // Mobilinkd (and most BLE TNCs) drop the connection after ~5 s of silence.
-  // 2 s gives comfortable headroom below the 5.12 s supervision timeout.
-  static const _keepaliveInterval = Duration(seconds: 2);
+  // The cadence is purely an application-level self-watchdog — the OS already
+  // surfaces a true link drop via the connection-state stream within the BLE
+  // supervision timeout, so we don't need to race that. 4 s is well under the
+  // 5.12 s supervision timeout, halves radio wakes vs the prior 2 s cadence,
+  // and still gives a fast indicator if the peripheral has wedged its TX path
+  // independent of the OS link state.
+  static const _keepaliveInterval = Duration(seconds: 4);
   Timer? _keepaliveTimer;
 
   final _kissFramer = KissFramer();
@@ -309,9 +313,10 @@ class BleTncTransport extends KissTncTransport {
       );
 
       // 10. Start the idle keepalive timer.
-      //    Mobilinkd (and most BLE TNCs) will drop the link after a few seconds
-      //    of post-connect silence. The keepalive sends a single TXDELAY frame
-      //    every 2 s to hold the link open.
+      //    Acts as an application-level self-watchdog so a wedged peripheral
+      //    TX path is detected promptly without waiting on the OS supervision
+      //    timeout. The keepalive sends a single TXDELAY frame every
+      //    [_keepaliveInterval] (currently 4 s — see field doc).
       //
       //    NOTE: Do NOT call _sendKissInit() here. Sending the five standard
       //    KISS parameter frames (TXDELAY/PERSIST/SLOTTIME/TXTAIL/FULLDUPLEX)

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -9,6 +9,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'aprs_transport.dart' show ConnectionStatus;
 import 'ble_constants.dart';
+import 'ble_diagnostics.dart';
 import 'kiss_framer.dart';
 import 'kiss_tnc_transport.dart';
 
@@ -157,6 +158,10 @@ class BleTncTransport extends KissTncTransport {
   Future<void> connect() => _connect(autoConnect: false);
 
   Future<void> _connect({required bool autoConnect}) async {
+    BleDiagnostics.I.log(
+      BleEventKind.connectStart,
+      'device=${_adapter.platformName} autoConnect=$autoConnect',
+    );
     _setStatus(
       autoConnect
           ? ConnectionStatus.waitingForDevice
@@ -211,6 +216,10 @@ class BleTncTransport extends KissTncTransport {
           debugPrint(
             'BleTncTransport: discoverServices attempt $attempt failed: $e',
           );
+          BleDiagnostics.I.log(
+            BleEventKind.serviceDiscoveryRetry,
+            'attempt=$attempt error=$e',
+          );
           if (attempt == 3) rethrow;
           await Future<void>.delayed(const Duration(milliseconds: 500));
         }
@@ -259,6 +268,10 @@ class BleTncTransport extends KissTncTransport {
       debugPrint(
         'BleTncTransport: connected to ${_adapter.platformName}, starting keepalive timer',
       );
+      BleDiagnostics.I.log(
+        BleEventKind.connectSuccess,
+        'device=${_adapter.platformName} mtu=$_mtu',
+      );
 
       // 10. Start the idle keepalive timer.
       //    Mobilinkd (and most BLE TNCs) will drop the link after a few seconds
@@ -277,6 +290,10 @@ class BleTncTransport extends KissTncTransport {
       _resetKeepalive();
     } catch (e) {
       debugPrint('BleTncTransport connect failed: $e');
+      BleDiagnostics.I.log(
+        BleEventKind.connectFailed,
+        'device=${_adapter.platformName} error=$e',
+      );
       _setStatus(ConnectionStatus.error);
       // Best-effort cleanup before rethrowing.
       await _cleanupSubscriptions();
@@ -290,6 +307,10 @@ class BleTncTransport extends KissTncTransport {
   @override
   Future<void> disconnect() async {
     if (_status == ConnectionStatus.disconnected) return;
+    BleDiagnostics.I.log(
+      BleEventKind.disconnectUser,
+      'device=${_adapter.platformName}',
+    );
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
     _setStatus(ConnectionStatus.disconnected);
@@ -343,10 +364,15 @@ class BleTncTransport extends KissTncTransport {
   }
 
   void _onBleConnectionState(BluetoothConnectionState state) {
+    BleDiagnostics.I.log(BleEventKind.bleStateChanged, state.name);
     if (state == BluetoothConnectionState.disconnected &&
         _status == ConnectionStatus.connected) {
       debugPrint(
         'BleTncTransport: unexpected disconnect from ${_adapter.platformName}',
+      );
+      BleDiagnostics.I.log(
+        BleEventKind.disconnectUnexpected,
+        'device=${_adapter.platformName}',
       );
       // _status is set synchronously before the unawaited cleanup, so a
       // second delivery of this event cannot re-enter (guard is already false).
@@ -394,6 +420,7 @@ class BleTncTransport extends KissTncTransport {
         Uint8List.fromList([0xC0, 0x01, 30, 0xC0]),
         withoutResponse: true,
       );
+      BleDiagnostics.I.log(BleEventKind.keepaliveSent);
       _resetKeepalive();
     } catch (e) {
       // Write failure means the link is gone. Mark as error immediately
@@ -402,7 +429,12 @@ class BleTncTransport extends KissTncTransport {
       debugPrint(
         'BleTncTransport: keepalive write failed, marking link dropped: $e',
       );
+      BleDiagnostics.I.log(BleEventKind.keepaliveFailed, 'error=$e');
       if (_status == ConnectionStatus.connected) {
+        BleDiagnostics.I.log(
+          BleEventKind.disconnectKeepaliveFailed,
+          'device=${_adapter.platformName}',
+        );
         _status = ConnectionStatus.error;
         _stateController.add(ConnectionStatus.error);
         await _cleanupSubscriptions();

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -213,25 +213,19 @@ class BleTncTransport extends KissTncTransport {
       //     so that a late OS state event still drives the error path.
       _connStateSub ??= _adapter.connectionState.listen(_onBleConnectionState);
 
-      // 2b. Ask Android to use HIGH connection priority for this link.
-      //     BALANCED (the default) lets the OS lengthen the connection
-      //     interval to ~50 ms, which is fragile under driving RF noise —
-      //     several missed connection events in a row will trip the
-      //     supervision timeout and drop the link. HIGH targets ~7.5–11.25 ms,
-      //     which materially reduces drop frequency in motion.
-      //     Advisory: a failure here is non-fatal (some peripherals refuse).
-      try {
-        await _adapter.requestConnectionPriority(ConnectionPriority.high);
-        BleDiagnostics.I.log(
-          BleEventKind.connectionPriorityRequested,
-          'priority=high',
-        );
-      } catch (e) {
-        BleDiagnostics.I.log(
-          BleEventKind.connectionPriorityFailed,
-          'priority=high error=$e',
-        );
-      }
+      // 2b. Connection-priority request is deliberately skipped.
+      //     `BluetoothDevice.requestConnectionPriority(high)` immediately
+      //     after `connect()` causes the Mobilinkd TNC4 to drop the link
+      //     within the 5.12 s LINK_SUPERVISION_TIMEOUT — the same hardware
+      //     quirk that forbids a fresh `requestMtu()` here (see step 3).
+      //     The 2026-04-30 drive-test diagnostics showed identical 5.4 s
+      //     drop cycles every reconnect with HIGH priority enabled, and a
+      //     stable 110 s keepalive cadence with it disabled. Re-introducing
+      //     this needs hardware-specific gating; track in a follow-up.
+      BleDiagnostics.I.log(
+        BleEventKind.connectionPriorityRequested,
+        'priority=balanced (skipped: TNC4 drops link if renegotiated)',
+      );
 
       // 3. Read the negotiated MTU.
       //    flutter_blue_plus on Android auto-requests MTU 512 inside

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -1,10 +1,11 @@
 library;
 
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'aprs_transport.dart' show ConnectionStatus;
@@ -32,6 +33,13 @@ abstract interface class BleDeviceAdapter {
   /// A no-op on iOS/desktop — implementations should swallow any
   /// platform exception so callers never need to handle it.
   Future<void> clearGattCache();
+
+  /// Asks the OS BLE stack to use [priority] for this connection.
+  ///
+  /// Android only. Implementations on iOS / desktop must silently no-op.
+  /// Returns normally on success; throws when the OS rejects the request —
+  /// callers should treat that as advisory and continue.
+  Future<void> requestConnectionPriority(ConnectionPriority priority);
 
   Stream<BluetoothConnectionState> get connectionState;
   String get platformName;
@@ -69,6 +77,14 @@ class DefaultBleDeviceAdapter implements BleDeviceAdapter {
     } catch (_) {
       // Not supported on iOS/desktop — silently ignore.
     }
+  }
+
+  @override
+  Future<void> requestConnectionPriority(ConnectionPriority priority) async {
+    if (!Platform.isAndroid) return;
+    await _device.requestConnectionPriority(
+      connectionPriorityRequest: priority,
+    );
   }
 
   @override
@@ -189,6 +205,34 @@ class BleTncTransport extends KissTncTransport {
         autoConnect: autoConnect,
       );
 
+      // 2a. Subscribe to BLE connection-state events as soon as the OS
+      //     considers the link established. The subscription is intentionally
+      //     attached BEFORE the rest of setup so an early adverse event
+      //     (e.g. a peer-side drop during service discovery) is captured.
+      //     It is also intentionally NOT torn down by [_cleanupSubscriptions]
+      //     so that a late OS state event still drives the error path.
+      _connStateSub ??= _adapter.connectionState.listen(_onBleConnectionState);
+
+      // 2b. Ask Android to use HIGH connection priority for this link.
+      //     BALANCED (the default) lets the OS lengthen the connection
+      //     interval to ~50 ms, which is fragile under driving RF noise —
+      //     several missed connection events in a row will trip the
+      //     supervision timeout and drop the link. HIGH targets ~7.5–11.25 ms,
+      //     which materially reduces drop frequency in motion.
+      //     Advisory: a failure here is non-fatal (some peripherals refuse).
+      try {
+        await _adapter.requestConnectionPriority(ConnectionPriority.high);
+        BleDiagnostics.I.log(
+          BleEventKind.connectionPriorityRequested,
+          'priority=high',
+        );
+      } catch (e) {
+        BleDiagnostics.I.log(
+          BleEventKind.connectionPriorityFailed,
+          'priority=high error=$e',
+        );
+      }
+
       // 3. Read the negotiated MTU.
       //    flutter_blue_plus on Android auto-requests MTU 512 inside
       //    connect(); issuing a second requestMtu() immediately after causes
@@ -261,9 +305,6 @@ class BleTncTransport extends KissTncTransport {
       // 8. Wire KissFramer output → frameStream.
       _framesSub = _kissFramer.frames.listen(_framesController.add);
 
-      // 9. Monitor for unexpected disconnects.
-      _connStateSub = _adapter.connectionState.listen(_onBleConnectionState);
-
       _setStatus(ConnectionStatus.connected);
       debugPrint(
         'BleTncTransport: connected to ${_adapter.platformName}, starting keepalive timer',
@@ -295,8 +336,11 @@ class BleTncTransport extends KissTncTransport {
         'device=${_adapter.platformName} error=$e',
       );
       _setStatus(ConnectionStatus.error);
-      // Best-effort cleanup before rethrowing.
+      // Best-effort cleanup before rethrowing — including the connection-state
+      // listener, since a failed connect produces no live session for it to
+      // observe.
       await _cleanupSubscriptions();
+      await _cancelConnStateSub();
       try {
         await _adapter.disconnect();
       } catch (_) {}
@@ -304,17 +348,35 @@ class BleTncTransport extends KissTncTransport {
     }
   }
 
+  /// Marks the next [disconnect] call as an internal teardown (e.g. mid-reconnect)
+  /// so the diagnostics log records [BleEventKind.disconnectInternal] instead of
+  /// [BleEventKind.disconnectUser]. The flag is consumed (cleared) by [disconnect].
+  ///
+  /// Used by the [BleConnection] layer when rebuilding the transport during a
+  /// reconnect attempt — without this, the log was misleadingly attributing
+  /// every reconnect cycle's teardown to a user action.
+  void markInternalTeardown() {
+    _internalTeardown = true;
+  }
+
+  bool _internalTeardown = false;
+
   @override
   Future<void> disconnect() async {
     if (_status == ConnectionStatus.disconnected) return;
+    final wasInternal = _internalTeardown;
+    _internalTeardown = false;
     BleDiagnostics.I.log(
-      BleEventKind.disconnectUser,
+      wasInternal
+          ? BleEventKind.disconnectInternal
+          : BleEventKind.disconnectUser,
       'device=${_adapter.platformName}',
     );
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
     _setStatus(ConnectionStatus.disconnected);
     await _cleanupSubscriptions();
+    await _cancelConnStateSub();
     try {
       await _txChar?.setNotifyValue(false);
     } catch (_) {}
@@ -384,15 +446,24 @@ class BleTncTransport extends KissTncTransport {
     }
   }
 
+  /// Cancels per-session subscriptions (notify / framer / keepalive).
+  ///
+  /// Intentionally does NOT cancel [_connStateSub] — that listener is the
+  /// only path by which a late OS-side disconnect can drive the error stream
+  /// after this method runs, and it must survive session teardown for that to
+  /// work. The listener is cancelled in [disconnect] / [_cancelConnStateSub].
   Future<void> _cleanupSubscriptions() async {
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
     await _notifySub?.cancel();
     _notifySub = null;
-    await _connStateSub?.cancel();
-    _connStateSub = null;
     await _framesSub?.cancel();
     _framesSub = null;
+  }
+
+  Future<void> _cancelConnStateSub() async {
+    await _connStateSub?.cancel();
+    _connStateSub = null;
   }
 
   /// Cancels any pending keepalive and schedules a new one.
@@ -406,30 +477,50 @@ class BleTncTransport extends KissTncTransport {
     _keepaliveTimer = Timer(_keepaliveInterval, _onKeepalive);
   }
 
+  // Static so tests can override without making _onKeepalive any wider.
+  @visibleForTesting
+  static Duration keepaliveRetryDelay = const Duration(milliseconds: 200);
+
   /// Fires when the link has been idle for [_keepaliveInterval].
   ///
   /// Sends a single KISS TXDELAY frame — harmless to any KISS TNC and
   /// sufficient to reset the Mobilinkd idle timer. Uses write-without-response
   /// to avoid ATT round-trip latency on a fire-and-forget keepalive.
-  /// A write failure is treated as a link-dropped signal rather than
-  /// silently rescheduling, ensuring the UI reflects the real state promptly.
+  ///
+  /// On write failure the keepalive retries exactly once after a short delay
+  /// before declaring the link dead. This absorbs a single transient stall
+  /// (Doze transition, brief OS scheduling hiccup) without tripping the full
+  /// reconnect cascade. If the retry also fails the link is marked as error.
   Future<void> _onKeepalive() async {
     if (!isConnected) return;
+    final rxChar = _rxChar;
+    if (rxChar == null) return;
+    final payload = Uint8List.fromList([0xC0, 0x01, 30, 0xC0]);
     try {
-      await _rxChar?.write(
-        Uint8List.fromList([0xC0, 0x01, 30, 0xC0]),
-        withoutResponse: true,
-      );
+      await rxChar.write(payload, withoutResponse: true);
       BleDiagnostics.I.log(BleEventKind.keepaliveSent);
       _resetKeepalive();
+      return;
     } catch (e) {
-      // Write failure means the link is gone. Mark as error immediately
-      // rather than silently rescheduling — don't wait for the BLE stack
-      // to eventually fire an onConnectionStateChange event.
+      BleDiagnostics.I.log(BleEventKind.keepaliveFailed, 'attempt=1 error=$e');
+    }
+
+    // Retry once after a short delay — rebind state in case status changed
+    // mid-delay (e.g. user tapped disconnect).
+    await Future<void>.delayed(keepaliveRetryDelay);
+    if (!isConnected) return;
+    final retryRx = _rxChar;
+    if (retryRx == null) return;
+    try {
+      await retryRx.write(payload, withoutResponse: true);
+      BleDiagnostics.I.log(BleEventKind.keepaliveRetried, 'recovered=true');
+      _resetKeepalive();
+      return;
+    } catch (e) {
       debugPrint(
-        'BleTncTransport: keepalive write failed, marking link dropped: $e',
+        'BleTncTransport: keepalive write failed twice, marking link dropped: $e',
       );
-      BleDiagnostics.I.log(BleEventKind.keepaliveFailed, 'error=$e');
+      BleDiagnostics.I.log(BleEventKind.keepaliveFailed, 'attempt=2 error=$e');
       if (_status == ConnectionStatus.connected) {
         BleDiagnostics.I.log(
           BleEventKind.disconnectKeepaliveFailed,

--- a/lib/core/transport/ble_tnc_transport_stub.dart
+++ b/lib/core/transport/ble_tnc_transport_stub.dart
@@ -37,4 +37,8 @@ class BleTncTransport extends KissTncTransport {
   @override
   Future<void> sendFrame(Uint8List ax25Frame) =>
       throw UnsupportedError('BLE TNC not supported on this platform');
+
+  /// No-op on the stub — the impl tags the next disconnect as an internal
+  /// teardown so the diagnostics log records [BleEventKind.disconnectInternal].
+  void markInternalTeardown() {}
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'core/credentials/secure_credential_store.dart';
 import 'core/packet/aprs_packet.dart' show PacketSource;
 import 'core/packet/device_resolver.dart';
 import 'core/transport/aprs_is_transport.dart';
+import 'core/transport/ble_diagnostics.dart';
 import 'map/stadia_tile_provider.dart';
 import 'screens/map_screen.dart';
 import 'screens/onboarding/onboarding_screen.dart';
@@ -81,6 +82,10 @@ Future<void> main() async {
   final themeController = await ThemeController.create();
   final advancedModeController = await AdvancedModeController.create();
   final prefs = await SharedPreferences.getInstance();
+
+  // Restore the BLE diagnostics ring buffer from persistence so the user can
+  // copy a session log even after a process restart.
+  await BleDiagnostics.I.hydrate();
   var onboardingComplete = prefs.getBool('onboarding_complete') ?? false;
 
   // StationSettingsService is the canonical owner of all station identity

--- a/lib/screens/connection_screen.dart
+++ b/lib/screens/connection_screen.dart
@@ -16,6 +16,7 @@ import '../services/background_service_manager.dart';
 import '../services/station_service.dart';
 import '../services/station_settings_service.dart';
 import '../theme/meridian_colors.dart';
+import '../ui/widgets/battery_optimization_card.dart';
 import '../ui/widgets/ble_scanner_sheet.dart';
 import '../ui/widgets/meridian_status_pill.dart';
 import '../ui/widgets/serial_connection_form.dart';
@@ -307,25 +308,31 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
         conn.status == ConnectionStatus.reconnecting ||
         conn.status == ConnectionStatus.waitingForDevice;
 
-    if (isSessionActive) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: Text(
-          'Connected — disconnect from the card above.',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-        ),
-      );
-    }
-
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: BleScannerSheet(
-        bleConnection: conn,
-        showDragHandle: false,
-        onBack: () {},
-        showBackButton: false,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Surfaced whenever the user is on the BLE tab — applies equally
+          // before/after a session is established because the prompt is about
+          // keeping the link alive in the background, not about starting one.
+          const BatteryOptimizationCard(),
+          const SizedBox(height: 12),
+          if (isSessionActive)
+            Text(
+              'Connected — disconnect from the card above.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            BleScannerSheet(
+              bleConnection: conn,
+              showDragHandle: false,
+              onBack: () {},
+              showBackButton: false,
+            ),
+        ],
       ),
     );
   }

--- a/lib/screens/onboarding/pages/connection_page.dart
+++ b/lib/screens/onboarding/pages/connection_page.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/connection/aprs_is_connection.dart';
@@ -155,10 +156,26 @@ class _ConnectionPageState extends State<ConnectionPage> {
       );
       if (!mounted) return;
       if (stable) {
+        // The user has just committed to BLE. Prompt for the battery-opt
+        // exemption now while the choice is fresh — without it the link will
+        // drop and stay dropped under Doze. Non-blocking: a denial does not
+        // prevent onboarding from advancing.
+        await _maybeRequestBatteryOptExemption();
+        if (!mounted) return;
         widget.onConnectionResult(true);
         widget.onNext();
       }
     });
+  }
+
+  /// Ensures the user is offered the ignore-battery-optimization grant when
+  /// completing BLE-TNC onboarding on Android. No-op on other platforms or
+  /// when the exemption is already in place.
+  Future<void> _maybeRequestBatteryOptExemption() async {
+    if (kIsWeb || !Platform.isAndroid) return;
+    final status = await Permission.ignoreBatteryOptimizations.status;
+    if (status.isGranted) return;
+    await Permission.ignoreBatteryOptimizations.request();
   }
 
   void _skipToLater() {

--- a/lib/screens/settings/ble_diagnostics_screen.dart
+++ b/lib/screens/settings/ble_diagnostics_screen.dart
@@ -202,13 +202,19 @@ class _EventTile extends StatelessWidget {
       case BleEventKind.disconnectKeepaliveFailed:
         return Symbols.bluetooth_disabled;
       case BleEventKind.disconnectUser:
+      case BleEventKind.disconnectInternal:
         return Symbols.link_off;
       case BleEventKind.bleStateChanged:
         return Symbols.swap_horiz;
       case BleEventKind.serviceDiscoveryRetry:
         return Symbols.refresh;
+      case BleEventKind.connectionPriorityRequested:
+      case BleEventKind.connectionPriorityFailed:
+        return Symbols.speed;
       case BleEventKind.keepaliveSent:
         return Symbols.favorite;
+      case BleEventKind.keepaliveRetried:
+        return Symbols.autorenew;
       case BleEventKind.keepaliveFailed:
         return Symbols.heart_broken;
       case BleEventKind.reconnectScheduled:

--- a/lib/screens/settings/ble_diagnostics_screen.dart
+++ b/lib/screens/settings/ble_diagnostics_screen.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '../../core/transport/ble_diagnostics.dart';
+
+/// Live view of the BLE diagnostics ring buffer.
+///
+/// Surfaced under Settings → Advanced. Hidden unless Advanced User Mode is on.
+/// The user copies the log to clipboard after a drive test so we can diagnose
+/// background BLE drops with real timestamps and reasons.
+class BleDiagnosticsScreen extends StatefulWidget {
+  const BleDiagnosticsScreen({super.key});
+
+  @override
+  State<BleDiagnosticsScreen> createState() => _BleDiagnosticsScreenState();
+}
+
+class _BleDiagnosticsScreenState extends State<BleDiagnosticsScreen> {
+  late final BleDiagnostics _diag;
+
+  @override
+  void initState() {
+    super.initState();
+    _diag = BleDiagnostics.I;
+    _diag.addListener(_onDiagChanged);
+  }
+
+  @override
+  void dispose() {
+    _diag.removeListener(_onDiagChanged);
+    super.dispose();
+  }
+
+  void _onDiagChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _copyToClipboard() async {
+    final events = _diag.events;
+    final buffer = StringBuffer();
+    buffer.writeln('Meridian APRS BLE diagnostics');
+    buffer.writeln('Captured: ${DateTime.now().toIso8601String()}');
+    buffer.writeln('Events: ${events.length}');
+    buffer.writeln('---');
+    for (final e in events) {
+      buffer.writeln(e.formatHuman());
+    }
+    await Clipboard.setData(ClipboardData(text: buffer.toString()));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Copied ${events.length} events to clipboard')),
+    );
+  }
+
+  Future<void> _confirmClear() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Clear diagnostics?'),
+        content: const Text(
+          'This removes all BLE diagnostic events. The log will rebuild as new '
+          'events occur.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await _diag.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final events = _diag.events;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('BLE Diagnostics'),
+        actions: [
+          IconButton(
+            tooltip: 'Copy log',
+            onPressed: events.isEmpty ? null : _copyToClipboard,
+            icon: const Icon(Symbols.content_copy),
+          ),
+          IconButton(
+            tooltip: 'Clear log',
+            onPressed: events.isEmpty ? null : _confirmClear,
+            icon: const Icon(Symbols.delete_sweep),
+          ),
+        ],
+      ),
+      body: events.isEmpty
+          ? const _EmptyState()
+          : ListView.builder(
+              reverse: true,
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              itemCount: events.length,
+              itemBuilder: (context, index) {
+                // Newest at the top → reverse the index.
+                final event = events[events.length - 1 - index];
+                return _EventTile(event: event);
+              },
+            ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Symbols.bluetooth_searching,
+              size: 64,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No BLE events yet',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Connect a BLE TNC and use the app — connect/disconnect, '
+              'reconnect attempts, and keepalive activity will appear here.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EventTile extends StatelessWidget {
+  const _EventTile({required this.event});
+
+  final BleEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _colorForKind(event.kind, theme);
+    return ListTile(
+      dense: true,
+      leading: Icon(_iconForKind(event.kind), color: color, size: 20),
+      title: Text(
+        event.kind.name,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: color,
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
+      subtitle: Text(
+        '${_formatTime(event.timestamp)}'
+        '${event.detail.isEmpty ? '' : '  ·  ${event.detail}'}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
+    );
+  }
+
+  static String _formatTime(DateTime t) {
+    final l = t.toLocal();
+    final hh = l.hour.toString().padLeft(2, '0');
+    final mm = l.minute.toString().padLeft(2, '0');
+    final ss = l.second.toString().padLeft(2, '0');
+    final ms = l.millisecond.toString().padLeft(3, '0');
+    return '$hh:$mm:$ss.$ms';
+  }
+
+  static IconData _iconForKind(BleEventKind kind) {
+    switch (kind) {
+      case BleEventKind.connectStart:
+      case BleEventKind.connectSuccess:
+      case BleEventKind.sessionConnected:
+        return Symbols.bluetooth_connected;
+      case BleEventKind.connectFailed:
+      case BleEventKind.disconnectUnexpected:
+      case BleEventKind.disconnectKeepaliveFailed:
+        return Symbols.bluetooth_disabled;
+      case BleEventKind.disconnectUser:
+        return Symbols.link_off;
+      case BleEventKind.bleStateChanged:
+        return Symbols.swap_horiz;
+      case BleEventKind.serviceDiscoveryRetry:
+        return Symbols.refresh;
+      case BleEventKind.keepaliveSent:
+        return Symbols.favorite;
+      case BleEventKind.keepaliveFailed:
+        return Symbols.heart_broken;
+      case BleEventKind.reconnectScheduled:
+      case BleEventKind.reconnectAttempt:
+        return Symbols.replay;
+      case BleEventKind.waitingPhase:
+        return Symbols.hourglass_empty;
+      case BleEventKind.note:
+        return Symbols.sticky_note_2;
+    }
+  }
+
+  static Color _colorForKind(BleEventKind kind, ThemeData theme) {
+    final cs = theme.colorScheme;
+    switch (kind) {
+      case BleEventKind.connectSuccess:
+      case BleEventKind.sessionConnected:
+        return cs.primary;
+      case BleEventKind.connectFailed:
+      case BleEventKind.disconnectUnexpected:
+      case BleEventKind.disconnectKeepaliveFailed:
+      case BleEventKind.keepaliveFailed:
+        return cs.error;
+      case BleEventKind.reconnectScheduled:
+      case BleEventKind.reconnectAttempt:
+      case BleEventKind.waitingPhase:
+      case BleEventKind.serviceDiscoveryRetry:
+        return cs.tertiary;
+      default:
+        return cs.onSurface;
+    }
+  }
+}

--- a/lib/screens/settings/ble_diagnostics_screen.dart
+++ b/lib/screens/settings/ble_diagnostics_screen.dart
@@ -82,34 +82,97 @@ class _BleDiagnosticsScreenState extends State<BleDiagnosticsScreen> {
   @override
   Widget build(BuildContext context) {
     final events = _diag.events;
+    final captureEnabled = _diag.enabled;
     return Scaffold(
       appBar: AppBar(
         title: const Text('BLE Diagnostics'),
         actions: [
           IconButton(
             tooltip: 'Copy log',
-            onPressed: events.isEmpty ? null : _copyToClipboard,
+            onPressed: (!captureEnabled || events.isEmpty)
+                ? null
+                : _copyToClipboard,
             icon: const Icon(Symbols.content_copy),
           ),
           IconButton(
             tooltip: 'Clear log',
-            onPressed: events.isEmpty ? null : _confirmClear,
+            onPressed: (!captureEnabled || events.isEmpty)
+                ? null
+                : _confirmClear,
             icon: const Icon(Symbols.delete_sweep),
           ),
         ],
       ),
-      body: events.isEmpty
-          ? const _EmptyState()
-          : ListView.builder(
-              reverse: true,
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: events.length,
-              itemBuilder: (context, index) {
-                // Newest at the top → reverse the index.
-                final event = events[events.length - 1 - index];
-                return _EventTile(event: event);
-              },
+      body: Column(
+        children: [
+          SwitchListTile.adaptive(
+            title: const Text('Capture BLE events'),
+            subtitle: const Text(
+              'Off by default. Enable temporarily to debug a connection issue, '
+              'then turn off when finished.',
             ),
+            secondary: const Icon(Symbols.bug_report),
+            value: captureEnabled,
+            onChanged: (v) => _diag.setEnabled(v),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: !captureEnabled
+                ? const _DisabledState()
+                : (events.isEmpty
+                      ? const _EmptyState()
+                      : ListView.builder(
+                          reverse: true,
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemCount: events.length,
+                          itemBuilder: (context, index) {
+                            // Newest at the top → reverse the index.
+                            final event = events[events.length - 1 - index];
+                            return _EventTile(event: event);
+                          },
+                        )),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DisabledState extends StatelessWidget {
+  const _DisabledState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Symbols.toggle_off,
+              size: 64,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Event capture is off',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Turn on the toggle above to start recording BLE TNC events. '
+              'Capture is off by default to keep normal use lightweight.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/settings/category/advanced_screen.dart
+++ b/lib/screens/settings/category/advanced_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
 
+import '../../../ui/utils/platform_route.dart';
 import '../advanced_mode_controller.dart';
+import '../ble_diagnostics_screen.dart';
 
 class AdvancedSettingsContent extends StatelessWidget {
   const AdvancedSettingsContent({super.key});
@@ -21,6 +23,20 @@ class AdvancedSettingsContent extends StatelessWidget {
           onChanged: (v) =>
               context.read<AdvancedModeController>().setEnabled(v),
         ),
+        if (advanced.isEnabled) ...[
+          const Divider(),
+          ListTile(
+            leading: const Icon(Symbols.bluetooth_searching),
+            title: const Text('BLE Diagnostics'),
+            subtitle: const Text(
+              'Live event log for debugging BLE TNC drops in the background.',
+            ),
+            trailing: const Icon(Symbols.chevron_right),
+            onTap: () => Navigator.of(
+              context,
+            ).push(buildPlatformRoute((_) => const BleDiagnosticsScreen())),
+          ),
+        ],
         const SizedBox(height: 16),
       ],
     );

--- a/lib/ui/widgets/battery_optimization_card.dart
+++ b/lib/ui/widgets/battery_optimization_card.dart
@@ -1,0 +1,148 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../theme/meridian_colors.dart';
+
+/// Inline warning card prompting the user to opt Meridian out of Doze battery
+/// optimization. Renders only when:
+///   - Running on Android (no-op everywhere else).
+///   - The runtime permission is currently DENIED.
+///
+/// Tapping the action opens the system "ignore battery optimization" dialog
+/// via [Permission.ignoreBatteryOptimizations.request]. Re-checks the state
+/// when the app returns to the foreground so the card disappears as soon as
+/// the user grants the exemption from system settings.
+///
+/// Used on the Connection screen's BLE tab and (eventually) anywhere else
+/// reliable background BLE matters.
+class BatteryOptimizationCard extends StatefulWidget {
+  const BatteryOptimizationCard({super.key, this.checker});
+
+  /// Test seam — overrides the platform permission check. The default reads
+  /// [Permission.ignoreBatteryOptimizations] on Android and returns granted
+  /// on every other platform. Returning `true` means the exemption is in
+  /// place (and the card collapses).
+  final Future<bool> Function()? checker;
+
+  @override
+  State<BatteryOptimizationCard> createState() =>
+      _BatteryOptimizationCardState();
+}
+
+class _BatteryOptimizationCardState extends State<BatteryOptimizationCard>
+    with WidgetsBindingObserver {
+  bool? _ignored;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _refresh();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _refresh();
+    }
+  }
+
+  Future<void> _refresh() async {
+    final granted = await (widget.checker ?? _defaultChecker)();
+    if (!mounted) return;
+    setState(() => _ignored = granted);
+  }
+
+  static Future<bool> _defaultChecker() async {
+    if (kIsWeb || !Platform.isAndroid) return true;
+    final status = await Permission.ignoreBatteryOptimizations.status;
+    return status.isGranted;
+  }
+
+  Future<void> _request() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await Permission.ignoreBatteryOptimizations.request();
+    } catch (_) {
+      // Permission_handler can throw on rare OEM quirks; refresh and continue.
+    }
+    // Always re-check; the system dialog may have been dismissed without
+    // a grant, in which case the card should remain visible.
+    await _refresh();
+    if (!mounted) return;
+    setState(() => _busy = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Hide everywhere the prompt is meaningless or already satisfied.
+    if (_ignored == null || _ignored == true) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final warning = MeridianColors.warning;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: warning.withValues(alpha: 0.08),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: warning.withValues(alpha: 0.4)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Symbols.battery_alert, color: warning, size: 22),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    'Battery optimization is on',
+                    style: theme.textTheme.titleSmall,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'When Android puts Meridian to sleep, the BLE TNC link can drop '
+              'and stay disconnected until you open the app again. Allow '
+              'Meridian to ignore battery optimization to keep beaconing and '
+              'reconnect timers running while the screen is off.',
+              style: theme.textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.tonalIcon(
+                onPressed: _busy ? null : _request,
+                icon: _busy
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Symbols.tune),
+                label: const Text('Allow'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/transport/ble_diagnostics_test.dart
+++ b/test/core/transport/ble_diagnostics_test.dart
@@ -77,6 +77,9 @@ void main() {
         maxEvents: 5,
         persistDebounce: const Duration(milliseconds: 10),
       );
+      // Most tests want the buffer to actually accumulate; the disabled-by-
+      // default contract is exercised by its own dedicated test below.
+      await diag.setEnabled(true);
     });
 
     test('log() appends events in order and notifies listeners', () {
@@ -141,6 +144,42 @@ void main() {
       expect(restored.events, hasLength(1));
       expect(restored.events.single.detail, 'persisted-by-debounce');
     });
+
+    test('log() is a no-op when capture is disabled', () async {
+      await diag.setEnabled(false);
+      var notifyCount = 0;
+      diag.addListener(() => notifyCount++);
+
+      diag.log(BleEventKind.connectStart, 'should-be-dropped');
+
+      expect(diag.events, isEmpty);
+      expect(notifyCount, 0);
+    });
+
+    test('setEnabled() persists across hydrate', () async {
+      // Start with a fresh diag whose default is OFF, flip to ON, persist,
+      // then build a sibling instance against the same prefs and confirm.
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final first = BleDiagnostics(prefs: prefs);
+      expect(first.enabled, isFalse, reason: 'fresh instance should be off');
+      await first.setEnabled(true);
+
+      final second = BleDiagnostics(prefs: prefs);
+      await second.hydrate();
+      expect(second.enabled, isTrue);
+    });
+
+    test(
+      'hydrate() defaults enabled to false when no preference saved',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final fresh = BleDiagnostics(prefs: prefs);
+        await fresh.hydrate();
+        expect(fresh.enabled, isFalse);
+      },
+    );
 
     test('hydrate() ignores corrupt entries but keeps valid ones', () async {
       final prefs = await SharedPreferences.getInstance();

--- a/test/core/transport/ble_diagnostics_test.dart
+++ b/test/core/transport/ble_diagnostics_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/transport/ble_diagnostics.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BleEvent', () {
+    test('encode/decode round-trip preserves all fields', () {
+      final original = BleEvent(
+        timestamp: DateTime.utc(2026, 4, 30, 12, 34, 56, 789),
+        kind: BleEventKind.connectSuccess,
+        detail: 'device=FakeTNC mtu=512',
+      );
+      final decoded = BleEvent.tryDecode(original.encode());
+      expect(decoded, isNotNull);
+      expect(decoded!.timestamp, original.timestamp);
+      expect(decoded.kind, original.kind);
+      expect(decoded.detail, original.detail);
+    });
+
+    test('detail containing pipes survives round-trip', () {
+      final original = BleEvent(
+        timestamp: DateTime.utc(2026, 1, 1),
+        kind: BleEventKind.note,
+        detail: 'has|pipes|in|it',
+      );
+      final decoded = BleEvent.tryDecode(original.encode());
+      expect(decoded, isNotNull);
+      expect(decoded!.detail, 'has|pipes|in|it');
+    });
+
+    test('tryDecode returns null for malformed input', () {
+      expect(BleEvent.tryDecode(''), isNull);
+      expect(BleEvent.tryDecode('no-pipes-at-all'), isNull);
+      expect(BleEvent.tryDecode('only|one-pipe'), isNull);
+      expect(BleEvent.tryDecode('not-a-number|0|x'), isNull);
+      expect(BleEvent.tryDecode('1234|not-int|x'), isNull);
+      // Out-of-range kind index.
+      expect(BleEvent.tryDecode('1234|9999|x'), isNull);
+    });
+
+    test('formatHuman includes time, kind, and detail', () {
+      final event = BleEvent(
+        timestamp: DateTime(2026, 4, 30, 12, 34, 56, 789),
+        kind: BleEventKind.keepaliveSent,
+        detail: 'extra',
+      );
+      final s = event.formatHuman();
+      expect(s, contains('keepaliveSent'));
+      expect(s, contains('extra'));
+      // Time format HH:mm:ss.SSS — local time, so just check delimiters.
+      expect(s, matches(RegExp(r'\d{2}:\d{2}:\d{2}\.\d{3}')));
+    });
+
+    test(
+      'formatHuman omits trailing detail separator when detail is empty',
+      () {
+        final event = BleEvent(
+          timestamp: DateTime(2026, 4, 30),
+          kind: BleEventKind.keepaliveSent,
+        );
+        // No double-space-detail suffix at the end.
+        expect(event.formatHuman(), endsWith('keepaliveSent'));
+      },
+    );
+  });
+
+  group('BleDiagnostics', () {
+    late BleDiagnostics diag;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      diag = BleDiagnostics(
+        prefs: prefs,
+        maxEvents: 5,
+        persistDebounce: const Duration(milliseconds: 10),
+      );
+    });
+
+    test('log() appends events in order and notifies listeners', () {
+      var notifyCount = 0;
+      diag.addListener(() => notifyCount++);
+
+      diag.log(BleEventKind.connectStart, 'a');
+      diag.log(BleEventKind.connectSuccess, 'b');
+
+      expect(diag.events, hasLength(2));
+      expect(diag.events[0].kind, BleEventKind.connectStart);
+      expect(diag.events[0].detail, 'a');
+      expect(diag.events[1].kind, BleEventKind.connectSuccess);
+      expect(notifyCount, 2);
+    });
+
+    test('ring buffer evicts oldest when maxEvents exceeded', () {
+      for (var i = 0; i < 8; i++) {
+        diag.log(BleEventKind.note, 'msg-$i');
+      }
+      expect(diag.events, hasLength(5));
+      // First 3 should have been evicted; we keep msg-3..msg-7.
+      expect(diag.events.first.detail, 'msg-3');
+      expect(diag.events.last.detail, 'msg-7');
+    });
+
+    test('clear() empties the buffer and notifies', () async {
+      diag.log(BleEventKind.note, 'x');
+      var cleared = false;
+      diag.addListener(() => cleared = diag.events.isEmpty);
+
+      await diag.clear();
+      expect(diag.events, isEmpty);
+      expect(cleared, isTrue);
+    });
+
+    test('flush() writes the current buffer to SharedPreferences', () async {
+      diag.log(BleEventKind.connectStart, 'a');
+      diag.log(BleEventKind.connectSuccess, 'b');
+      await diag.flush();
+
+      // Build a fresh instance against the same backing store; hydrate must
+      // see the two persisted events.
+      final prefs = await SharedPreferences.getInstance();
+      final restored = BleDiagnostics(prefs: prefs, maxEvents: 5);
+      await restored.hydrate();
+      expect(restored.events, hasLength(2));
+      expect(restored.events[0].kind, BleEventKind.connectStart);
+      expect(restored.events[0].detail, 'a');
+      expect(restored.events[1].kind, BleEventKind.connectSuccess);
+      expect(restored.events[1].detail, 'b');
+    });
+
+    test('debounced persist eventually writes after log()', () async {
+      diag.log(BleEventKind.note, 'persisted-by-debounce');
+      // Debounce was set to 10ms in setUp; wait safely longer.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final prefs = await SharedPreferences.getInstance();
+      final restored = BleDiagnostics(prefs: prefs, maxEvents: 5);
+      await restored.hydrate();
+      expect(restored.events, hasLength(1));
+      expect(restored.events.single.detail, 'persisted-by-debounce');
+    });
+
+    test('hydrate() ignores corrupt entries but keeps valid ones', () async {
+      final prefs = await SharedPreferences.getInstance();
+      // Pre-seed prefs with a mix of valid and invalid lines.
+      final goodLine = BleEvent(
+        timestamp: DateTime.utc(2026, 4, 30),
+        kind: BleEventKind.sessionConnected,
+        detail: 'survivor',
+      ).encode();
+      await prefs.setStringList('ble_diagnostics_log_v1', [
+        'corrupt-line',
+        goodLine,
+        '|',
+      ]);
+
+      final restored = BleDiagnostics(prefs: prefs, maxEvents: 5);
+      await restored.hydrate();
+      expect(restored.events, hasLength(1));
+      expect(restored.events.single.detail, 'survivor');
+    });
+  });
+}

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -52,6 +52,7 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   // ----- configuration knobs -----
   bool connectThrows = false;
   bool discoverThrows = false;
+  bool requestPriorityThrows = false;
   int fakeMtu = 512;
   List<BluetoothService> services = [];
 
@@ -61,6 +62,7 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   int requestMtuCallCount = 0;
   int discoverCallCount = 0;
   int clearGattCacheCallCount = 0;
+  final List<ConnectionPriority> requestedPriorities = [];
 
   // ----- connection state stream -----
   final _connStateController =
@@ -105,6 +107,16 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
   @override
   Future<void> clearGattCache() async {
     clearGattCacheCallCount++;
+  }
+
+  @override
+  Future<void> requestConnectionPriority(ConnectionPriority priority) async {
+    requestedPriorities.add(priority);
+    if (requestPriorityThrows) {
+      throw Exception(
+        'FakeBleDeviceAdapter: requestConnectionPriority refused',
+      );
+    }
   }
 
   @override
@@ -303,6 +315,110 @@ void main() {
             .toList();
         // The transport retries up to 3× before rethrowing.
         expect(retries, hasLength(3));
+      },
+    );
+
+    // 8c ----------------------------------------------------------------------
+    test(
+      'connect requests HIGH connection priority after adapter.connect',
+      () async {
+        // service-not-found path is fine — priority is requested BEFORE
+        // discovery, so the request count is still observable.
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+        expect(fakeAdapter.requestedPriorities, [ConnectionPriority.high]);
+        final priorityEvents = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.connectionPriorityRequested)
+            .toList();
+        expect(priorityEvents, hasLength(1));
+      },
+    );
+
+    // 8d ----------------------------------------------------------------------
+    test(
+      'connect logs connectionPriorityFailed when adapter rejects priority but does not abort',
+      () async {
+        fakeAdapter.requestPriorityThrows = true;
+        // Connect still proceeds and ultimately fails on service discovery
+        // (no service registered) — NOT on the priority refusal.
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+        final priorityFailed = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.connectionPriorityFailed)
+            .toList();
+        expect(priorityFailed, hasLength(1));
+        // Discovery still happened — proving the priority refusal was treated
+        // as advisory rather than fatal.
+        expect(fakeAdapter.discoverCallCount, greaterThanOrEqualTo(1));
+      },
+    );
+
+    // 8e ----------------------------------------------------------------------
+    test(
+      'connection-state listener survives _cleanupSubscriptions on connect failure',
+      () async {
+        // After a failed connect, the conn-state listener is also cancelled
+        // (no live session for it to observe). Verify that a subsequent state
+        // emission does NOT re-enter the disconnect handler — i.e. we don't
+        // see disconnectUnexpected in the log.
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        BleDiagnostics.I.clear();
+
+        fakeAdapter.emitConnectionState(BluetoothConnectionState.disconnected);
+        await Future<void>.delayed(Duration.zero);
+
+        final unexpected = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.disconnectUnexpected)
+            .toList();
+        expect(unexpected, isEmpty);
+      },
+    );
+
+    // 8f ----------------------------------------------------------------------
+    test(
+      'markInternalTeardown causes the next disconnect to log as internal',
+      () async {
+        // Force a session so disconnect actually runs (status != disconnected).
+        // We can't reach connected via the fake (characteristic ops need
+        // native), but we can drive a partial state by emitting connecting →
+        // then calling disconnect.
+        fakeAdapter.connectThrows = true;
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        // After a failed connect status is `error`, so disconnect() runs.
+        transport.markInternalTeardown();
+        BleDiagnostics.I.clear();
+
+        await transport.disconnect();
+
+        final internal = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.disconnectInternal)
+            .toList();
+        final user = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.disconnectUser)
+            .toList();
+        expect(internal, hasLength(1));
+        expect(user, isEmpty);
+      },
+    );
+
+    // 8g ----------------------------------------------------------------------
+    test(
+      'disconnect without markInternalTeardown logs as user disconnect',
+      () async {
+        fakeAdapter.connectThrows = true;
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+        BleDiagnostics.I.clear();
+
+        await transport.disconnect();
+
+        final internal = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.disconnectInternal)
+            .toList();
+        final user = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.disconnectUser)
+            .toList();
+        expect(internal, isEmpty);
+        expect(user, hasLength(1));
       },
     );
 

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -156,6 +156,10 @@ void main() {
         prefs: await SharedPreferences.getInstance(),
         persistDebounce: const Duration(milliseconds: 1),
       );
+      // Production default is OFF so end-users don't pay for capture they
+      // didn't ask for; transport tests need capture ON to assert
+      // instrumentation actually fires.
+      await BleDiagnostics.I.setEnabled(true);
       fakeAdapter = FakeBleDeviceAdapter();
       transport = BleTncTransport(dummyDevice, adapter: fakeAdapter);
     });

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -4,8 +4,10 @@ import 'dart:typed_data';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meridian_aprs/core/transport/aprs_transport.dart';
+import 'package:meridian_aprs/core/transport/ble_diagnostics.dart';
 import 'package:meridian_aprs/core/transport/ble_tnc_transport_impl.dart';
 import 'package:meridian_aprs/core/transport/kiss_framer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // ---------------------------------------------------------------------------
 // AX.25 / KISS helpers (mirrors serial_kiss_pipeline_test.dart)
@@ -123,14 +125,25 @@ class FakeBleDeviceAdapter implements BleDeviceAdapter {
 // ---------------------------------------------------------------------------
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('BleTncTransport', () {
     late FakeBleDeviceAdapter fakeAdapter;
     late BleTncTransport transport;
+    late BleDiagnostics savedDiag;
     // A dummy BluetoothDevice — the transport constructor requires one even
     // when an adapter is injected. fromId avoids any platform call.
     final dummyDevice = BluetoothDevice.fromId('AA:BB:CC:DD:EE:FF');
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      // Swap the global diagnostics singleton for a per-test isolated instance
+      // so assertions don't see leakage from other tests.
+      savedDiag = BleDiagnostics.I;
+      BleDiagnostics.I = BleDiagnostics(
+        prefs: await SharedPreferences.getInstance(),
+        persistDebounce: const Duration(milliseconds: 1),
+      );
       fakeAdapter = FakeBleDeviceAdapter();
       transport = BleTncTransport(dummyDevice, adapter: fakeAdapter);
     });
@@ -141,6 +154,7 @@ void main() {
         await transport.disconnect();
       } catch (_) {}
       await fakeAdapter.close();
+      BleDiagnostics.I = savedDiag;
     });
 
     // 1 -----------------------------------------------------------------------
@@ -261,6 +275,36 @@ void main() {
       final ax25 = Uint8List.fromList([0x01, 0x02, 0x03]);
       expect(() async => transport.sendFrame(ax25), throwsA(isA<StateError>()));
     });
+
+    // 8a ----------------------------------------------------------------------
+    test(
+      'connect failure logs connectStart + connectFailed diagnostics',
+      () async {
+        fakeAdapter.connectThrows = true;
+
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+        final kinds = BleDiagnostics.I.events.map((e) => e.kind).toList();
+        expect(kinds, contains(BleEventKind.connectStart));
+        expect(kinds, contains(BleEventKind.connectFailed));
+      },
+    );
+
+    // 8b ----------------------------------------------------------------------
+    test(
+      'connect failure due to discoverServices logs serviceDiscoveryRetry',
+      () async {
+        fakeAdapter.discoverThrows = true;
+
+        await expectLater(transport.connect(), throwsA(isA<Exception>()));
+
+        final retries = BleDiagnostics.I.events
+            .where((e) => e.kind == BleEventKind.serviceDiscoveryRetry)
+            .toList();
+        // The transport retries up to 3× before rethrowing.
+        expect(retries, hasLength(3));
+      },
+    );
 
     // 9 -----------------------------------------------------------------------
     group('KISS framer reassembly (BLE chunked delivery)', () {

--- a/test/core/transport/ble_tnc_transport_test.dart
+++ b/test/core/transport/ble_tnc_transport_test.dart
@@ -320,36 +320,24 @@ void main() {
 
     // 8c ----------------------------------------------------------------------
     test(
-      'connect requests HIGH connection priority after adapter.connect',
+      'connect does NOT call requestConnectionPriority (TNC4 supervision-timeout drop guard)',
       () async {
-        // service-not-found path is fine — priority is requested BEFORE
-        // discovery, so the request count is still observable.
+        // Regression guard. The 2026-04-30 drive test showed every cycle
+        // dropping at ~5.4 s when HIGH priority was requested immediately
+        // after connect — same TNC4 firmware quirk that already forbids
+        // requestMtu here. Re-introducing the priority request needs
+        // hardware-specific gating; this test fails loudly if someone wires
+        // it up unconditionally.
         await expectLater(transport.connect(), throwsA(isA<Exception>()));
 
-        expect(fakeAdapter.requestedPriorities, [ConnectionPriority.high]);
+        expect(fakeAdapter.requestedPriorities, isEmpty);
+        // The decision is still recorded in diagnostics so session logs
+        // explain why BALANCED priority is in effect.
         final priorityEvents = BleDiagnostics.I.events
             .where((e) => e.kind == BleEventKind.connectionPriorityRequested)
             .toList();
         expect(priorityEvents, hasLength(1));
-      },
-    );
-
-    // 8d ----------------------------------------------------------------------
-    test(
-      'connect logs connectionPriorityFailed when adapter rejects priority but does not abort',
-      () async {
-        fakeAdapter.requestPriorityThrows = true;
-        // Connect still proceeds and ultimately fails on service discovery
-        // (no service registered) — NOT on the priority refusal.
-        await expectLater(transport.connect(), throwsA(isA<Exception>()));
-
-        final priorityFailed = BleDiagnostics.I.events
-            .where((e) => e.kind == BleEventKind.connectionPriorityFailed)
-            .toList();
-        expect(priorityFailed, hasLength(1));
-        // Discovery still happened — proving the priority refusal was treated
-        // as advisory rather than fatal.
-        expect(fakeAdapter.discoverCallCount, greaterThanOrEqualTo(1));
+        expect(priorityEvents.single.detail, contains('skipped'));
       },
     );
 

--- a/test/widget/battery_optimization_card_test.dart
+++ b/test/widget/battery_optimization_card_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/ui/widgets/battery_optimization_card.dart';
+
+Widget _host(BatteryOptimizationCard card) => MaterialApp(
+  home: Scaffold(
+    body: SizedBox(
+      width: 600,
+      child: Padding(padding: const EdgeInsets.all(16), child: card),
+    ),
+  ),
+);
+
+void main() {
+  group('BatteryOptimizationCard', () {
+    testWidgets('collapses to SizedBox.shrink when permission is granted', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(BatteryOptimizationCard(checker: () async => true)),
+      );
+      // First frame shows nothing while the future is pending; resolve it.
+      await tester.pumpAndSettle();
+
+      expect(find.text('Battery optimization is on'), findsNothing);
+      expect(find.text('Allow'), findsNothing);
+    });
+
+    testWidgets('renders prompt when permission is denied', (tester) async {
+      await tester.pumpWidget(
+        _host(BatteryOptimizationCard(checker: () async => false)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Battery optimization is on'), findsOneWidget);
+      expect(find.text('Allow'), findsOneWidget);
+      // The body text mentions the BLE-link consequence so the user
+      // understands why we're asking.
+      expect(find.textContaining('BLE TNC link'), findsOneWidget);
+    });
+
+    testWidgets(
+      'renders nothing on the very first frame (before async resolve)',
+      (tester) async {
+        await tester.pumpWidget(
+          _host(BatteryOptimizationCard(checker: () async => false)),
+        );
+        // Build only — no settle. The future hasn't resolved so _ignored is
+        // still null and the card returns SizedBox.shrink to avoid a
+        // false-positive flash of the warning.
+        expect(find.text('Battery optimization is on'), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Three layered improvements that together address the v0.7+ Android background BLE TNC reliability gap, validated across four real-world drive tests on a Pixel 14+ with a Mobilinkd TNC4. The original failure mode — link drops mid-drive and the reconnect path goes silent under Doze when the screen has been off for a while — is no longer reproducible after this branch.

- **BLE diagnostics ring buffer** (`lib/core/transport/ble_diagnostics.dart`) capturing connect lifecycle, keepalive activity, BLE state transitions, reconnect scheduling, and discovery retries. 200-event buffer, persisted on a 1 s debounce so a session log survives a process kill. **Off by default** with a toggle on a new Settings → Advanced → BLE Diagnostics screen — capture is meant as an opt-in debug aid, not always-on instrumentation. When enabled, the screen shows a live event list with copy-to-clipboard.
- **Link-quality + listener resilience** in `BleTncTransport`:
  - Connection-state listener attached **before** service discovery and **not** torn down by per-session cleanup, so a late OS-side disconnect after a session ends still drives the error stream. This is the change that recovered backgrounded reconnect.
  - Keepalive write retries once after a 200 ms delay before declaring the link dead, absorbing transient OS scheduling stalls without tripping the full reconnect cascade.
  - Keepalive cadence relaxed from 2 s to 4 s; the OS already surfaces real link drops via `onConnectionStateChange` within the 5.12 s supervision timeout, so the app-level keepalive is purely a self-watchdog and was over-aggressive.
  - `markInternalTeardown()` + new `disconnectInternal` event distinguish reconnect-cycle teardowns from real user disconnects so the diagnostics log is honest.
- **Battery-optimization exemption prompt** (Android-only): manifest permission `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`, an inline warning card on the Connection → BLE tab when the exemption is denied, and an in-line prompt during onboarding once a BLE session is established. Non-blocking — denial does not prevent onboarding from advancing; the warning card persists.

### What was tried and rolled back

`requestConnectionPriority(HIGH)` immediately after `connect()` was added in commit `42b6b64`, then dropped in `246ebf0`. The TNC4 firmware does not tolerate parameter renegotiation immediately after connect — every session dropped at exactly ~5.4 s (the 5.12 s LINK_SUPERVISION_TIMEOUT). The matching test now guards against re-introducing the call without hardware-specific gating. (Same hardware quirk that already forbids `requestMtu()` here.)

### Diagnosis confidence

Independent research (separate audit) confirmed: in-motion drops on TNC4 are RF physics, not a software bug; `requestConnectionPriority` is documented to collapse supervision timeouts on peripherals whose PPCP doesn't enforce a longer floor; `autoConnect=true` is unreliable in background and should remain a long-tail fallback. Our current fast-active-retry-then-autoConnect strategy is consistent with the public record.

### Drive-test evidence

- **Drive 1 (pre-PR)**: link dropped silently in background; manual beacon required on arrival.
- **Drive 4 (this branch, ~8 min, screen off, app backgrounded)**: 9 in-motion drops in the first ~3 minutes, every one recovered in ~1.3 s in the background; followed by ~5 minutes of unbroken keepalive cadence once stationary, proving the main isolate stayed alive throughout.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 720 passing (10 new across `ble_diagnostics_test`, `ble_tnc_transport_test`, `battery_optimization_card_test`)
- [x] Stationary BLE connect + 5+ minute hold (no false drops)
- [x] Drive-around-the-block, screen off, app backgrounded (recovery fires reliably)
- [x] BLE Diagnostics toggle on/off persists across app restart
- [x] Battery-optimization warning card appears when denied, disappears immediately on grant from system settings
- [ ] Long pocket-locked drive (15+ min) to validate the battery-opt path under sustained Doze — recommended before tagging
- [ ] Verify card / prompt are no-ops on iOS once the BLE TNC iOS path is exercised

## Notes for review

- New ADR is intentionally NOT included; the existing decision history (ADR-060 in particular) is referenced in code comments where the trade-offs matter, and an ADR can be added when the larger v0.19 bundle ships if reviewers prefer.
- `disconnectInternal` and three other `BleEventKind` values are appended at the end of the enum to preserve persisted-log indices from earlier development builds (decoder validates `kindIdx < BleEventKind.values.length`).
- Connection priority remains an unresolved opportunity — re-introducing it would need device-name probing or a settings toggle. Not in scope for this PR; opening as a follow-up issue is cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)