### PR TITLE
feat(ble): broaden TNC support beyond Mobilinkd (aprs-specs + Benshi families)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,11 @@ All three tiers fully implemented. iOS pending simulator validation.
 | `lib/core/transport/kiss_framer.dart` | `KissFramer` | Pure Dart KISS framer; stateful `addBytes` stream processor; static `encode` method |
 | `lib/core/ax25/ax25_parser.dart` | `Ax25Parser` | Pure Dart AX.25 UI frame decoder; sealed `Ax25ParseResult` (`Ax25Ok` \| `Ax25Err`); never throws |
 | `lib/core/transport/serial_kiss_transport.dart` | `SerialKissTransport` | Implements `KissTncTransport`; platform-conditional export; desktop only (Linux/macOS/Windows) |
-| `lib/core/transport/ble_tnc_transport.dart` | `BleTncTransport` | Implements `KissTncTransport`; platform-conditional export; mobile only (iOS/Android); Mobilinkd-compatible |
-| `lib/core/transport/ble_constants.dart` | `kMobilinkdServiceUuid` etc. | Mobilinkd UART-over-BLE GATT service/characteristic UUIDs |
+| `lib/core/transport/ble_tnc_transport.dart` | `BleTncTransport` | Implements `KissTncTransport`; platform-conditional export; mobile only (iOS/Android); supports both BLE-KISS GATT families (`aprs-specs` standard + Benshi/BTECH); autodetects family at connect time |
+| `lib/core/transport/ble_constants.dart` | `kBleKiss*`, `kBenshiKiss*`, `BleKissFamily`, `BleKissProfile` | BLE-KISS GATT service/characteristic UUIDs for both supported families (aprs-specs + Benshi); family enum + resolver helper |
 | `lib/services/tnc_service.dart` | `TncService` | ChangeNotifier; owns `TransportManager`; parses AX.25 frames via `AprsParser`; bridges to `StationService.ingestLine` |
-| `lib/ui/widgets/ble_scanner_sheet.dart` | `BleScannerSheet` | BLE scan + connect UI; filters to Mobilinkd devices; device list with RSSI icons |
+| `lib/ui/widgets/ble_scanner_sheet.dart` | `BleScannerSheet` | BLE scan + connect UI; default filters to known BLE-KISS family service UUIDs (aprs-specs + Benshi); "Show all Bluetooth devices" advanced toggle; friendly model labels via `BleTncKnownDevice` registry |
+| `lib/ui/widgets/ble_tnc_known_device.dart` | `BleTncKnownDevice` | Static registry of known BLE TNC models (Mobilinkd TNC3/TNC4, PicoAPRS, B.B. Link, BTECH UV-Pro, Vero VR-N76/N7500, Radioddity GA-5WB, RPC ESP32, CA2RXU); name-regex match → display name + icon + family |
 
 ### Notification files (v0.11)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1509,3 +1509,52 @@ A one-line comment in `pubspec.yaml` references this ADR so the constraint is se
 - pub.dev changelog: `https://pub.dev/packages/flutter_blue_plus/changelog`
 - License text: `https://github.com/chipweinberger/flutter_blue_plus/blob/master/LICENSE.md`
 
+---
+
+## ADR-066: Standards-aware BLE-KISS naming and multi-family TNC support
+
+**Date:** 2026-05-01
+**Status:** Accepted
+
+### Context
+
+Until this change, `lib/core/transport/ble_constants.dart` exposed three constants — `kMobilinkdServiceUuid`, `kMobilinkdTxCharUuid`, `kMobilinkdRxCharUuid` — and the BLE scanner UI filtered to a single "Mobilinkd TNC4" preset. The naming implied a vendor-proprietary GATT service, but the UUID `00000001-ba2a-46c9-ae49-01b0961f68bb` is in fact the standardized [`hessu/aprs-specs` BLE-KISS API](https://github.com/hessu/aprs-specs/blob/master/BLE-KISS-API.md) shared by Mobilinkd TNC3/TNC4, PicoAPRS v4, B.B. Link adapter, RPC ESP32 trackers, CA2RXU LoRa trackers, and any future spec-compliant device. The "Mobilinkd-only" framing was misleading and unnecessarily limiting.
+
+A second, older family also exists. The [`ge0rg/bluetoothle-tnc`](https://github.com/ge0rg/bluetoothle-tnc/blob/master/Bluetooth-LE-TNC.md) spec — Family B — is what BTECH UV-Pro firmware ≥ 0.7.11, Vero VR-N76 / VR-N7500, and Radioddity GA-5WB use for KISS-over-BLE (when KISS mode is enabled in the radio menu). KISS framing on the wire is identical across both families; only the GATT plumbing differs.
+
+A user is bringing a BTECH UV-Pro online, and broader market support is on the v0.20 polish agenda regardless. Doing both — the rename and Family B support — together is cleaner than two staggered passes.
+
+### Decision
+
+Rename the constants to reflect the standard:
+  - `kMobilinkdServiceUuid` → `kBleKissServiceUuid`
+  - `kMobilinkdTxCharUuid` → `kBleKissNotifyCharUuid` (the host's RX, also corrects the inverted Tx/Rx naming the original constants used)
+  - `kMobilinkdRxCharUuid` → `kBleKissWriteCharUuid` (the host's TX)
+
+Add Family B constants alongside (`kBenshiKiss*`).
+
+Introduce `BleKissFamily` enum and `BleKissProfile` value object so the transport, connection, and scanner can speak about the family explicitly. Add `bleKissFamilyForServiceUuids(...)` for resolving advertised UUIDs to a family.
+
+Refactor `BleTncTransport` to autodetect the family at connect time from the discovered service list, with an optional `family` constructor hint when scan advertisement data already names it. The Mobilinkd-specific quirks — no `requestConnectionPriority`, no KISS init frames, no SETHARDWARE 0x06 — remain gated to all families conservatively until each is proven safe per-family on real hardware.
+
+The scanner sheet drops the per-model dropdown in favour of a single "Show all Bluetooth devices" toggle; default scans pass both family service UUIDs to `FlutterBluePlus.startScan(withServices: ...)` so the OS performs advertisement filtering. A small `BleTncKnownDevice` registry in `lib/ui/widgets/` renders friendly labels and icons for known hardware (Mobilinkd TNC3/TNC4, PicoAPRS, B.B. Link, BTECH UV-Pro, Vero VR-N76/VR-N7500, Radioddity GA-5WB, RPC ESP32, CA2RXU).
+
+`@Deprecated` aliases for the three old constant names remain for one release to soften the migration for any in-flight branches.
+
+### Consequences
+
+- BLE TNC support is no longer single-vendor. Users with Family B hardware can connect without code changes — the transport autodetects the family.
+- The "Show all Bluetooth devices" toggle keeps a path for DIY ESP32 builds (Nordic UART) and troubleshooting; users still see those devices when the default filter excludes them.
+- `BleConnection.connectToDevice` gained an optional `family` parameter. Callers that don't pass it (background reconnects from a persisted device id) still work — the transport autodetects.
+- Family-specific quirks are now expressible. The current code intentionally applies Mobilinkd's conservative defaults to every family until per-family hardware data justifies relaxation; future ADRs will narrow this as we learn what each family actually tolerates.
+
+### References
+
+- `lib/core/transport/ble_constants.dart` — family enum, profiles, resolver
+- `lib/core/transport/ble_tnc_transport_impl.dart` — autodetect on connect
+- `lib/ui/widgets/ble_tnc_known_device.dart` — friendly-name registry
+- `lib/ui/widgets/ble_scanner_sheet.dart` — multi-family default scan + advanced toggle
+- [hessu/aprs-specs BLE-KISS API](https://github.com/hessu/aprs-specs/blob/master/BLE-KISS-API.md) — Family A spec
+- [ge0rg/bluetoothle-tnc spec](https://github.com/ge0rg/bluetoothle-tnc/blob/master/Bluetooth-LE-TNC.md) — Family B spec
+- [BTECH UV-Pro firmware 0.7.11 KISS announcement](https://baofengtech.com/btech-uv-pro-firmware-update-0-7-11-kiss-mode-now-built-in/)
+

--- a/lib/core/connection/ble_connection_impl.dart
+++ b/lib/core/connection/ble_connection_impl.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../ax25/ax25_encoder.dart';
 import '../packet/aprs_parser.dart';
+import '../transport/ble_constants.dart';
 import '../transport/ble_diagnostics.dart';
 import '../transport/ble_tnc_transport.dart';
 import '../transport/kiss_tnc_transport.dart';
@@ -52,6 +53,13 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   // ---------------------------------------------------------------------------
 
   BluetoothDevice? _device;
+
+  /// Optional family hint for the active session, supplied by the scanner via
+  /// [connectToDevice]. When null, the transport autodetects the family from
+  /// the discovered service list — robust across cold reconnects where the
+  /// scan advertisement isn't available.
+  BleKissFamily? _family;
+
   KissTncTransport? _transport;
 
   StreamSubscription<Uint8List>? _frameSub;
@@ -160,8 +168,15 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   /// Set the target device and connect.
   ///
   /// Stores [device] so that automatic reconnect attempts use the same device.
-  Future<void> connectToDevice(BluetoothDevice device) {
+  /// [family] is an optional hint about which BLE-KISS GATT family this device
+  /// implements — supply it from the scanner when known from advertised
+  /// service UUIDs to skip a round of post-discovery autodetection.
+  Future<void> connectToDevice(
+    BluetoothDevice device, {
+    BleKissFamily? family,
+  }) {
     _device = device;
+    _family = family;
     return connect();
   }
 
@@ -185,6 +200,7 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   Future<void> disconnect() async {
     cancelReconnect();
     _device = null;
+    _family = null;
     await _tearDownTransport(internal: false);
     _emitStatus(ConnectionStatus.disconnected);
     notifyListeners();
@@ -273,7 +289,8 @@ class BleConnection extends MeridianConnection with ReconnectableMixin {
   // ---------------------------------------------------------------------------
 
   KissTncTransport _buildTransport(BluetoothDevice device) =>
-      transportFactory?.call(device) ?? BleTncTransport(device);
+      transportFactory?.call(device) ??
+      BleTncTransport(device, family: _family);
 
   void _buildAndAttachTransport(BluetoothDevice device) {
     final t = _buildTransport(device);

--- a/lib/core/connection/ble_connection_stub.dart
+++ b/lib/core/connection/ble_connection_stub.dart
@@ -54,7 +54,7 @@ class BleConnection extends MeridianConnection {
   Future<void> connect() =>
       throw UnsupportedError('BLE not supported on this platform');
 
-  Future<void> connectToDevice(dynamic device) =>
+  Future<void> connectToDevice(dynamic device, {dynamic family}) =>
       throw UnsupportedError('BLE not supported on this platform');
 
   @override

--- a/lib/core/transport/ble_constants.dart
+++ b/lib/core/transport/ble_constants.dart
@@ -1,7 +1,135 @@
-/// Mobilinkd UART-over-BLE GATT service UUID constants.
+/// GATT service / characteristic UUIDs for the BLE-KISS TNC families
+/// Meridian supports.
 ///
-/// These are public so they can be used by both the transport implementation
-/// and UI code (e.g., BLE scanner filtering by service UUID).
-const kMobilinkdServiceUuid = '00000001-ba2a-46c9-ae49-01b0961f68bb';
-const kMobilinkdTxCharUuid = '00000003-ba2a-46c9-ae49-01b0961f68bb'; // notify
-const kMobilinkdRxCharUuid = '00000002-ba2a-46c9-ae49-01b0961f68bb'; // write
+/// Two non-overlapping UUID families exist in the wild:
+///
+///   - **`aprs-specs` BLE-KISS API** ("standard" family, post-2023). Used by
+///     Mobilinkd TNC3/TNC4, PicoAPRS v4, B.B. Link adapter, RPC ESP32 trackers,
+///     CA2RXU LoRa trackers and any device that follows the spec.
+///     Reference: https://github.com/hessu/aprs-specs/blob/master/BLE-KISS-API.md
+///
+///   - **Benshi / older `bluetoothle-tnc` family** (BTECH UV-Pro, Vero VR-N76,
+///     VR-N7500, Radioddity GA-5WB). KISS available on UV-Pro firmware ≥ 0.7.11
+///     once the user enables KISS mode in the radio menu.
+///     Reference: https://github.com/ge0rg/bluetoothle-tnc/blob/master/Bluetooth-LE-TNC.md
+///
+/// KISS framing on the wire is identical between both families — only the GATT
+/// plumbing differs.
+library;
+
+// ---------------------------------------------------------------------------
+// Family A — aprs-specs BLE-KISS API (Mobilinkd, PicoAPRS, B.B. Link, ...)
+// ---------------------------------------------------------------------------
+
+/// Service UUID for the standard BLE-KISS API.
+const kBleKissServiceUuid = '00000001-ba2a-46c9-ae49-01b0961f68bb';
+
+/// Characteristic the host writes KISS frames to (write w/ response).
+const kBleKissWriteCharUuid = '00000002-ba2a-46c9-ae49-01b0961f68bb';
+
+/// Characteristic the TNC notifies KISS frames on (subscribe / notify).
+const kBleKissNotifyCharUuid = '00000003-ba2a-46c9-ae49-01b0961f68bb';
+
+// ---------------------------------------------------------------------------
+// Family B — Benshi / older bluetoothle-tnc family (BTECH UV-Pro, VR-N76, ...)
+// ---------------------------------------------------------------------------
+
+/// Service UUID for the Benshi/BTECH KISS-over-BLE family.
+const kBenshiKissServiceUuid = '0000ca10-6fb0-4d48-b931-073ed111081b';
+
+/// Characteristic the host writes KISS frames to (write).
+const kBenshiKissWriteCharUuid = '00000001-6fb0-4d48-b931-073ed111081b';
+
+/// Characteristic the TNC notifies KISS frames on (subscribe / notify).
+const kBenshiKissNotifyCharUuid = '00000002-6fb0-4d48-b931-073ed111081b';
+
+// ---------------------------------------------------------------------------
+// Deprecated aliases — kept for one release to ease in-flight PR churn.
+// ---------------------------------------------------------------------------
+
+@Deprecated(
+  'Use kBleKissServiceUuid (renamed to reflect the aprs-specs '
+  'standard, which is shared by Mobilinkd, PicoAPRS, B.B. Link, etc.)',
+)
+const kMobilinkdServiceUuid = kBleKissServiceUuid;
+
+@Deprecated(
+  'Use kBleKissNotifyCharUuid (note: "Tx" / "Rx" naming was '
+  'inverted relative to the host\'s perspective in the old constants — '
+  '"Tx" was the notify characteristic the host listens on)',
+)
+const kMobilinkdTxCharUuid = kBleKissNotifyCharUuid;
+
+@Deprecated(
+  'Use kBleKissWriteCharUuid (note: "Tx" / "Rx" naming was '
+  'inverted relative to the host\'s perspective in the old constants — '
+  '"Rx" was the write characteristic the host writes to)',
+)
+const kMobilinkdRxCharUuid = kBleKissWriteCharUuid;
+
+// ---------------------------------------------------------------------------
+// Family enum + resolver
+// ---------------------------------------------------------------------------
+
+/// Which BLE-KISS GATT family a device implements.
+enum BleKissFamily {
+  /// `aprs-specs` BLE-KISS API. Mobilinkd, PicoAPRS, B.B. Link, RPC, CA2RXU.
+  aprsSpecs,
+
+  /// Older `bluetoothle-tnc` family. BTECH UV-Pro, Vero VR-N76 / VR-N7500,
+  /// Radioddity GA-5WB.
+  benshi,
+}
+
+/// Profile for a BLE-KISS family — the three UUIDs the transport needs.
+class BleKissProfile {
+  const BleKissProfile({
+    required this.family,
+    required this.serviceUuid,
+    required this.writeCharUuid,
+    required this.notifyCharUuid,
+  });
+
+  final BleKissFamily family;
+  final String serviceUuid;
+
+  /// Characteristic the host writes KISS frames to.
+  final String writeCharUuid;
+
+  /// Characteristic the host subscribes to for incoming KISS frames.
+  final String notifyCharUuid;
+
+  static const aprsSpecs = BleKissProfile(
+    family: BleKissFamily.aprsSpecs,
+    serviceUuid: kBleKissServiceUuid,
+    writeCharUuid: kBleKissWriteCharUuid,
+    notifyCharUuid: kBleKissNotifyCharUuid,
+  );
+
+  static const benshi = BleKissProfile(
+    family: BleKissFamily.benshi,
+    serviceUuid: kBenshiKissServiceUuid,
+    writeCharUuid: kBenshiKissWriteCharUuid,
+    notifyCharUuid: kBenshiKissNotifyCharUuid,
+  );
+
+  static const all = [aprsSpecs, benshi];
+
+  static BleKissProfile forFamily(BleKissFamily family) {
+    return all.firstWhere((p) => p.family == family);
+  }
+}
+
+/// Resolve a BLE-KISS family from a list of advertised service UUIDs.
+///
+/// Matching is case-insensitive — different BLE stacks normalize UUID strings
+/// differently. Returns `null` when no advertised UUID matches a known family.
+BleKissFamily? bleKissFamilyForServiceUuids(Iterable<String> advertisedUuids) {
+  final lower = advertisedUuids.map((u) => u.toLowerCase()).toSet();
+  for (final profile in BleKissProfile.all) {
+    if (lower.contains(profile.serviceUuid.toLowerCase())) {
+      return profile.family;
+    }
+  }
+  return null;
+}

--- a/lib/core/transport/ble_tnc_transport_impl.dart
+++ b/lib/core/transport/ble_tnc_transport_impl.dart
@@ -102,8 +102,12 @@ class DefaultBleDeviceAdapter implements BleDeviceAdapter {
 /// BLE KISS TNC transport.
 ///
 /// Implements [KissTncTransport], emitting raw AX.25 frame payloads on
-/// [frameStream]. Connects to Mobilinkd-compatible BLE TNCs via a UART-
-/// over-BLE GATT service.
+/// [frameStream]. Connects to BLE TNCs from either supported GATT family —
+/// the `aprs-specs` BLE-KISS API (Mobilinkd, PicoAPRS, B.B. Link, RPC,
+/// CA2RXU) and the older Benshi/BTECH family (UV-Pro, Vero VR-N76, VR-N7500,
+/// Radioddity GA-5WB). The family is autodetected at connect time from the
+/// discovered service list, or selected explicitly via the `family`
+/// constructor argument when known from advertisement data.
 ///
 /// Connection flow:
 ///   scan → connect → discoverServices
@@ -113,21 +117,31 @@ class DefaultBleDeviceAdapter implements BleDeviceAdapter {
 /// existing [KissFramer]. Outgoing frames are KISS-encoded and split into
 /// MTU-sized chunks before writing to the RX characteristic.
 class BleTncTransport extends KissTncTransport {
+  /// Construct a transport for a given device.
+  ///
+  /// [family] selects the BLE-KISS GATT family. When `null` (default), the
+  /// transport autodetects the family at connect time by scanning the
+  /// discovered service list. Pass a non-null value when the family is already
+  /// known from advertisement data — it skips one round of service-list
+  /// inspection and produces clearer error messages on mismatch.
   BleTncTransport(
     BluetoothDevice device, {
     BleDeviceAdapter? adapter,
-    String serviceUuid = kMobilinkdServiceUuid,
-    String txCharUuid = kMobilinkdTxCharUuid,
-    String rxCharUuid = kMobilinkdRxCharUuid,
+    BleKissFamily? family,
   }) : _adapter = adapter ?? DefaultBleDeviceAdapter(device),
-       _serviceUuid = serviceUuid,
-       _txCharUuid = txCharUuid,
-       _rxCharUuid = rxCharUuid;
+       _hintedFamily = family;
 
   final BleDeviceAdapter _adapter;
-  final String _serviceUuid;
-  final String _txCharUuid;
-  final String _rxCharUuid;
+  final BleKissFamily? _hintedFamily;
+
+  /// The active GATT profile, resolved either from [_hintedFamily] or by
+  /// scanning the post-discovery service list. Null until [connect] succeeds
+  /// far enough to pick one. Exposed as [activeFamily] for diagnostics.
+  BleKissProfile? _profile;
+
+  /// Which BLE-KISS family the live session is using, or `null` when not
+  /// connected. Useful for diagnostics and family-aware UI hints.
+  BleKissFamily? get activeFamily => _profile?.family;
 
   // Effective MTU for outgoing chunk size (payload bytes, not ATT frame size).
   int _mtu = 20;
@@ -217,15 +231,15 @@ class BleTncTransport extends KissTncTransport {
       //     so that a late OS state event still drives the error path.
       _connStateSub ??= _adapter.connectionState.listen(_onBleConnectionState);
 
-      // 2b. Connection-priority request is deliberately skipped.
-      //     `BluetoothDevice.requestConnectionPriority(high)` immediately
-      //     after `connect()` causes the Mobilinkd TNC4 to drop the link
-      //     within the 5.12 s LINK_SUPERVISION_TIMEOUT — the same hardware
-      //     quirk that forbids a fresh `requestMtu()` here (see step 3).
-      //     The 2026-04-30 drive-test diagnostics showed identical 5.4 s
-      //     drop cycles every reconnect with HIGH priority enabled, and a
-      //     stable 110 s keepalive cadence with it disabled. Re-introducing
-      //     this needs hardware-specific gating; track in a follow-up.
+      // 2b. Connection-priority request is deliberately skipped for all
+      //     families. The Mobilinkd TNC4 drops the link within the 5.12 s
+      //     LINK_SUPERVISION_TIMEOUT if `requestConnectionPriority(high)` is
+      //     called immediately after `connect()` (2026-04-30 drive-test
+      //     diagnostics showed identical 5.4 s drop cycles with HIGH priority
+      //     enabled, stable 110 s keepalive cadence with it disabled). The
+      //     Benshi family is untested here — apply the same conservative
+      //     default until proven safe per-family. Re-introducing the priority
+      //     request needs family-aware gating; track in a follow-up.
       BleDiagnostics.I.log(
         BleEventKind.connectionPriorityRequested,
         'priority=balanced (skipped: TNC4 drops link if renegotiated)',
@@ -267,32 +281,37 @@ class BleTncTransport extends KissTncTransport {
         }
       }
 
-      // 5. Find the TNC GATT service.
-      final targetServiceGuid = Guid(_serviceUuid);
-      final service = services!
-          .where((s) => s.serviceUuid == targetServiceGuid)
-          .firstOrNull;
-      if (service == null) {
+      // 5. Resolve the GATT profile (which BLE-KISS family this device speaks)
+      //    and find the matching service. When [_hintedFamily] was provided we
+      //    look for that exact service; otherwise we scan the discovered list
+      //    for the first known family service and adopt it.
+      final profile = _resolveProfile(services!);
+      if (profile == null) {
         throw Exception(
-          'BleTncTransport: service $_serviceUuid not found on ${_adapter.platformName}. '
-          'Is this a Mobilinkd-compatible TNC?',
+          'BleTncTransport: no supported BLE-KISS service found on '
+          '${_adapter.platformName}. Make sure KISS mode is enabled — '
+          'BTECH/Vero radios require enabling KISS in the radio menu.',
         );
       }
+      _profile = profile;
+      final service = services
+          .where((s) => s.serviceUuid == Guid(profile.serviceUuid))
+          .first;
 
-      // 6. Find TX (notify) and RX (write) characteristics.
-      final txGuid = Guid(_txCharUuid);
-      final rxGuid = Guid(_rxCharUuid);
+      // 6. Find the notify (host RX) and write (host TX) characteristics.
+      final notifyGuid = Guid(profile.notifyCharUuid);
+      final writeGuid = Guid(profile.writeCharUuid);
       _txChar = service.characteristics
-          .where((c) => c.characteristicUuid == txGuid)
+          .where((c) => c.characteristicUuid == notifyGuid)
           .firstOrNull;
       _rxChar = service.characteristics
-          .where((c) => c.characteristicUuid == rxGuid)
+          .where((c) => c.characteristicUuid == writeGuid)
           .firstOrNull;
 
       if (_txChar == null || _rxChar == null) {
         throw Exception(
-          'BleTncTransport: TX or RX characteristic not found. '
-          'TX found: ${_txChar != null}, RX found: ${_rxChar != null}',
+          'BleTncTransport: notify or write characteristic not found for '
+          '${profile.family.name}. notify=${_txChar != null} write=${_rxChar != null}',
         );
       }
 
@@ -309,7 +328,7 @@ class BleTncTransport extends KissTncTransport {
       );
       BleDiagnostics.I.log(
         BleEventKind.connectSuccess,
-        'device=${_adapter.platformName} mtu=$_mtu',
+        'device=${_adapter.platformName} family=${profile.family.name} mtu=$_mtu',
       );
 
       // 10. Start the idle keepalive timer.
@@ -318,15 +337,18 @@ class BleTncTransport extends KissTncTransport {
       //    timeout. The keepalive sends a single TXDELAY frame every
       //    [_keepaliveInterval] (currently 4 s — see field doc).
       //
-      //    NOTE: Do NOT call _sendKissInit() here. Sending the five standard
-      //    KISS parameter frames (TXDELAY/PERSIST/SLOTTIME/TXTAIL/FULLDUPLEX)
-      //    causes the Mobilinkd TNC4 to reinitialise its modem, which takes its
-      //    BLE radio dark for ~5 s — long enough for the supervision timeout
-      //    (5.12 s) to expire and drop the connection. The Mobilinkd retains its
-      //    own configuration persistently; the host does not need to reprogram
-      //    these values on every connect.
-      //    DO NOT use command 0x06 (SETHARDWARE) either — that is Mobilinkd's
-      //    proprietary config protocol and also causes an immediate disconnect.
+      //    NOTE: Do NOT call _sendKissInit() here on any family. On the
+      //    Mobilinkd TNC4 (aprs-specs family), sending the five standard KISS
+      //    parameter frames (TXDELAY/PERSIST/SLOTTIME/TXTAIL/FULLDUPLEX)
+      //    causes the modem to reinitialise — its BLE radio goes dark for
+      //    ~5 s, long enough for the supervision timeout (5.12 s) to expire
+      //    and drop the connection. The Mobilinkd retains its own
+      //    configuration persistently. The Benshi family is untested for KISS
+      //    init behaviour; default to skipping until proven safe.
+      //    DO NOT use command 0x06 (SETHARDWARE) on any family either — it is
+      //    Mobilinkd's proprietary config protocol and causes an immediate
+      //    disconnect on aprs-specs hardware. Benshi devices ignore unknown
+      //    KISS commands today but that's incidental, not contractual.
       _resetKeepalive();
     } catch (e) {
       debugPrint('BleTncTransport connect failed: $e');
@@ -381,6 +403,7 @@ class BleTncTransport extends KissTncTransport {
     } catch (_) {}
     _txChar = null;
     _rxChar = null;
+    _profile = null;
     try {
       await _adapter.disconnect();
     } catch (_) {}
@@ -419,6 +442,33 @@ class BleTncTransport extends KissTncTransport {
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------
+
+  /// Pick the GATT profile to use for this connection.
+  ///
+  /// Honours [_hintedFamily] when provided — that's the path scan-driven
+  /// connects take, since the family is already known from advertisement data.
+  /// When no hint is provided (cold reconnect from persisted device id),
+  /// scan the discovered service list for the first known family.
+  BleKissProfile? _resolveProfile(List<BluetoothService> services) {
+    final advertised = services
+        .map((s) => s.serviceUuid.str.toLowerCase())
+        .toSet();
+    if (_hintedFamily != null) {
+      final hinted = BleKissProfile.forFamily(_hintedFamily);
+      if (advertised.contains(hinted.serviceUuid.toLowerCase())) {
+        return hinted;
+      }
+      // Hint was wrong — fall through to autodetect rather than fail outright.
+      // This is forgiving when a user's saved device ID belongs to a model
+      // whose family they later changed (e.g. firmware swap).
+    }
+    for (final profile in BleKissProfile.all) {
+      if (advertised.contains(profile.serviceUuid.toLowerCase())) {
+        return profile;
+      }
+    }
+    return null;
+  }
 
   void _onBleChunk(List<int> chunk) {
     _kissFramer.addBytes(chunk);
@@ -483,7 +533,7 @@ class BleTncTransport extends KissTncTransport {
   /// Fires when the link has been idle for [_keepaliveInterval].
   ///
   /// Sends a single KISS TXDELAY frame — harmless to any KISS TNC and
-  /// sufficient to reset the Mobilinkd idle timer. Uses write-without-response
+  /// sufficient to reset the peripheral's idle timer. Uses write-without-response
   /// to avoid ATT round-trip latency on a fire-and-forget keepalive.
   ///
   /// On write failure the keepalive retries exactly once after a short delay

--- a/lib/core/transport/ble_tnc_transport_stub.dart
+++ b/lib/core/transport/ble_tnc_transport_stub.dart
@@ -11,7 +11,7 @@ import 'kiss_tnc_transport.dart';
 /// Stub [BleTncTransport] for platforms where BLE is not available (web).
 class BleTncTransport extends KissTncTransport {
   // ignore: avoid_unused_constructor_parameters
-  BleTncTransport(BluetoothDevice device, {dynamic adapter});
+  BleTncTransport(BluetoothDevice device, {dynamic adapter, dynamic family});
 
   @override
   Stream<Uint8List> get frameStream =>

--- a/lib/ui/widgets/ble_scanner_sheet.dart
+++ b/lib/ui/widgets/ble_scanner_sheet.dart
@@ -8,44 +8,20 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import '../../core/connection/ble_connection.dart';
 import '../../core/transport/ble_constants.dart';
-import '../../core/transport/tnc_preset.dart';
-
-/// Filter option for the BLE device scanner.
-///
-/// [_BleFilterOption.all] shows every discovered device. A preset-based
-/// option limits results to devices whose advertised GATT service UUIDs
-/// match the known UUID for that TNC model.
-class _BleFilterOption {
-  const _BleFilterOption({required this.label, this.serviceUuid});
-
-  /// Display name shown in the dropdown.
-  final String label;
-
-  /// If non-null, only devices advertising this service UUID are shown.
-  final String? serviceUuid;
-
-  static const _BleFilterOption all = _BleFilterOption(label: 'All Devices');
-
-  /// One entry per TNC preset with a known BLE service UUID.
-  static final List<_BleFilterOption> presetOptions = [
-    _BleFilterOption(
-      label: TncPreset.mobilinkdTnc4.displayName,
-      serviceUuid: kMobilinkdServiceUuid,
-    ),
-  ];
-
-  static List<_BleFilterOption> get values => [all, ...presetOptions];
-}
+import 'ble_tnc_known_device.dart';
 
 /// Bottom sheet for scanning and connecting to a BLE KISS TNC.
 ///
-/// Scans for nearby BLE devices and optionally filters results by TNC type
-/// selected in the dropdown. "All Devices" shows everything; selecting a
-/// specific TNC model limits results to devices advertising that TNC's GATT
-/// service UUID.
+/// Default behaviour scans only for devices advertising one of the supported
+/// BLE-KISS GATT services (the `aprs-specs` family — Mobilinkd, PicoAPRS,
+/// B.B. Link, RPC, CA2RXU — and the Benshi/BTECH family — UV-Pro, Vero
+/// VR-N76 / VR-N7500, Radioddity GA-5WB). The "Show all Bluetooth devices"
+/// switch lifts the filter for DIY hardware (e.g. ESP32 builds advertising
+/// Nordic UART) or troubleshooting.
 ///
-/// Tapping "Connect" on a device calls [BleConnection.connectToDevice] and
-/// closes the sheet (or calls [onBack] when embedded inline).
+/// Tapping "Connect" on a device calls [BleConnection.connectToDevice] (with
+/// the resolved family hint when known) and closes the sheet (or calls
+/// [onBack] when embedded inline).
 ///
 /// Set [showDragHandle] to false and provide [onBack] when embedding this
 /// widget inside another sheet instead of presenting it as a standalone modal.
@@ -81,7 +57,7 @@ class BleScannerSheet extends StatefulWidget {
 
 class _BleScannerSheetState extends State<BleScannerSheet> {
   bool _scanning = false;
-  _BleFilterOption _filter = _BleFilterOption.presetOptions.first;
+  bool _showAllDevices = false;
   String? _bleError;
   String? _connectingDeviceId;
 
@@ -135,8 +111,18 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
 
     _scanSub?.cancel();
 
+    // When the "show all" toggle is off, ask the OS to filter advertisements
+    // at parse time using the supported family service UUIDs. This is
+    // strictly equivalent to filtering in-app, but cheaper on the radio.
+    final withServices = _showAllDevices
+        ? const <Guid>[]
+        : [Guid(kBleKissServiceUuid), Guid(kBenshiKissServiceUuid)];
+
     try {
-      await FlutterBluePlus.startScan(timeout: const Duration(seconds: 15));
+      await FlutterBluePlus.startScan(
+        timeout: const Duration(seconds: 15),
+        withServices: withServices,
+      );
     } on FlutterBluePlusException catch (e) {
       setState(() {
         _bleError = _friendlyBleError(e.description ?? e.toString());
@@ -149,14 +135,6 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
       if (!mounted) return;
       setState(() {
         for (final r in results) {
-          if (_filter.serviceUuid != null) {
-            final advertisedUuids = r.advertisementData.serviceUuids
-                .map((g) => g.str.toLowerCase())
-                .toList();
-            if (!advertisedUuids.contains(_filter.serviceUuid!.toLowerCase())) {
-              continue;
-            }
-          }
           _deviceMap[r.device.remoteId] = r;
         }
       });
@@ -179,7 +157,14 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
     });
 
     try {
-      await widget.bleConnection.connectToDevice(result.device);
+      // Resolve the GATT family from advertisement data so the transport can
+      // skip post-discovery autodetection. Falls back to null (autodetect)
+      // when the device only advertised an unrelated service.
+      final advertisedUuids = result.advertisementData.serviceUuids.map(
+        (g) => g.str,
+      );
+      final family = bleKissFamilyForServiceUuids(advertisedUuids);
+      await widget.bleConnection.connectToDevice(result.device, family: family);
       if (mounted) {
         if (widget.onBack != null) {
           widget.onBack!();
@@ -301,50 +286,57 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
             const SizedBox(height: 16),
           ],
 
-          // Controls row: scan button + TNC filter dropdown.
+          // Scan controls.
           if (_isBlePlatform && _bleError == null) ...[
             Row(
               children: [
                 FilledButton.icon(
                   onPressed: _scanning ? null : _startScan,
                   icon: Icon(_scanning ? Symbols.stop : Symbols.search),
-                  label: Text(_scanning ? 'Scanning\u2026' : 'Scan'),
+                  label: Text(_scanning ? 'Scanning…' : 'Scan'),
                 ),
                 const SizedBox(width: 12),
-                if (_scanning) ...[
+                if (_scanning)
                   SizedBox(
                     width: 16,
                     height: 16,
                     child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                   ),
-                  const SizedBox(width: 8),
-                ],
-                const Spacer(),
-                // TNC type filter dropdown.
-                DropdownButton<_BleFilterOption>(
-                  value: _filter,
-                  isDense: true,
-                  items: _BleFilterOption.values.map((option) {
-                    return DropdownMenuItem<_BleFilterOption>(
-                      value: option,
-                      child: Text(
-                        option.label,
-                        style: theme.textTheme.bodySmall,
-                      ),
-                    );
-                  }).toList(),
-                  onChanged: (option) {
-                    if (option != null) {
-                      setState(() {
-                        _filter = option;
-                        _deviceMap.clear();
-                      });
-                    }
-                  },
-                ),
               ],
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 4),
+
+            // "Show all Bluetooth devices" advanced toggle.
+            //
+            // The default scan filters advertisements to known BLE-KISS family
+            // service UUIDs. Lifting the filter is occasionally necessary for
+            // DIY ESP32 builds that advertise Nordic UART (or no service UUID
+            // at all) and for troubleshooting when a TNC isn't appearing.
+            SwitchListTile.adaptive(
+              title: Text(
+                'Show all Bluetooth devices',
+                style: theme.textTheme.bodyMedium,
+              ),
+              subtitle: Text(
+                _showAllDevices
+                    ? 'Showing every BLE device in range.'
+                    : 'Filtering to known TNC families.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
+              ),
+              value: _showAllDevices,
+              onChanged: _scanning
+                  ? null
+                  : (value) {
+                      setState(() {
+                        _showAllDevices = value;
+                        _deviceMap.clear();
+                      });
+                    },
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+            ),
 
             // Scanning progress indicator.
             if (_scanning) const LinearProgressIndicator(),
@@ -354,21 +346,41 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
           // Device list.
           if (devices.isNotEmpty)
             ...devices.map((result) {
-              final name = result.device.platformName.isNotEmpty
+              final advertisedName = result.device.platformName.isNotEmpty
                   ? result.device.platformName
-                  : result.device.remoteId.str;
+                  : null;
+              final known = BleTncKnownDevice.matchByName(advertisedName);
+              final displayName =
+                  known?.displayName ??
+                  advertisedName ??
+                  result.device.remoteId.str;
+              final subtitle = known != null && advertisedName != null
+                  ? '$advertisedName • RSSI ${result.rssi} dBm'
+                  : 'RSSI: ${result.rssi} dBm';
+              final leadingIcon = known?.icon ?? Symbols.bluetooth;
               final isConnecting =
                   _connectingDeviceId == result.device.remoteId.str;
 
               return Card(
                 margin: const EdgeInsets.only(bottom: 8),
                 child: ListTile(
-                  leading: Icon(_rssiIcon(result.rssi)),
-                  title: Text(name),
-                  subtitle: Text(
-                    'RSSI: ${result.rssi} dBm',
-                    style: theme.textTheme.bodySmall,
+                  leading: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      Icon(leadingIcon),
+                      Positioned(
+                        right: -2,
+                        bottom: -2,
+                        child: Icon(
+                          _rssiIcon(result.rssi),
+                          size: 12,
+                          color: theme.colorScheme.outline,
+                        ),
+                      ),
+                    ],
                   ),
+                  title: Text(displayName),
+                  subtitle: Text(subtitle, style: theme.textTheme.bodySmall),
                   trailing: isConnecting
                       ? SizedBox(
                           width: 24,
@@ -406,7 +418,11 @@ class _BleScannerSheetState extends State<BleScannerSheet> {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      'Make sure your TNC is powered on and in range.',
+                      _showAllDevices
+                          ? 'Make sure your device is powered on and advertising.'
+                          : 'Make sure your TNC is powered on and in range. '
+                                'Toggle "Show all Bluetooth devices" if your TNC '
+                                'is not in the supported list.',
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.outline,
                       ),

--- a/lib/ui/widgets/ble_tnc_known_device.dart
+++ b/lib/ui/widgets/ble_tnc_known_device.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '../../core/transport/ble_constants.dart';
+
+/// A known BLE-KISS TNC model — used by the scanner UI to render a friendly
+/// label + icon for advertised devices.
+///
+/// The registry is purely cosmetic; it does not gate connection. Devices that
+/// do not match any known entry still appear with their advertised name and a
+/// generic Bluetooth icon.
+@immutable
+class BleTncKnownDevice {
+  const BleTncKnownDevice({
+    required this.displayName,
+    required this.namePattern,
+    required this.family,
+    required this.icon,
+  });
+
+  /// Human-readable model name shown in the scanner list.
+  final String displayName;
+
+  /// Regex matched against the advertised platform name (case-insensitive).
+  final RegExp namePattern;
+
+  /// Which GATT family this device speaks.
+  final BleKissFamily family;
+
+  /// Icon shown alongside the model name.
+  final IconData icon;
+
+  /// All known devices, ordered roughly by likely user popularity.
+  ///
+  /// Add new entries here as we test new hardware. Patterns are
+  /// case-insensitive and anchored to the start of the advertised name so
+  /// "Mobilinkd TNC4 1234" matches `^Mobilinkd TNC4` while "Bob's Mobilinkd"
+  /// does not.
+  static final List<BleTncKnownDevice> all = [
+    BleTncKnownDevice(
+      displayName: 'Mobilinkd TNC4',
+      namePattern: RegExp(r'^Mobilinkd\s*TNC4', caseSensitive: false),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.router,
+    ),
+    BleTncKnownDevice(
+      displayName: 'Mobilinkd TNC3',
+      namePattern: RegExp(r'^Mobilinkd\s*TNC3', caseSensitive: false),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.router,
+    ),
+    BleTncKnownDevice(
+      displayName: 'PicoAPRS v4',
+      namePattern: RegExp(r'^PicoAPRS', caseSensitive: false),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.router,
+    ),
+    BleTncKnownDevice(
+      displayName: 'B.B. Link',
+      namePattern: RegExp(
+        r'^(B\.?B\.?[\s-]*Link|BBLink)',
+        caseSensitive: false,
+      ),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.cable,
+    ),
+    BleTncKnownDevice(
+      displayName: 'BTECH UV-Pro',
+      namePattern: RegExp(r'^(BTECH\s*)?UV[\s-]*PRO', caseSensitive: false),
+      family: BleKissFamily.benshi,
+      icon: Symbols.radio,
+    ),
+    BleTncKnownDevice(
+      displayName: 'Vero VR-N76',
+      namePattern: RegExp(r'^VR[\s-]*N76', caseSensitive: false),
+      family: BleKissFamily.benshi,
+      icon: Symbols.radio,
+    ),
+    BleTncKnownDevice(
+      displayName: 'Vero VR-N7500',
+      namePattern: RegExp(r'^VR[\s-]*N7500', caseSensitive: false),
+      family: BleKissFamily.benshi,
+      icon: Symbols.radio,
+    ),
+    BleTncKnownDevice(
+      displayName: 'Radioddity GA-5WB',
+      namePattern: RegExp(
+        r'^(Radioddity\s*)?GA[\s-]*5WB',
+        caseSensitive: false,
+      ),
+      family: BleKissFamily.benshi,
+      icon: Symbols.radio,
+    ),
+    BleTncKnownDevice(
+      displayName: 'RPC ESP32 APRS',
+      namePattern: RegExp(
+        r'^(RPC.*APRS|ESP32[\s-]*APRS)',
+        caseSensitive: false,
+      ),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.developer_board,
+    ),
+    BleTncKnownDevice(
+      displayName: 'CA2RXU LoRa Tracker',
+      namePattern: RegExp(r'^(LoRa[\s-]*Tracker|CA2RXU)', caseSensitive: false),
+      family: BleKissFamily.aprsSpecs,
+      icon: Symbols.developer_board,
+    ),
+  ];
+
+  /// Look up the registry by advertised name. Returns `null` for devices that
+  /// don't match any known pattern.
+  static BleTncKnownDevice? matchByName(String? advertisedName) {
+    if (advertisedName == null || advertisedName.isEmpty) return null;
+    for (final entry in all) {
+      if (entry.namePattern.hasMatch(advertisedName)) return entry;
+    }
+    return null;
+  }
+}

--- a/test/core/transport/ble_constants_test.dart
+++ b/test/core/transport/ble_constants_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/transport/ble_constants.dart';
+
+void main() {
+  group('bleKissFamilyForServiceUuids', () {
+    test('matches the aprs-specs family service UUID', () {
+      final family = bleKissFamilyForServiceUuids([kBleKissServiceUuid]);
+      expect(family, BleKissFamily.aprsSpecs);
+    });
+
+    test('matches the Benshi family service UUID', () {
+      final family = bleKissFamilyForServiceUuids([kBenshiKissServiceUuid]);
+      expect(family, BleKissFamily.benshi);
+    });
+
+    test('matching is case-insensitive', () {
+      final family = bleKissFamilyForServiceUuids([
+        kBleKissServiceUuid.toUpperCase(),
+      ]);
+      expect(family, BleKissFamily.aprsSpecs);
+    });
+
+    test('returns null when no advertised UUID matches a known family', () {
+      final family = bleKissFamilyForServiceUuids([
+        '0000180f-0000-1000-8000-00805f9b34fb', // battery service
+      ]);
+      expect(family, isNull);
+    });
+
+    test('picks the first matching family when both are advertised', () {
+      // Devices advertising both shouldn't exist in practice, but the resolver
+      // must still pick deterministically — order is BleKissProfile.all.
+      final family = bleKissFamilyForServiceUuids([
+        kBenshiKissServiceUuid,
+        kBleKissServiceUuid,
+      ]);
+      expect(family, BleKissFamily.aprsSpecs);
+    });
+
+    test('handles an empty list', () {
+      expect(bleKissFamilyForServiceUuids(const []), isNull);
+    });
+  });
+
+  group('BleKissProfile', () {
+    test('aprsSpecs profile uses the standard UUIDs', () {
+      const p = BleKissProfile.aprsSpecs;
+      expect(p.serviceUuid, kBleKissServiceUuid);
+      expect(p.writeCharUuid, kBleKissWriteCharUuid);
+      expect(p.notifyCharUuid, kBleKissNotifyCharUuid);
+      expect(p.family, BleKissFamily.aprsSpecs);
+    });
+
+    test('benshi profile uses the BTECH/Benshi UUIDs', () {
+      const p = BleKissProfile.benshi;
+      expect(p.serviceUuid, kBenshiKissServiceUuid);
+      expect(p.writeCharUuid, kBenshiKissWriteCharUuid);
+      expect(p.notifyCharUuid, kBenshiKissNotifyCharUuid);
+      expect(p.family, BleKissFamily.benshi);
+    });
+
+    test('forFamily returns the right profile', () {
+      expect(
+        BleKissProfile.forFamily(BleKissFamily.aprsSpecs).serviceUuid,
+        kBleKissServiceUuid,
+      );
+      expect(
+        BleKissProfile.forFamily(BleKissFamily.benshi).serviceUuid,
+        kBenshiKissServiceUuid,
+      );
+    });
+
+    test('all profiles have distinct service UUIDs', () {
+      final uuids = BleKissProfile.all.map((p) => p.serviceUuid).toSet();
+      expect(uuids.length, BleKissProfile.all.length);
+    });
+  });
+}

--- a/test/ui/widgets/ble_tnc_known_device_test.dart
+++ b/test/ui/widgets/ble_tnc_known_device_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/transport/ble_constants.dart';
+import 'package:meridian_aprs/ui/widgets/ble_tnc_known_device.dart';
+
+void main() {
+  group('BleTncKnownDevice.matchByName', () {
+    test('returns null for null / empty input', () {
+      expect(BleTncKnownDevice.matchByName(null), isNull);
+      expect(BleTncKnownDevice.matchByName(''), isNull);
+    });
+
+    test('returns null for unknown / generic Bluetooth devices', () {
+      expect(BleTncKnownDevice.matchByName("iPhone of Bob"), isNull);
+      expect(BleTncKnownDevice.matchByName('AirPods Pro'), isNull);
+      expect(BleTncKnownDevice.matchByName('Random ESP32'), isNull);
+    });
+
+    test('matches Mobilinkd TNC4 advertised names', () {
+      final m = BleTncKnownDevice.matchByName('Mobilinkd TNC4 ABCD');
+      expect(m, isNotNull);
+      expect(m!.displayName, 'Mobilinkd TNC4');
+      expect(m.family, BleKissFamily.aprsSpecs);
+    });
+
+    test('matches Mobilinkd TNC3 advertised names', () {
+      final m = BleTncKnownDevice.matchByName('Mobilinkd TNC3 1234');
+      expect(m?.displayName, 'Mobilinkd TNC3');
+      expect(m?.family, BleKissFamily.aprsSpecs);
+    });
+
+    test('matches PicoAPRS', () {
+      final m = BleTncKnownDevice.matchByName('PicoAPRS V4 1234');
+      expect(m?.displayName, 'PicoAPRS v4');
+      expect(m?.family, BleKissFamily.aprsSpecs);
+    });
+
+    test('matches B.B. Link variants', () {
+      expect(
+        BleTncKnownDevice.matchByName('BB-Link 0001')?.displayName,
+        'B.B. Link',
+      );
+      expect(
+        BleTncKnownDevice.matchByName('B.B. Link 1234')?.displayName,
+        'B.B. Link',
+      );
+    });
+
+    test('matches BTECH UV-Pro variants and resolves to Benshi family', () {
+      expect(
+        BleTncKnownDevice.matchByName('UV-PRO')?.family,
+        BleKissFamily.benshi,
+      );
+      expect(
+        BleTncKnownDevice.matchByName('BTECH UV-PRO')?.family,
+        BleKissFamily.benshi,
+      );
+      expect(
+        BleTncKnownDevice.matchByName('UV PRO 1234')?.displayName,
+        'BTECH UV-Pro',
+      );
+    });
+
+    test('matches Vero VR-N76 / VR-N7500', () {
+      expect(
+        BleTncKnownDevice.matchByName('VR-N76 1234')?.displayName,
+        'Vero VR-N76',
+      );
+      expect(
+        BleTncKnownDevice.matchByName('VR-N7500')?.displayName,
+        'Vero VR-N7500',
+      );
+    });
+
+    test('matches Radioddity GA-5WB', () {
+      expect(
+        BleTncKnownDevice.matchByName('GA-5WB 0001')?.family,
+        BleKissFamily.benshi,
+      );
+      expect(
+        BleTncKnownDevice.matchByName('Radioddity GA-5WB')?.displayName,
+        'Radioddity GA-5WB',
+      );
+    });
+
+    test('every registry entry has a non-empty display name and pattern', () {
+      for (final entry in BleTncKnownDevice.all) {
+        expect(entry.displayName, isNotEmpty);
+        expect(entry.namePattern.pattern, isNotEmpty);
+      }
+    });
+
+    test('every registry entry pattern is anchored to the start', () {
+      // Stops "X mentions Mobilinkd somewhere" from matching the wrong row.
+      for (final entry in BleTncKnownDevice.all) {
+        expect(
+          entry.namePattern.pattern.startsWith('^'),
+          isTrue,
+          reason: 'pattern for ${entry.displayName} must start with ^',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Renames the BLE-KISS GATT constants from Mobilinkd-specific names to standards-aware names (`kBleKissServiceUuid`, etc.) — the UUIDs were always the published [`aprs-specs` BLE-KISS API](https://github.com/hessu/aprs-specs/blob/master/BLE-KISS-API.md), so this rename immediately broadens spec-compliant device support (Mobilinkd TNC3/TNC4, PicoAPRS v4, B.B. Link, RPC ESP32, CA2RXU).
- Adds first-class support for the Benshi / `bluetoothle-tnc` family (BTECH UV-Pro, Vero VR-N76 / VR-N7500, Radioddity GA-5WB) via a second GATT profile. KISS framing is identical between families — only the GATT plumbing differs, so a single `BleTncTransport` autodetects the family at connect time.
- Replaces the per-model dropdown in the BLE scanner with a default scan across both family service UUIDs, plus a `Show all Bluetooth devices` advanced toggle for DIY hardware. Adds a `BleTncKnownDevice` registry so known TNCs (10 models) render with friendly labels + icons. ADR-066 captures the rationale.

## Test plan
- [x] `dart format .` clean
- [x] `flutter analyze` clean
- [x] `flutter test` — 741 tests passing
- [x] Manual: Mobilinkd TNC4 connects under the new aprs-specs path with friendly label/icon
- [x] Manual: BTECH UV-Pro (firmware ≥ 0.7.11, KISS mode enabled in radio menu) connects via Benshi family path and round-trips KISS frames
- [x] Manual: `Show all Bluetooth devices` toggle lifts the service-UUID filter
- [x] Manual: cold-reconnect autodetects family from discovered services when the scan hint isn't available

🤖 Generated with [Claude Code](https://claude.com/claude-code)