### PR TITLE
Receive-only mode UX + Linux GPS pre-detection

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -15,6 +15,7 @@ import '../core/connection/connection_registry.dart';
 import '../core/connection/lat_lng_box.dart';
 import '../core/packet/station.dart';
 import '../map/meridian_tile_provider.dart';
+import '../services/beaconing_service.dart';
 import '../services/station_service.dart';
 import '../services/station_settings_service.dart';
 import '../services/tx_service.dart';
@@ -81,6 +82,7 @@ class _MapScreenState extends State<MapScreen> {
   // current time-window boundary without deleting any underlying data.
   Timer? _slidingWindowTick;
   StreamSubscription<TxEvent>? _txEventSub;
+  StreamSubscription<BeaconingEvent>? _beaconingEventSub;
   bool _northUpLocked = true;
   int _visibleStationCount = 0;
   int _totalStationCount = 0;
@@ -105,6 +107,9 @@ class _MapScreenState extends State<MapScreen> {
       (_) => _rebuildMarkers(),
     );
     _txEventSub = context.read<TxService>().events.listen(_onTxEvent);
+    _beaconingEventSub = context.read<BeaconingService>().events.listen(
+      _onBeaconingEvent,
+    );
 
     // Push the persisted APRS-IS filter config into the connection once at
     // startup, before the first viewport update fires, so the initial
@@ -167,6 +172,7 @@ class _MapScreenState extends State<MapScreen> {
     _reclusterDebounce?.cancel();
     _slidingWindowTick?.cancel();
     _txEventSub?.cancel();
+    _beaconingEventSub?.cancel();
     _service.removeListener(_onServiceSettingChanged);
     _settingsRef?.removeListener(_onFilterSettingsChanged);
     _tileProvider.dispose();
@@ -203,17 +209,67 @@ class _MapScreenState extends State<MapScreen> {
     // Routing is now unconditional Serial > BLE > APRS-IS; the banners just
     // surface the transition so the user knows which path is live.
     // TODO(ios): use Cupertino-styled banner
-    final content = switch (event) {
-      TxEventTncDisconnected() =>
-        _aprsIsConnected()
-            ? 'TNC disconnected — using APRS-IS'
-            : 'TNC disconnected',
-      TxEventTncReconnected() => 'TNC connected — using RF',
-    };
+    switch (event) {
+      case TxEventTncDisconnected():
+        _showBanner(
+          messenger,
+          _aprsIsConnected()
+              ? 'TNC disconnected — using APRS-IS'
+              : 'TNC disconnected',
+        );
+      case TxEventTncReconnected():
+        _showBanner(messenger, 'TNC connected — using RF');
+      case TxEventUnlicensed():
+        _showBanner(
+          messenger,
+          'Transmit blocked: receive-only mode is on. Enable it in '
+          'Settings → My Station to send beacons and messages.',
+          actionLabel: 'Settings',
+          onAction: () {
+            messenger.clearMaterialBanners();
+            Navigator.push(
+              context,
+              buildPlatformRoute((_) => const SettingsScreen()),
+            );
+          },
+        );
+    }
+  }
+
+  void _onBeaconingEvent(BeaconingEvent event) {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearMaterialBanners();
+    switch (event) {
+      case BeaconingEventGpsUnsupported():
+        _showBanner(
+          messenger,
+          'GPS isn\'t available on this platform. Switch the position source '
+          'to Manual in Settings → My Station to beacon.',
+          actionLabel: 'Settings',
+          onAction: () {
+            messenger.clearMaterialBanners();
+            Navigator.push(
+              context,
+              buildPlatformRoute((_) => const SettingsScreen()),
+            );
+          },
+        );
+    }
+  }
+
+  void _showBanner(
+    ScaffoldMessengerState messenger,
+    String content, {
+    String? actionLabel,
+    VoidCallback? onAction,
+  }) {
     messenger.showMaterialBanner(
       MaterialBanner(
         content: Text(content),
         actions: [
+          if (actionLabel != null && onAction != null)
+            TextButton(onPressed: onAction, child: Text(actionLabel)),
           TextButton(
             onPressed: messenger.clearMaterialBanners,
             child: const Text('Dismiss'),

--- a/lib/screens/settings/category/my_station_screen.dart
+++ b/lib/screens/settings/category/my_station_screen.dart
@@ -71,99 +71,132 @@ class _MyStationSettingsContentState extends State<MyStationSettingsContent> {
   Widget build(BuildContext context) {
     final service = context.watch<StationSettingsService>();
 
+    final isLicensed = service.isLicensed;
+
     return ListView(
       children: [
         const SectionHeader('My Station'),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: CallsignField(
-            controller: _callsignCtrl,
-            focusNode: _callsignFocus,
-            label: 'Callsign',
-            onChanged: (_) {},
+        SwitchListTile.adaptive(
+          title: const Text('Licensed amateur radio operator'),
+          subtitle: const Text(
+            'Required to transmit. Turn off to use Meridian in receive-only '
+            'mode (no beacons, messages, or bulletins are sent).',
           ),
+          value: isLicensed,
+          onChanged: (v) =>
+              context.read<StationSettingsService>().setIsLicensed(v),
         ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-          child: DropdownButtonFormField<int>(
-            decoration: const InputDecoration(
-              labelText: 'SSID',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Symbols.tag),
+        // Everything below depends on having a license: identity fields
+        // (callsign, SSID, address) only matter for outgoing packets —
+        // APRS-IS receive-only mode auto-logs in as `N0CALL/-1` per
+        // ADR-045 — and symbol / comment / position source only feed
+        // outgoing beacons. Hide the lot in receive-only mode so the
+        // screen reflects what actually has effect.
+        if (!isLicensed)
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 4, 16, 16),
+            child: Text(
+              'Receive-only mode is on. Turn on the switch above to '
+              'configure your callsign, SSID, symbol, comment, and beacon '
+              'position.',
             ),
-            initialValue: service.ssid,
-            items: List.generate(16, (i) {
-              final label = switch (i) {
-                0 => '0 — No suffix',
-                1 => '1 — Digipeater',
-                2 => '2 — Generic',
-                3 => '3 — Generic',
-                4 => '4 — Generic',
-                5 => '5 — Portable',
-                6 => '6 — Special',
-                7 => '7 — Handheld',
-                8 => '8 — Boat',
-                9 => '9 — Vehicle',
-                10 => '10 — Internet',
-                11 => '11 — Aircraft',
-                12 => '12 — Balloon',
-                13 => '13 — Bike',
-                14 => '14 — ATV/GPS',
-                _ => '15 — Satellite',
-              };
-              return DropdownMenuItem(value: i, child: Text(label));
-            }),
-            onChanged: (v) {
-              if (v != null) {
-                context.read<StationSettingsService>().setSsid(v);
-              }
+          ),
+        if (isLicensed) ...[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: CallsignField(
+              controller: _callsignCtrl,
+              focusNode: _callsignFocus,
+              label: 'Callsign',
+              onChanged: (_) {},
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: DropdownButtonFormField<int>(
+              decoration: const InputDecoration(
+                labelText: 'SSID',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Symbols.tag),
+              ),
+              initialValue: service.ssid,
+              items: List.generate(16, (i) {
+                final label = switch (i) {
+                  0 => '0 — No suffix',
+                  1 => '1 — Digipeater',
+                  2 => '2 — Generic',
+                  3 => '3 — Generic',
+                  4 => '4 — Generic',
+                  5 => '5 — Portable',
+                  6 => '6 — Special',
+                  7 => '7 — Handheld',
+                  8 => '8 — Boat',
+                  9 => '9 — Vehicle',
+                  10 => '10 — Internet',
+                  11 => '11 — Aircraft',
+                  12 => '12 — Balloon',
+                  13 => '13 — Bike',
+                  14 => '14 — ATV/GPS',
+                  _ => '15 — Satellite',
+                };
+                return DropdownMenuItem(value: i, child: Text(label));
+              }),
+              onChanged: (v) {
+                if (v != null) {
+                  context.read<StationSettingsService>().setSsid(v);
+                }
+              },
+            ),
+          ),
+          ListTile(
+            dense: true,
+            title: const Text('Your address'),
+            subtitle: Text(
+              service.fullAddress.isEmpty ? '—' : service.fullAddress,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+          ),
+          // Symbol, comment, and position source only matter for outgoing
+          // beacons. They live inside the same licensed-only block as the
+          // identity fields so the receive-only view collapses to just the
+          // Licensed switch.
+          _SymbolPickerTile(
+            symbolTable: service.symbolTable,
+            symbolCode: service.symbolCode,
+            onChanged: (table, code) {
+              context.read<StationSettingsService>().setSymbol(table, code);
             },
           ),
-        ),
-        ListTile(
-          dense: true,
-          title: const Text('Your address'),
-          subtitle: Text(
-            service.fullAddress.isEmpty ? '—' : service.fullAddress,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: Theme.of(context).colorScheme.primary,
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+            child: TextFormField(
+              controller: _commentCtrl,
+              focusNode: _commentFocus,
+              decoration: const InputDecoration(
+                labelText: 'Comment',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Symbols.comment),
+                hintText: 'e.g. Meridian APRS',
+                counterText: '',
+              ),
+              maxLength: 36,
+              onEditingComplete: () => FocusScope.of(context).unfocus(),
+              onChanged: (v) => setState(() {}),
+              buildCounter:
+                  (_, {required currentLength, required isFocused, maxLength}) {
+                    return Text(
+                      '$currentLength / ${maxLength ?? 36}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    );
+                  },
             ),
           ),
-        ),
-        _SymbolPickerTile(
-          symbolTable: service.symbolTable,
-          symbolCode: service.symbolCode,
-          onChanged: (table, code) {
-            context.read<StationSettingsService>().setSymbol(table, code);
-          },
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
-          child: TextFormField(
-            controller: _commentCtrl,
-            focusNode: _commentFocus,
-            decoration: const InputDecoration(
-              labelText: 'Comment',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Symbols.comment),
-              hintText: 'e.g. Meridian APRS',
-              counterText: '',
-            ),
-            maxLength: 36,
-            onEditingComplete: () => FocusScope.of(context).unfocus(),
-            onChanged: (v) => setState(() {}),
-            buildCounter:
-                (_, {required currentLength, required isFocused, maxLength}) {
-                  return Text(
-                    '$currentLength / ${maxLength ?? 36}',
-                    style: Theme.of(context).textTheme.bodySmall,
-                  );
-                },
-          ),
-        ),
-        const SectionHeader('Position Source'),
-        _LocationSourcePicker(latCtrl: _latCtrl, lonCtrl: _lonCtrl),
+          const SectionHeader('Position Source'),
+          _LocationSourcePicker(latCtrl: _latCtrl, lonCtrl: _lonCtrl),
+        ],
         const SizedBox(height: 16),
       ],
     );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
 
+import '../services/station_settings_service.dart';
 import 'settings/category/about_screen.dart';
 import 'settings/category/advanced_screen.dart';
 import 'settings/category/appearance_screen.dart';
@@ -22,76 +24,113 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  int _selectedIndex = 0;
+  /// Title of the currently-selected category (desktop master/detail only).
+  ///
+  /// Stored by title rather than by index so that when the visible category
+  /// set changes (e.g. Beaconing disappears on Licensed-off), the selection
+  /// either follows its category to a new index or — if the category itself
+  /// is gone — explicitly falls back to the first visible category. The
+  /// previous index-based approach silently shifted the user's selection to
+  /// whatever category happened to land at the same slot.
+  String? _selectedTitle;
 
-  static final _categories = <SettingsCategory>[
-    SettingsCategory(
-      title: 'My Station',
-      icon: Symbols.person,
-      content: const MyStationSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Beaconing',
-      icon: Symbols.broadcast_on_personal,
-      content: const BeaconingSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Connections',
-      icon: Symbols.hub,
-      content: const ConnectionsSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Map',
-      icon: Symbols.map,
-      content: const MapSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Notifications',
-      icon: Symbols.notifications,
-      content: const NotificationsSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Messaging',
-      icon: Symbols.forum,
-      content: const MessagingSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'History & Storage',
-      icon: Symbols.history,
-      content: const HistorySettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Appearance',
-      icon: Symbols.palette,
-      content: const AppearanceSettingsContent(),
-    ),
-    SettingsCategory(
-      title: 'Advanced',
-      icon: Symbols.tune,
-      content: const AdvancedSettingsContent(),
-      indicatesAdvanced: true,
-    ),
-    SettingsCategory(
-      title: 'About',
-      icon: Symbols.info,
-      content: const AboutSettingsContent(),
-    ),
-  ];
+  /// Returns the visible settings categories for the current license state.
+  ///
+  /// In receive-only mode (unlicensed) the **Beaconing** category is hidden
+  /// — every control on that screen produces RF, which the TX gate would
+  /// silently drop anyway. Showing it just invites the user to spend time
+  /// configuring something that won't fire.
+  ///
+  /// All other categories stay visible: Connections (still need APRS-IS to
+  /// receive), Messaging (the per-channel viewing toggles still apply),
+  /// Map / Notifications / History / Appearance / Advanced / About are
+  /// orthogonal to TX.
+  List<SettingsCategory> _visibleCategories(bool isLicensed) {
+    return [
+      SettingsCategory(
+        title: 'My Station',
+        icon: Symbols.person,
+        content: const MyStationSettingsContent(),
+      ),
+      if (isLicensed)
+        SettingsCategory(
+          title: 'Beaconing',
+          icon: Symbols.broadcast_on_personal,
+          content: const BeaconingSettingsContent(),
+        ),
+      SettingsCategory(
+        title: 'Connections',
+        icon: Symbols.hub,
+        content: const ConnectionsSettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'Map',
+        icon: Symbols.map,
+        content: const MapSettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'Notifications',
+        icon: Symbols.notifications,
+        content: const NotificationsSettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'Messaging',
+        icon: Symbols.forum,
+        content: const MessagingSettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'History & Storage',
+        icon: Symbols.history,
+        content: const HistorySettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'Appearance',
+        icon: Symbols.palette,
+        content: const AppearanceSettingsContent(),
+      ),
+      SettingsCategory(
+        title: 'Advanced',
+        icon: Symbols.tune,
+        content: const AdvancedSettingsContent(),
+        indicatesAdvanced: true,
+      ),
+      SettingsCategory(
+        title: 'About',
+        icon: Symbols.info,
+        content: const AboutSettingsContent(),
+      ),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
+    final isLicensed = context.select<StationSettingsService, bool>(
+      (s) => s.isLicensed,
+    );
+    final categories = _visibleCategories(isLicensed);
+    // Resolve the persisted selection title against the current category set.
+    // If the previously-selected category is gone (e.g. user just disabled
+    // Licensed and Beaconing was selected) fall back to the first entry —
+    // i.e. My Station.
+    final resolvedIndex = _selectedTitle == null
+        ? 0
+        : categories.indexWhere((c) => c.title == _selectedTitle);
+    final selectedIndex = resolvedIndex < 0 ? 0 : resolvedIndex;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: LayoutBuilder(
         builder: (context, constraints) {
           if (constraints.maxWidth >= 840) {
             return _DesktopLayout(
-              categories: _categories,
-              selectedIndex: _selectedIndex,
-              onSelect: (i) => setState(() => _selectedIndex = i),
+              categories: categories,
+              selectedIndex: selectedIndex,
+              onSelect: (i) => setState(() {
+                _selectedTitle = categories[i].title;
+              }),
             );
           }
-          return _MobileLayout(categories: _categories);
+          return _MobileLayout(categories: categories);
         },
       ),
     );

--- a/lib/services/beaconing_service.dart
+++ b/lib/services/beaconing_service.dart
@@ -40,6 +40,15 @@ enum BeaconError {
   unknown,
 }
 
+/// Events emitted by [BeaconingService] for one-shot UI surfacing (banners,
+/// snackbars). Distinct from [lastError] which is a continuously-observable
+/// state for in-screen warnings — these fire once per occurrence.
+sealed class BeaconingEvent {}
+
+/// A beacon attempt was skipped because the platform has no GPS support
+/// (e.g. Linux desktop) and the user has [LocationSource.gps] selected.
+class BeaconingEventGpsUnsupported extends BeaconingEvent {}
+
 class BeaconingService extends ChangeNotifier {
   BeaconingService(
     this._settings,
@@ -48,7 +57,15 @@ class BeaconingService extends ChangeNotifier {
     Clock clock = DateTime.now,
     GeolocatorAdapter geo = const RealGeolocatorAdapter(),
   }) : _clock = clock,
-       _geo = geo;
+       _geo = geo {
+    // The geolocator package has no Linux federated implementation, so the
+    // first call to any GPS API throws MissingPluginException. Surface that
+    // up front so the My Station UI can show the "switch to Manual" warning
+    // before the user ever wonders why their beacons aren't going out.
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux) {
+      _gpsUnsupported = true;
+    }
+  }
 
   final StationSettingsService _settings;
   final TxService _tx;
@@ -83,6 +100,15 @@ class BeaconingService extends ChangeNotifier {
   Position? _lastPosition;
   double? _lastHeading;
   StreamSubscription<Position>? _positionSub;
+
+  // One-shot event surfacing (banners). Distinct from notifyListeners so the
+  // UI can showSnackBar/showBanner only when a fresh event arrives instead of
+  // on every rebuild.
+  final _eventController = StreamController<BeaconingEvent>.broadcast();
+  bool _gpsUnsupportedNotified = false;
+
+  /// Stream of one-shot events for UI surfacing.
+  Stream<BeaconingEvent> get events => _eventController.stream;
 
   // ---------------------------------------------------------------------------
   // Public read API
@@ -193,9 +219,21 @@ class BeaconingService extends ChangeNotifier {
     double? lon;
 
     if (_settings.locationSource == LocationSource.gps) {
+      // Fast-path: on platforms with no geolocator implementation we already
+      // know the call will fail. Surface the banner immediately rather than
+      // waiting for the MissingPluginException catch deeper in.
+      if (_gpsUnsupported) {
+        _lastError = BeaconError.locationUnsupported;
+        _emitGpsUnsupportedOnce();
+        notifyListeners();
+        return;
+      }
       final position = await _requestPosition();
       if (position == null) {
         // GPS failed — respect the user's choice and skip the beacon.
+        if (_lastError == BeaconError.locationUnsupported) {
+          _emitGpsUnsupportedOnce();
+        }
         notifyListeners();
         return;
       }
@@ -312,7 +350,16 @@ class BeaconingService extends ChangeNotifier {
   void dispose() {
     _timer?.cancel();
     _positionSub?.cancel();
+    _eventController.close();
     super.dispose();
+  }
+
+  void _emitGpsUnsupportedOnce() {
+    if (_gpsUnsupportedNotified) return;
+    _gpsUnsupportedNotified = true;
+    if (!_eventController.isClosed) {
+      _eventController.add(BeaconingEventGpsUnsupported());
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/services/station_settings_service.dart
+++ b/lib/services/station_settings_service.dart
@@ -36,7 +36,7 @@ class StationSettingsService extends ChangeNotifier {
       _manualLon = _prefs.getDouble(_keyManualLon),
       _locationSource =
           LocationSource.values.elementAtOrNull(
-            _prefs.getInt(_keyLocationSource) ?? 0,
+            _prefs.getInt(_keyLocationSource) ?? _defaultLocationSourceIndex(),
           ) ??
           LocationSource.gps,
       _isLicensed = _prefs.getBool(_keyIsLicensed) ?? false,
@@ -274,6 +274,19 @@ class StationSettingsService extends ChangeNotifier {
     );
     // No notifyListeners — the active filter state is [aprsIsFilter], not
     // this remembered slot. Callers typically update both in one operation.
+  }
+
+  /// Default `LocationSource` index for first-run installs.
+  ///
+  /// Linux desktop has no `geolocator` plugin implementation, so defaulting
+  /// to GPS would produce silent beacon failures with no manual coordinates
+  /// to fall back on. Default to manual there. Every other platform keeps
+  /// GPS as the first-run default.
+  static int _defaultLocationSourceIndex() {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux) {
+      return LocationSource.manual.index;
+    }
+    return LocationSource.gps.index;
   }
 
   /// Rehydrate the persisted [AprsIsFilterConfig], falling back to

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -28,13 +28,20 @@ class TxEventTncDisconnected extends TxEvent {}
 /// A TNC (BLE or Serial) reconnected — notify the user that RF is live again.
 class TxEventTncReconnected extends TxEvent {}
 
+/// A TX attempt was rejected because the user is not marked as a licensed
+/// amateur. Surfaced once per app session to prompt them to flip the toggle
+/// in Settings → My Station rather than silently dropping packets.
+class TxEventUnlicensed extends TxEvent {}
+
 // ---------------------------------------------------------------------------
 // TxService
 // ---------------------------------------------------------------------------
 
 class TxService extends ChangeNotifier {
-  TxService(this._registry, this._settings, {this.onSent}) {
+  TxService(this._registry, this._settings, {this.onSent})
+    : _wasLicensed = _settings.isLicensed {
     _registry.addListener(_onRegistryChanged);
+    _settings.addListener(_onSettingsChanged);
   }
 
   final ConnectionRegistry _registry;
@@ -52,12 +59,34 @@ class TxService extends ChangeNotifier {
   };
 
   bool _tncWasConnected = false;
+  bool _unlicensedNotified = false;
+  bool _wasLicensed;
+
+  void _rejectUnlicensed(String reason) {
+    debugPrint('[TxService] $reason rejected: unlicensed mode');
+    if (_unlicensedNotified) return;
+    _unlicensedNotified = true;
+    _eventController.add(TxEventUnlicensed());
+  }
+
+  /// Reset the once-per-session unlicensed-banner dedupe whenever the user
+  /// flips Licensed off. The banner should fire again the next time they
+  /// try to TX in receive-only mode — otherwise toggling off → on → off →
+  /// TX silently swallows the rejection.
+  void _onSettingsChanged() {
+    final nowLicensed = _settings.isLicensed;
+    if (_wasLicensed && !nowLicensed) {
+      _unlicensedNotified = false;
+    }
+    _wasLicensed = nowLicensed;
+  }
 
   // ---------------------------------------------------------------------------
   // Public API — routing
   // ---------------------------------------------------------------------------
 
-  /// Stream of [TxEvent]s for UI banner display (TNC connect/disconnect).
+  /// Stream of [TxEvent]s for UI banner display. Surfaces TNC connect /
+  /// disconnect transitions and unlicensed-mode TX rejections.
   Stream<TxEvent> get events => _eventController.stream;
 
   /// Human-readable label for the effective TX path.
@@ -89,7 +118,7 @@ class TxService extends ChangeNotifier {
     List<String>? digipeaterPath,
   }) async {
     if (!_settings.isLicensed) {
-      debugPrint('[TxService] TX rejected: unlicensed mode');
+      _rejectUnlicensed('TX');
       return;
     }
     final conn = _effectiveConnection(forceVia: forceVia);
@@ -114,7 +143,7 @@ class TxService extends ChangeNotifier {
     List<String>? rfPath,
   }) async {
     if (!_settings.isLicensed) {
-      debugPrint('[TxService] bulletin TX rejected: unlicensed mode');
+      _rejectUnlicensed('bulletin TX');
       return;
     }
     if (viaAprsIs) {
@@ -159,7 +188,7 @@ class TxService extends ChangeNotifier {
   /// No-op when the user is unlicensed — TX is unconditionally blocked.
   Future<void> sendBeacon(String aprsLine) async {
     if (!_settings.isLicensed) {
-      debugPrint('[TxService] TX rejected: unlicensed mode');
+      _rejectUnlicensed('beacon TX');
       return;
     }
     for (final conn in _registry.all) {
@@ -212,6 +241,7 @@ class TxService extends ChangeNotifier {
   @override
   void dispose() {
     _registry.removeListener(_onRegistryChanged);
+    _settings.removeListener(_onSettingsChanged);
     _eventController.close();
     super.dispose();
   }

--- a/lib/ui/layout/desktop_scaffold.dart
+++ b/lib/ui/layout/desktop_scaffold.dart
@@ -216,11 +216,12 @@ class _DesktopScaffoldState extends State<DesktopScaffold> {
               onPressed: widget.onOpenFilterPanel,
             ),
           ),
-          IconButton(
-            icon: const Icon(Symbols.person_pin),
-            tooltip: 'Find my station',
-            onPressed: _showOwnStation,
-          ),
+          if (context.select<StationSettingsService, bool>((s) => s.isLicensed))
+            IconButton(
+              icon: const Icon(Symbols.person_pin),
+              tooltip: 'Find my station',
+              onPressed: _showOwnStation,
+            ),
           IconButton(
             icon: _locating
                 ? SizedBox(
@@ -421,6 +422,10 @@ class _ConnectionStatusChip extends StatelessWidget {
 class _BeaconToolbarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final isLicensed = context.select<StationSettingsService, bool>(
+      (s) => s.isLicensed,
+    );
+    if (!isLicensed) return const SizedBox.shrink();
     final svc = context.watch<BeaconingService>();
     final registry = context.watch<ConnectionRegistry>();
     final isActive = svc.isActive;

--- a/lib/ui/layout/mobile_scaffold.dart
+++ b/lib/ui/layout/mobile_scaffold.dart
@@ -325,13 +325,17 @@ class _MobileScaffoldState extends State<MobileScaffold> {
                                     : Symbols.explore,
                               ),
                             ),
-                            const SizedBox(width: 8),
-                            FloatingActionButton.small(
-                              heroTag: 'my_station_fab',
-                              onPressed: _showOwnStation,
-                              tooltip: 'Find my station',
-                              child: const Icon(Symbols.person_pin),
-                            ),
+                            if (context.select<StationSettingsService, bool>(
+                              (s) => s.isLicensed,
+                            )) ...[
+                              const SizedBox(width: 8),
+                              FloatingActionButton.small(
+                                heroTag: 'my_station_fab',
+                                onPressed: _showOwnStation,
+                                tooltip: 'Find my station',
+                                child: const Icon(Symbols.person_pin),
+                              ),
+                            ],
                             const SizedBox(width: 8),
                             FloatingActionButton.small(
                               heroTag: 'center_fab',
@@ -350,9 +354,16 @@ class _MobileScaffoldState extends State<MobileScaffold> {
                           ],
                         ),
                         const SizedBox(height: 8),
-                        // Primary beacon FAB.
+                        // Primary beacon FAB — hidden in receive-only mode
+                        // since every tap would be silently rejected at the
+                        // TX gate.
                         Builder(
                           builder: (ctx) {
+                            final isLicensed = ctx
+                                .select<StationSettingsService, bool>(
+                                  (s) => s.isLicensed,
+                                );
+                            if (!isLicensed) return const SizedBox.shrink();
                             final beaconing = ctx.watch<BeaconingService>();
                             final reg = ctx.watch<ConnectionRegistry>();
                             final noTarget =

--- a/lib/ui/layout/tablet_scaffold.dart
+++ b/lib/ui/layout/tablet_scaffold.dart
@@ -218,11 +218,12 @@ class _TabletScaffoldState extends State<TabletScaffold> {
               onPressed: widget.onOpenFilterPanel,
             ),
           ),
-          IconButton(
-            icon: const Icon(Symbols.person_pin),
-            tooltip: 'Find my station',
-            onPressed: _showOwnStation,
-          ),
+          if (context.select<StationSettingsService, bool>((s) => s.isLicensed))
+            IconButton(
+              icon: const Icon(Symbols.person_pin),
+              tooltip: 'Find my station',
+              onPressed: _showOwnStation,
+            ),
           IconButton(
             icon: _locating
                 ? SizedBox(

--- a/test/services/beaconing_service_test.dart
+++ b/test/services/beaconing_service_test.dart
@@ -408,12 +408,16 @@ void main() {
     });
 
     test('failed beacons do not retrigger the timer chain', () {
-      // Each `beaconNow` makes exactly one entry call. When position
-      // resolution fails the early-return path skips `_restartTimer`
-      // (beaconing_service.dart:194-197), so the one-shot timer chain
-      // halts after a single fire. Pinning current behavior — there is
-      // no exponential retry, and there is no infinite "tight loop"
-      // either.
+      // Two invariants are pinned here:
+      //
+      //   1. Each `beaconNow` makes at most one entry call into the geo
+      //      plugin. When position resolution fails the early-return path
+      //      skips `_restartTimer`, so the one-shot timer chain halts
+      //      after a single fire.
+      //   2. Once a `MissingPluginException` is observed, subsequent
+      //      `beaconNow` calls take the `_gpsUnsupported` fast-path and
+      //      do *not* re-enter the plugin at all — a separate guard
+      //      against thrash on platforms with no GPS.
       _runFakeAsync((f, async) async {
         f.geo.throwMissingPlugin = true;
 
@@ -421,20 +425,61 @@ void main() {
         await f.svc.setAutoInterval(120);
         unawaited(f.svc.startBeaconing());
         async.flushMicrotasks();
-        // Initial beaconNow inside startBeaconing.
+        // Initial beaconNow inside startBeaconing — the first call sets
+        // `_gpsUnsupported = true` after the catch.
         expect(f.geo.isLocationServiceEnabledCalls, 1);
 
         // The 120 s one-shot timer scheduled before that first beaconNow
-        // still fires once; it then dies because the failed beacon did
-        // not reschedule.
+        // still fires once; it now hits the fast-path and bails without
+        // calling into the geo plugin again.
         async.elapse(const Duration(seconds: 120));
-        expect(f.geo.isLocationServiceEnabledCalls, 2);
+        expect(f.geo.isLocationServiceEnabledCalls, 1);
 
         // No further fires for hours — confirms there is no hidden retry
         // loop.
         async.elapse(const Duration(hours: 1));
-        expect(f.geo.isLocationServiceEnabledCalls, 2);
+        expect(f.geo.isLocationServiceEnabledCalls, 1);
         expect(f.tx.sentBeacons, isEmpty);
+      });
+    });
+
+    test('fires BeaconingEventGpsUnsupported once per session', () {
+      _runFakeAsync((f, async) async {
+        f.geo.throwMissingPlugin = true;
+
+        final events = <BeaconingEvent>[];
+        final sub = f.svc.events.listen(events.add);
+
+        await f.svc.beaconNow();
+        async.flushMicrotasks();
+        await f.svc.beaconNow();
+        async.flushMicrotasks();
+        await f.svc.beaconNow();
+        async.flushMicrotasks();
+
+        expect(
+          events.whereType<BeaconingEventGpsUnsupported>().toList(),
+          hasLength(1),
+          reason:
+              'banner is once-per-session — three failed beacons must produce '
+              'one event, not three',
+        );
+
+        await sub.cancel();
+      });
+    });
+
+    test('no BeaconingEvent fires before any beacon attempt is made', () {
+      _runFakeAsync((f, async) async {
+        // Even with the geo plugin set to throw, simply constructing the
+        // service and listening must not produce events — events are only
+        // emitted on actual beaconNow attempts.
+        f.geo.throwMissingPlugin = true;
+        final events = <BeaconingEvent>[];
+        final sub = f.svc.events.listen(events.add);
+        async.flushMicrotasks();
+        expect(events, isEmpty);
+        await sub.cancel();
       });
     });
   });

--- a/test/services/tx_service_unlicensed_test.dart
+++ b/test/services/tx_service_unlicensed_test.dart
@@ -144,6 +144,108 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // TxEventUnlicensed event-stream behavior
+  // ---------------------------------------------------------------------------
+
+  group('TxService — TxEventUnlicensed event stream', () {
+    late SharedPreferences prefs;
+    late StationSettingsService settings;
+    late ConnectionRegistry registry;
+    late FakeMeridianConnection conn;
+    late TxService tx;
+    late List<TxEvent> events;
+    late StreamSubscription<TxEvent> sub;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({
+        'user_callsign': 'W1AW',
+        'user_ssid': 9,
+      });
+      prefs = await SharedPreferences.getInstance();
+      settings = StationSettingsService(
+        prefs,
+        store: FakeSecureCredentialStore(),
+      );
+      registry = ConnectionRegistry();
+      conn = _TrackingFakeConnection(
+        id: 'aprs_is',
+        displayName: 'APRS-IS',
+        type: ConnectionType.aprsIs,
+        sentLines: [],
+      );
+      registry.register(conn);
+      conn.setStatus(ConnectionStatus.connected);
+
+      tx = TxService(registry, settings);
+      events = [];
+      sub = tx.events.listen(events.add);
+    });
+
+    tearDown(() async {
+      await sub.cancel();
+      tx.dispose();
+      await conn.dispose();
+    });
+
+    test('first unlicensed TX emits a TxEventUnlicensed', () async {
+      await tx.sendBeacon('=1234.56N/12345.67W>test');
+      // Events fire on the broadcast stream's microtask queue.
+      await Future<void>.delayed(Duration.zero);
+      expect(events, hasLength(1));
+      expect(events.first, isA<TxEventUnlicensed>());
+    });
+
+    test('repeat unlicensed TX in the same session does NOT re-emit', () async {
+      await tx.sendBeacon('=1234.56N/12345.67W>a');
+      await tx.sendLine('=1234.56N/12345.67W>b');
+      await tx.sendBulletin(
+        '=1234.56N/12345.67W>c',
+        viaRf: false,
+        viaAprsIs: true,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        events.whereType<TxEventUnlicensed>().toList(),
+        hasLength(1),
+        reason:
+            'banner is once-per-session — the user has been told and we should '
+            'not spam them on every subsequent TX attempt',
+      );
+    });
+
+    test('flipping Licensed off after on resets the dedupe', () async {
+      // First reject — fires the banner.
+      await tx.sendBeacon('=a');
+      await Future<void>.delayed(Duration.zero);
+      expect(events.whereType<TxEventUnlicensed>().toList(), hasLength(1));
+
+      // User flips Licensed on, then back off (e.g. they're testing).
+      await settings.setIsLicensed(true);
+      await settings.setIsLicensed(false);
+      await Future<void>.delayed(Duration.zero);
+
+      // Next reject should fire the banner again — they've been off, on, off,
+      // and the next TX needs the reminder.
+      await tx.sendBeacon('=b');
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        events.whereType<TxEventUnlicensed>().toList(),
+        hasLength(2),
+        reason:
+            'TxService listens to settings and resets the once-per-session '
+            'flag on every licensed → unlicensed transition',
+      );
+    });
+
+    test('licensed TX does not emit TxEventUnlicensed', () async {
+      await settings.setIsLicensed(true);
+      await tx.sendBeacon('=1234.56N/12345.67W>ok');
+      await Future<void>.delayed(Duration.zero);
+      expect(events.whereType<TxEventUnlicensed>(), isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // AprsIsConnection — N0CALL/-1 login substitution
   // ---------------------------------------------------------------------------
 

--- a/test/widget/settings/license_gating_test.dart
+++ b/test/widget/settings/license_gating_test.dart
@@ -1,0 +1,316 @@
+/// Widget tests for the receive-only / licensed UI gating added alongside
+/// the new Settings → My Station "Licensed amateur radio operator" switch.
+///
+/// Pins the contract that flipping `isLicensed` off in [StationSettingsService]
+/// hides every TX-only piece of UI in real time:
+///
+///   * [SettingsScreen] — the **Beaconing** category is removed from the list.
+///   * [MyStationSettingsContent] — Callsign / SSID / address / symbol /
+///     comment / position-source fields are removed; a receive-only
+///     explainer takes their place.
+///
+/// Toggling Licensed back on restores the full layout in the same session.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/screens/settings/advanced_mode_controller.dart';
+import 'package:meridian_aprs/screens/settings/category/my_station_screen.dart';
+import 'package:meridian_aprs/screens/settings_screen.dart';
+import 'package:meridian_aprs/services/beaconing_service.dart';
+import 'package:meridian_aprs/services/station_settings_service.dart';
+import 'package:meridian_aprs/services/tx_service.dart';
+
+import '../../helpers/fake_geolocator_adapter.dart';
+import '../../helpers/fake_secure_credential_store.dart';
+
+// ---------------------------------------------------------------------------
+// Harness — only wires the providers MyStation + the SettingsScreen list pane
+// actually read. Other settings categories (Beaconing, Notifications, etc.)
+// are constructed inside `_visibleCategories` but their Provider lookups only
+// fire when the category is actually entered, so they don't need to be in the
+// tree for these tests.
+// ---------------------------------------------------------------------------
+
+class _Harness {
+  _Harness._({
+    required this.settings,
+    required this.beaconing,
+    required this.widget,
+  });
+
+  final StationSettingsService settings;
+  final BeaconingService beaconing;
+  final Widget widget;
+
+  static Future<_Harness> create({
+    required bool isLicensed,
+    required Widget child,
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'user_callsign': 'W1ABC',
+      'user_ssid': 7,
+      'user_is_licensed': isLicensed,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final settings = StationSettingsService(
+      prefs,
+      store: FakeSecureCredentialStore(),
+    );
+    final registry = ConnectionRegistry();
+    final tx = TxService(registry, settings);
+    final beaconing = BeaconingService(
+      settings,
+      tx,
+      geo: FakeGeolocatorAdapter(),
+    );
+    final advanced = await AdvancedModeController.create();
+
+    final widget = MaterialApp(
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<StationSettingsService>.value(value: settings),
+          ChangeNotifierProvider<BeaconingService>.value(value: beaconing),
+          ChangeNotifierProvider<AdvancedModeController>.value(value: advanced),
+        ],
+        child: child,
+      ),
+    );
+
+    return _Harness._(settings: settings, beaconing: beaconing, widget: widget);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MyStationSettingsContent — license gating', () {
+    testWidgets('licensed: identity + beacon fields are visible', (
+      tester,
+    ) async {
+      final h = await _Harness.create(
+        isLicensed: true,
+        child: const Scaffold(body: MyStationSettingsContent()),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      // Licensed switch is always present and is on.
+      expect(find.text('Licensed amateur radio operator'), findsOneWidget);
+      final switchTile = tester.widget<SwitchListTile>(
+        find.byType(SwitchListTile),
+      );
+      expect(switchTile.value, isTrue);
+
+      // Identity fields are visible.
+      expect(find.text('Callsign'), findsOneWidget);
+      expect(find.text('SSID'), findsOneWidget);
+      expect(find.text('Your address'), findsOneWidget);
+
+      // Position-source section header is visible.
+      expect(find.text('POSITION SOURCE'), findsOneWidget);
+
+      // The receive-only explainer must NOT be present.
+      expect(find.textContaining('Receive-only mode is on'), findsNothing);
+    });
+
+    testWidgets('unlicensed: identity + beacon fields are hidden', (
+      tester,
+    ) async {
+      final h = await _Harness.create(
+        isLicensed: false,
+        child: const Scaffold(body: MyStationSettingsContent()),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      // Switch is present and off.
+      final switchTile = tester.widget<SwitchListTile>(
+        find.byType(SwitchListTile),
+      );
+      expect(switchTile.value, isFalse);
+
+      // Identity / beacon fields are gone.
+      expect(find.text('Callsign'), findsNothing);
+      expect(find.text('SSID'), findsNothing);
+      expect(find.text('Your address'), findsNothing);
+      expect(find.text('POSITION SOURCE'), findsNothing);
+
+      // The receive-only explainer is shown so the screen isn't barren.
+      expect(find.textContaining('Receive-only mode is on'), findsOneWidget);
+    });
+
+    testWidgets('toggling Licensed re-renders the field set live', (
+      tester,
+    ) async {
+      final h = await _Harness.create(
+        isLicensed: false,
+        child: const Scaffold(body: MyStationSettingsContent()),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Callsign'), findsNothing);
+
+      await h.settings.setIsLicensed(true);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Callsign'), findsOneWidget);
+      expect(find.textContaining('Receive-only mode is on'), findsNothing);
+
+      await h.settings.setIsLicensed(false);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Callsign'), findsNothing);
+      expect(find.textContaining('Receive-only mode is on'), findsOneWidget);
+    });
+  });
+
+  group('SettingsScreen — license gating', () {
+    // Force a wide test surface so the master/detail desktop layout renders
+    // and the category list is fully visible without scrolling.
+    Future<void> setWide(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1400, 1000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+    }
+
+    testWidgets('licensed: Beaconing category is in the list', (tester) async {
+      await setWide(tester);
+      final h = await _Harness.create(
+        isLicensed: true,
+        child: const SettingsScreen(),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beaconing'), findsOneWidget);
+      expect(find.text('My Station'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('unlicensed: Beaconing category is hidden', (tester) async {
+      await setWide(tester);
+      final h = await _Harness.create(
+        isLicensed: false,
+        child: const SettingsScreen(),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beaconing'), findsNothing);
+      // Other categories still present — gating is targeted, not blanket.
+      expect(find.text('My Station'), findsAtLeastNWidgets(1));
+      expect(find.text('Connections'), findsOneWidget);
+      expect(find.text('Messaging'), findsOneWidget);
+      expect(find.text('About'), findsOneWidget);
+    });
+
+    testWidgets('toggling Licensed adds/removes Beaconing from the list', (
+      tester,
+    ) async {
+      await setWide(tester);
+      final h = await _Harness.create(
+        isLicensed: false,
+        child: const SettingsScreen(),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beaconing'), findsNothing);
+
+      await h.settings.setIsLicensed(true);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beaconing'), findsOneWidget);
+
+      await h.settings.setIsLicensed(false);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Beaconing'), findsNothing);
+    });
+
+    testWidgets('selection survives reorder when a category appears above it', (
+      tester,
+    ) async {
+      // Pin the desktop-master/detail invariant: when we tap a category and
+      // then a *different* category becomes visible above it (Beaconing
+      // appears between My Station and the user's selection), the selection
+      // must continue pointing at the same category — not silently shift to
+      // whatever lands at the old index.
+      //
+      // Uses About as the selected category because its content widget has
+      // zero provider dependencies, keeping this test focused on the
+      // selection state machine rather than provider plumbing.
+      await setWide(tester);
+      final h = await _Harness.create(
+        isLicensed: false,
+        child: const SettingsScreen(),
+      );
+      await tester.pumpWidget(h.widget);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('About'));
+      await tester.pumpAndSettle();
+
+      // Two matches: the list entry + the detail header above the divider.
+      expect(find.text('About'), findsNWidgets(2));
+
+      // Flip Licensed on — Beaconing inserts at index 1; About slides one
+      // slot deeper. Selection must remain on About.
+      await h.settings.setIsLicensed(true);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('About'),
+        findsNWidgets(2),
+        reason:
+            'selection follows the category across reorders — the detail '
+            'header should still show About, not the category that happens '
+            'to land at the old index',
+      );
+    });
+
+    testWidgets(
+      'selection falls back to My Station when its category disappears',
+      (tester) async {
+        await setWide(tester);
+        final h = await _Harness.create(
+          isLicensed: true,
+          child: const SettingsScreen(),
+        );
+        await tester.pumpWidget(h.widget);
+        await tester.pumpAndSettle();
+
+        // Select Beaconing.
+        await tester.tap(find.text('Beaconing'));
+        await tester.pumpAndSettle();
+
+        // Disable Licensed — Beaconing disappears from the visible list.
+        await h.settings.setIsLicensed(false);
+        await tester.pumpAndSettle();
+
+        // The detail pane must now show My Station, not whatever happened to
+        // shift into the old index slot.
+        final myStationTexts = find.text('My Station');
+        expect(
+          myStationTexts,
+          findsNWidgets(2),
+          reason:
+              'when the selected category disappears, selection falls back to '
+              'the first visible category (My Station) — both the list entry '
+              'and the detail header must show it',
+        );
+        expect(find.text('Beaconing'), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Adds an in-app **Licensed amateur radio operator** toggle in Settings → My Station — previously settable only during onboarding, so users who answered \"no\" or skipped that step had no way to flip it later.
- Hides every TX-only piece of UI when receive-only mode is on (Beaconing settings category, identity / symbol / comment / position-source fields in My Station, BeaconFAB, desktop & tablet beacon toolbar buttons, \"Find my station\" buttons across all three scaffolds).
- Surfaces previously-silent failures via `MaterialBanner`: `TxEventUnlicensed` (TX rejected because receive-only) and `BeaconingEventGpsUnsupported` (Linux desktop has no `geolocator` plugin). The unlicensed banner is once-per-session but resets when the user toggles licensed off, so the reminder fires again on the next rejection rather than being permanently latched.
- Linux first-run defaults `LocationSource` to `manual` since the plugin can't satisfy GPS, and `BeaconingService` pre-detects the missing implementation at construction so the My Station \"switch to Manual\" warning appears immediately.
- `SettingsScreen` master/detail selection now tracks by category title instead of by index — selection follows its category across reorder (Beaconing appearing/disappearing as Licensed flips) and falls back to My Station when the selected category disappears, instead of silently shifting to whatever lands at the old slot.

## How this came about

Started as a debug session — user reported beacons not transmitting on Linux/USB. Root cause turned out to be `_settings.isLicensed = false` (Android prefs don't carry over to Linux), but every TX rejection was a silent `debugPrint`. Fix grew to cover all the silent-failure modes around licensing and Linux GPS.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 734/734 pass (+14 new tests)
- [x] **TxService — TxEventUnlicensed event stream** (4 tests): once-per-session, reset on licensed-off, no fire when licensed
- [x] **BeaconingService — locationUnsupported events** (2 tests): once-per-session, no fire before any beacon attempt
- [x] **License gating widget tests** (8 tests in new `test/widget/settings/license_gating_test.dart`): MyStation field visibility, SettingsScreen category visibility, live toggle re-renders, selection-by-title follows reorder, selection falls back to My Station when its category disappears
- [ ] Manual: flip Licensed off in My Station → confirm Beaconing category disappears, BeaconFAB disappears, identity fields collapse to receive-only explainer, \"Find my station\" buttons hidden
- [ ] Manual: flip Licensed off, attempt to send a message → confirm `TxEventUnlicensed` banner fires with \"Settings\" deep-link
- [ ] Manual (Linux): fresh install defaults Position Source to Manual; switching to GPS shows the warning row
- [ ] Manual (Android): toggle Licensed off → on → off — banner re-fires on the second rejection rather than staying silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)