### PR TITLE
feat(persistence): SQLite-backed storage via drift (v0.19, ADR-062)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -4,7 +4,7 @@ A consolidated reference of what Meridian can do today, organized by user-facing
 
 > **Maintenance:** This document is generated and maintained by Claude Code as part of milestone close-out. When a milestone changes user-visible capabilities or platform behavior, update this file alongside `ROADMAP.md` and `DECISIONS.md`. Source of truth is the codebase, not aspiration — partially implemented or untested capabilities are flagged explicitly.
 
-**Last updated:** 2026-04-26 (v0.18 Foundations shipped; v0.19 Performance next)
+**Last updated:** 2026-05-24 (v0.19 Performance shipped; v0.20 Polish & A11y next)
 
 ---
 
@@ -95,7 +95,7 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 | Capability | Detail |
 |---|---|
 | Direct messages | One-to-one APRS messaging with retry; spec §14 backoff `[30, 60, 120, 240, 480]` s |
-| Persistence | Conversations + message entries stored in SQLite via drift (ADR-062); survive restart. In-flight (pending/retrying) sends demoted to failed on reload — timers don't resume |
+| Persistence | Conversations + message entries stored in SQLite via drift (ADR-067); survive restart. In-flight (pending/retrying) sends demoted to failed on reload — timers don't resume |
 | Configurable retention | Message history retention in Settings → History (default 90 days, `0 = Forever`); prunes direct + group entries and sweeps empty conversations |
 | ACK / REJ | Sent and received; ACK is exact-callsign-match only |
 | Cross-SSID matching | Capture-always: any message addressed to any SSID of operator's base callsign is persisted (ADR-054) |
@@ -104,8 +104,8 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 | Addressee badge | Subdued chip on bubbles when `addressee ≠ currentStation` |
 | Conversation grouping | Threads with 2+ SSIDs of the same base callsign render under a non-collapsible group header with aggregated unread count |
 | Groups | `ALL` / `CQ` / `QST` seeded idempotently + custom; per-group `notify` / `matchMode` / `replyMode` (ADR-056) |
-| Bulletins | `BLN0`–`BLN9` general and `BLN*NAME` named; SQLite-backed receive store (ADR-062) with `(source, addressee)` upsert and retention sweeper |
-| Outgoing bulletins | Fixed-interval retransmission + initial pulse + max lifetime (ADR-057); main-isolate scheduler + parallel 30 s background-isolate timer, both reading/writing the shared SQLite DB so background transmissions no longer drift out of sync on resume (ADR-062 fixes ADR-057/061) |
+| Bulletins | `BLN0`–`BLN9` general and `BLN*NAME` named; SQLite-backed receive store (ADR-067) with `(source, addressee)` upsert and retention sweeper |
+| Outgoing bulletins | Fixed-interval retransmission + initial pulse + max lifetime (ADR-057); main-isolate scheduler + parallel 30 s background-isolate timer, both reading/writing the shared SQLite DB so background transmissions no longer drift out of sync on resume (ADR-067 fixes ADR-057/061) |
 | Bulletin distance filter | Client-side haversine vs operator manual position; RF + named groups never distance-filtered |
 | APRS-IS group filter | `g/BLN0..9` always; `g/BLN*NAME` per enabled subscription (ADR-058); rebuilt on subscription change |
 | Matcher precedence | Bulletin → Direct → Group (ADR-055) — load-bearing for ACK correctness |
@@ -135,7 +135,7 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 ## 6. Station Management
 
 - Real-time station list driven by `StationService` packetStream
-- **SQLite-backed persistence** via drift (ADR-062): stations, position history, and the packet log survive app restarts; the map repopulates on cold start before any new packets arrive
+- **SQLite-backed persistence** via drift (ADR-067): stations, position history, and the packet log survive app restarts; the map repopulates on cold start before any new packets arrive
 - Snapshot getters (`currentStations`, `recentPackets`) are kept in sync with the database via `watch()` streams; packet snapshot capped at 5000 in memory, the underlying table bounded by retention
 - Full-screen station list screen
 - Station detail sheet with summary (callsign, symbol, comment, last heard, capabilities)

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -95,6 +95,8 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 | Capability | Detail |
 |---|---|
 | Direct messages | One-to-one APRS messaging with retry; spec §14 backoff `[30, 60, 120, 240, 480]` s |
+| Persistence | Conversations + message entries stored in SQLite via drift (ADR-062); survive restart. In-flight (pending/retrying) sends demoted to failed on reload — timers don't resume |
+| Configurable retention | Message history retention in Settings → History (default 90 days, `0 = Forever`); prunes direct + group entries and sweeps empty conversations |
 | ACK / REJ | Sent and received; ACK is exact-callsign-match only |
 | Cross-SSID matching | Capture-always: any message addressed to any SSID of operator's base callsign is persisted (ADR-054) |
 | `showOtherSsids` | Default off; controls conversation list / thread visibility; non-destructive |
@@ -102,8 +104,8 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 | Addressee badge | Subdued chip on bubbles when `addressee ≠ currentStation` |
 | Conversation grouping | Threads with 2+ SSIDs of the same base callsign render under a non-collapsible group header with aggregated unread count |
 | Groups | `ALL` / `CQ` / `QST` seeded idempotently + custom; per-group `notify` / `matchMode` / `replyMode` (ADR-056) |
-| Bulletins | `BLN0`–`BLN9` general and `BLN*NAME` named; receive store with `(source, addressee)` upsert and retention sweeper |
-| Outgoing bulletins | Fixed-interval retransmission + initial pulse + max lifetime (ADR-057); main-isolate scheduler + parallel 30 s background-isolate timer |
+| Bulletins | `BLN0`–`BLN9` general and `BLN*NAME` named; SQLite-backed receive store (ADR-062) with `(source, addressee)` upsert and retention sweeper |
+| Outgoing bulletins | Fixed-interval retransmission + initial pulse + max lifetime (ADR-057); main-isolate scheduler + parallel 30 s background-isolate timer, both reading/writing the shared SQLite DB so background transmissions no longer drift out of sync on resume (ADR-062 fixes ADR-057/061) |
 | Bulletin distance filter | Client-side haversine vs operator manual position; RF + named groups never distance-filtered |
 | APRS-IS group filter | `g/BLN0..9` always; `g/BLN*NAME` per enabled subscription (ADR-058); rebuilt on subscription change |
 | Matcher precedence | Bulletin → Direct → Group (ADR-055) — load-bearing for ACK correctness |
@@ -133,12 +135,13 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 ## 6. Station Management
 
 - Real-time station list driven by `StationService` packetStream
-- 500-packet rolling buffer in memory
+- **SQLite-backed persistence** via drift (ADR-062): stations, position history, and the packet log survive app restarts; the map repopulates on cold start before any new packets arrive
+- Snapshot getters (`currentStations`, `recentPackets`) are kept in sync with the database via `watch()` streams; packet snapshot capped at 5000 in memory, the underlying table bounded by retention
 - Full-screen station list screen
 - Station detail sheet with summary (callsign, symbol, comment, last heard, capabilities)
-- Per-station track history (capped at 500 timestamped positions, time-filter-bounded)
+- Per-station track history (capped at 500 timestamped positions, time-filter-bounded; `ON DELETE CASCADE` cleans history when a station is pruned)
 - Station search by callsign + place
-- No persistent station database yet (SQLite/drift evaluation scheduled for v0.19)
+- Retention (packet log / station history) configurable in Settings → History; pruned by a 60 s timer + immediately on setting change
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1558,3 +1558,52 @@ The scanner sheet drops the per-model dropdown in favour of a single "Show all B
 - [ge0rg/bluetoothle-tnc spec](https://github.com/ge0rg/bluetoothle-tnc/blob/master/Bluetooth-LE-TNC.md) — Family B spec
 - [BTECH UV-Pro firmware 0.7.11 KISS announcement](https://baofengtech.com/btech-uv-pro-firmware-update-0-7-11-kiss-mode-now-built-in/)
 
+---
+
+## ADR-062: SQLite persistence via drift
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Milestone:** v0.19 — Performance
+**Closes:** #87 (SQLite/drift evaluation spike)
+**Related:** ADR-025 (Android background isolate), ADR-032 (iOS background model), ADR-057 (BulletinService retransmission), ADR-061 (APRS-IS background RX)
+
+> This is the **as-built** record. The pre-implementation design sketch lives at `docs/adrs/ADR-062-sqlite-drift.md`; where the two differ, this entry is authoritative.
+
+### Context
+
+Structured/volumetric data had accreted across services with mismatched storage: `StationService` stations + packets and `MessageService`/`BulletinService` conversations + bulletins all serialized to SharedPreferences JSON blobs (stations/packets were JSON-on-prefs, not in-memory-only as the original sketch assumed). Problems: full-deserialization for every query/prune, no schema evolution, and — most importantly — **foreground/background state drift** (ADR-057/061): the Android background isolate mutated the outgoing-bulletin JSON while the main isolate held a stale in-memory copy that never re-synced on resume.
+
+### Decision
+
+Adopt **drift** (MIT, type-safe SQLite ORM) as the single store for structured data. One database file (`meridian.db`), eight tables: `stations`, `position_history`, `packets`, `conversations`, `message_entries`, `group_message_entries`, `bulletins`, `outgoing_bulletins`. SharedPreferences is retained exclusively for flat settings/preferences, onboarding state, group subscriptions, and (via `SecureCredentialStore`) credentials.
+
+Key as-built decisions:
+
+- **Full-fidelity schema.** Tables carry every field the existing models use (e.g. `message_entries` keeps the full `MessageStatus` enum, `wire_id`, `retry_count`, `category`, `group_name`; `bulletins` keeps `transports`/`heard_count`/`first_heard_at`/`received_lat·lon`/`is_read`). Enums are stored via `EnumNameConverter` (text), safer under reordering than int indices.
+- **Multi-isolate via `IsolateNameServer`, not a passed `SendPort`.** `flutter_foreground_task`'s start-data channel cannot marshal a `SendPort`. Instead the main isolate spawns a `DriftIsolate`, opens `meridian.db` inside it, and registers `DriftIsolate.connectPort` under `meridian_drift_port` via `IsolateNameServer` (`dart:ui`). The Android background isolate looks the port up lazily and opens a client connection; null/throw → skip the tick and retry. iOS (main-isolate-only, ADR-032) never has a second client; web opens the DB directly (no isolate machinery).
+- **Per-service caching strategy differs by hazard:**
+  - `StationService` — drift is the source of truth; sync getters (`currentStations`, `recentPackets`) are cache snapshots fed by `watch()` streams plus immediate write-through. A 60 s timer prunes packets/stations by the existing retention windows. Position-history append + per-station 500-entry cap run in one transaction; `ON DELETE CASCADE` cleans history when a station is pruned.
+  - `MessageService` — keeps its in-memory `_conversations` working set with **targeted write-through** to drift; **deliberately no `watch()`** (the retry scheduler holds direct `MessageEntry` references and mutates them in place — rebuilding from a watch emission would orphan those references and break ACK→timer cancellation). Messages are main-isolate-only writes, so no cross-isolate watch benefit is lost.
+  - `BulletinService` — incoming bulletins are an in-memory write-through working set (the model `id` is a session-scoped navigation handle; the table is keyed `(source, addressee)` per ADR-057). Outgoing bulletins use drift autoincrement ids and are **re-read fresh each `BulletinScheduler` tick** (`refreshOutgoing()`) rather than via a continuous `watch()` — a watch raced with write-through (a lagging emission carrying a pre-mutation snapshot, or the initial empty emission landing mid-mutation, could revert the cache and transmit a just-disabled bulletin). The background isolate writes transmission/expiry updates to the shared DB; the next main-isolate tick observes them, and `BackgroundServiceManager`'s resume hook calls `refreshOutgoing()` for near-instant correction on return to foreground.
+- **State-drift fix is polled, not pushed.** The ADR-057/061 fix (main isolate sees background-isolate writes through the shared DB with no operator action) is preserved, but for outgoing bulletins the mechanism is the per-tick re-read + resume hook, bounded by the 30 s tick — not a drift `watch()`. This is a deliberate trade for race-freedom.
+- **`group_message_entries` is reserved but unused in v0.19.** Group messages route through the unified `conversations`/`message_entries` path (`category=group`, `peer_callsign='#GROUP:<NAME>'`) to preserve group `unreadCount`/`lastActivity` and the `totalGroupUnread` badge, which the leaner `group_message_entries` table has no column for. The table exists (schema-complete, DAO-covered) for a future refactor or removal.
+- **Migration: silent reset.** Schema version 1, `onCreate` only. No migration from the old SharedPreferences JSON — message/bulletin history and station/packet data reset on first launch of the migrated build (stations/packets backfill from APRS-IS within minutes). Old keys are orphaned, not cleaned.
+- **Message retention stays in Settings → History.** The handoff proposed a new Settings → Messaging control with a `message_retention_days`/`-1` key; the existing `history_message_days`/`0 = Forever` control (grouped with packet/station retention, consistent with `StationService.forever = 0`) was kept instead. The Phase-3.2 prune wiring (`pruneOlderThan` + `pruneEmptyConversations`, covering direct + group entries) satisfies the retention requirement. No periodic timer for messages — day-granularity retention is handled by the startup + on-change prune.
+
+### Consequences
+
+- New `lib/database/` module: `meridian_database.dart` (+ generated `.g.dart`), `tables/`, `converters/`, `daos/` (`StationDao`, `PacketDao`, `MessageDao`, `BulletinDao`), `database_provider.dart`.
+- `drift ^2.33` / `drift_flutter ^0.3` added; `drift_dev` + `build_runner` dev deps. All MIT (with `sqlite3` / `sqlite3_flutter_libs`), GPL-compatible.
+- `StationService`, `MessageService`, `BulletinService` constructors now take injected DAOs; service tests use `NativeDatabase.memory()` via `test/helpers/test_database.dart`.
+- Two cross-isolate integration tests (`test/integration/drift_isolate_test.dart`, `bulletin_cross_isolate_test.dart`) prove background→main visibility through the shared DB without an Android FGS. Per-DAO unit tests in `test/database/`.
+- The DAO `prune*` methods take a `DateTime cutoff` (clock-injected by services) rather than computing `DateTime.now()` internally, preserving deterministic clock injection.
+
+### References
+
+- `lib/database/` — database, tables, DAOs, provider
+- `lib/services/{station,message,bulletin}_service.dart`, `lib/services/bulletin_scheduler.dart`, `lib/services/meridian_connection_task.dart`
+- `lib/services/background_service_manager.dart` — `onResumed` → `refreshOutgoing()`
+- `docs/adrs/ADR-062-sqlite-drift.md` — pre-implementation design sketch
+- [drift documentation](https://drift.simonbinder.eu/)
+

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1560,7 +1560,7 @@ The scanner sheet drops the per-model dropdown in favour of a single "Show all B
 
 ---
 
-## ADR-062: SQLite persistence via drift
+## ADR-067: SQLite persistence via drift
 
 **Date:** 2026-05-23
 **Status:** Accepted
@@ -1568,7 +1568,7 @@ The scanner sheet drops the per-model dropdown in favour of a single "Show all B
 **Closes:** #87 (SQLite/drift evaluation spike)
 **Related:** ADR-025 (Android background isolate), ADR-032 (iOS background model), ADR-057 (BulletinService retransmission), ADR-061 (APRS-IS background RX)
 
-> This is the **as-built** record. The pre-implementation design sketch lives at `docs/adrs/ADR-062-sqlite-drift.md`; where the two differ, this entry is authoritative.
+> This is the **as-built** record of the persistence layer delivered for #87.
 
 ### Context
 
@@ -1604,6 +1604,5 @@ Key as-built decisions:
 - `lib/database/` — database, tables, DAOs, provider
 - `lib/services/{station,message,bulletin}_service.dart`, `lib/services/bulletin_scheduler.dart`, `lib/services/meridian_connection_task.dart`
 - `lib/services/background_service_manager.dart` — `onResumed` → `refreshOutgoing()`
-- `docs/adrs/ADR-062-sqlite-drift.md` — pre-implementation design sketch
 - [drift documentation](https://drift.simonbinder.eu/)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -174,7 +174,7 @@ Performance pass — measurable baselines and the structural fixes that move the
 - MapScreen rebuild fix — stop the entire scaffold from rebuilding on every packet (#51)
 - Selector convention — establish the `Selector<>` pattern across `Provider`-driven UI rather than the current single-site usage (#57)
 - Non-builder `ListView` sweep — convert eager-inflate sites in SettingsScreen, PacketDetailSheet, and the PacketLogScreen filter bar (#58, absorbed #64)
-- SQLite / drift evaluation spike — decision doc on persistence for stations, packets, and (follow-on) bulletins (#87)
+- ✅ SQLite / drift evaluation spike (#87) — graduated from a decision doc into a full implementation (ADR-062). drift now backs stations, position history, packet log, conversations + message entries, and incoming + outgoing bulletins; multi-isolate access via `DriftIsolate` + `IsolateNameServer` resolves the ADR-057/061 foreground/background state drift. Configurable message/packet/station retention; per-DAO + cross-isolate integration tests.
 - Background service battery drain — profiling report on Android + iOS, plus go/no-go on optimization sub-tasks (#88)
 - Memory audit — stress-test station count target (5k stable), identify allocation hotspots, document baseline (#89)
 - Packet processing throughput — establish baseline at ≥5 packets/second sustained, identify bottlenecks (#90)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -174,7 +174,7 @@ Performance pass — measurable baselines and the structural fixes that move the
 - MapScreen rebuild fix — stop the entire scaffold from rebuilding on every packet (#51)
 - Selector convention — establish the `Selector<>` pattern across `Provider`-driven UI rather than the current single-site usage (#57)
 - Non-builder `ListView` sweep — convert eager-inflate sites in SettingsScreen, PacketDetailSheet, and the PacketLogScreen filter bar (#58, absorbed #64)
-- ✅ SQLite / drift evaluation spike (#87) — graduated from a decision doc into a full implementation (ADR-062). drift now backs stations, position history, packet log, conversations + message entries, and incoming + outgoing bulletins; multi-isolate access via `DriftIsolate` + `IsolateNameServer` resolves the ADR-057/061 foreground/background state drift. Configurable message/packet/station retention; per-DAO + cross-isolate integration tests.
+- ✅ SQLite / drift evaluation spike (#87) — graduated from a decision doc into a full implementation (ADR-067). drift now backs stations, position history, packet log, conversations + message entries, and incoming + outgoing bulletins; multi-isolate access via `DriftIsolate` + `IsolateNameServer` resolves the ADR-057/061 foreground/background state drift. Configurable message/packet/station retention; per-DAO + cross-isolate integration tests.
 - Background service battery drain — profiling report on Android + iOS, plus go/no-go on optimization sub-tasks (#88)
 - Memory audit — stress-test station count target (5k stable), identify allocation hotspots, document baseline (#89)
 - Packet processing throughput — establish baseline at ≥5 packets/second sustained, identify bottlenecks (#90)

--- a/lib/database/converters/bulletin_transports_converter.dart
+++ b/lib/database/converters/bulletin_transports_converter.dart
@@ -26,5 +26,7 @@ class BulletinTransportsConverter
 
   @override
   String toSql(Set<BulletinTransport> value) =>
-      value.map((t) => t.name).join(',');
+      // Sort for a canonical serialization so semantically identical sets
+      // always produce the same SQL string (set iteration order is undefined).
+      (value.map((t) => t.name).toList()..sort()).join(',');
 }

--- a/lib/database/converters/bulletin_transports_converter.dart
+++ b/lib/database/converters/bulletin_transports_converter.dart
@@ -1,0 +1,30 @@
+import 'package:drift/drift.dart';
+
+import '../../models/bulletin.dart';
+
+/// Stores `Set<BulletinTransport>` as a comma-joined `text` column.
+/// Unknown tokens are silently dropped (forward-compat with future
+/// transports), preserving the canonical small set.
+class BulletinTransportsConverter
+    extends TypeConverter<Set<BulletinTransport>, String> {
+  const BulletinTransportsConverter();
+
+  @override
+  Set<BulletinTransport> fromSql(String fromDb) {
+    if (fromDb.isEmpty) return <BulletinTransport>{};
+    return fromDb
+        .split(',')
+        .map((s) => s.trim())
+        .where((s) => s.isNotEmpty)
+        .map(
+          (name) =>
+              BulletinTransport.values.where((t) => t.name == name).firstOrNull,
+        )
+        .whereType<BulletinTransport>()
+        .toSet();
+  }
+
+  @override
+  String toSql(Set<BulletinTransport> value) =>
+      value.map((t) => t.name).join(',');
+}

--- a/lib/database/daos/bulletin_dao.dart
+++ b/lib/database/daos/bulletin_dao.dart
@@ -19,12 +19,6 @@ class BulletinDao extends DatabaseAccessor<MeridianDatabase>
   Future<void> upsertIncoming(BulletinsCompanion bulletin) =>
       into(bulletins).insertOnConflictUpdate(bulletin);
 
-  Stream<List<BulletinRow>> watchIncoming() {
-    return (select(
-      bulletins,
-    )..orderBy([(b) => OrderingTerm.desc(b.lastHeardAt)])).watch();
-  }
-
   /// One-shot read of all incoming bulletins, newest `last_heard_at` first.
   Future<List<BulletinRow>> getAllIncoming() {
     return (select(
@@ -117,20 +111,6 @@ class BulletinDao extends DatabaseAccessor<MeridianDatabase>
 
   Future<int> deleteOutgoing(int id) =>
       (delete(outgoingBulletins)..where((o) => o.id.equals(id))).go();
-
-  Stream<List<OutgoingBulletinRow>> watchAllOutgoing() {
-    return (select(
-      outgoingBulletins,
-    )..orderBy([(o) => OrderingTerm.asc(o.createdAt)])).watch();
-  }
-
-  /// All currently-active outgoing bulletins (enabled, not yet expired).
-  /// Drives `BulletinScheduler` (replaces the SharedPreferences per-tick read).
-  Stream<List<OutgoingBulletinRow>> watchActiveOutgoing() {
-    return (select(
-      outgoingBulletins,
-    )..where((o) => o.enabled.equals(true))).watch();
-  }
 
   /// One-shot read of all outgoing bulletins, oldest first. Used by `load()`
   /// on the main isolate and by the background isolate's bulletin timer.

--- a/lib/database/daos/bulletin_dao.dart
+++ b/lib/database/daos/bulletin_dao.dart
@@ -1,0 +1,142 @@
+import 'package:drift/drift.dart';
+
+import '../meridian_database.dart';
+import '../tables/bulletins.dart';
+import '../tables/outgoing_bulletins.dart';
+
+part 'bulletin_dao.g.dart';
+
+@DriftAccessor(tables: [Bulletins, OutgoingBulletins])
+class BulletinDao extends DatabaseAccessor<MeridianDatabase>
+    with _$BulletinDaoMixin {
+  BulletinDao(super.db);
+
+  // ---------------------------------------------------------------------------
+  // Incoming bulletins
+  // ---------------------------------------------------------------------------
+
+  /// Upsert keyed by `(source_callsign, addressee)` per ADR-057.
+  Future<void> upsertIncoming(BulletinsCompanion bulletin) =>
+      into(bulletins).insertOnConflictUpdate(bulletin);
+
+  Stream<List<BulletinRow>> watchIncoming() {
+    return (select(
+      bulletins,
+    )..orderBy([(b) => OrderingTerm.desc(b.lastHeardAt)])).watch();
+  }
+
+  /// One-shot read of all incoming bulletins, newest `last_heard_at` first.
+  Future<List<BulletinRow>> getAllIncoming() {
+    return (select(
+      bulletins,
+    )..orderBy([(b) => OrderingTerm.desc(b.lastHeardAt)])).get();
+  }
+
+  Future<int> markIncomingRead(String source, String addressee) {
+    return (update(bulletins)..where(
+          (b) =>
+              b.sourceCallsign.equals(source) & b.addressee.equals(addressee),
+        ))
+        .write(const BulletinsCompanion(isRead: Value(true)));
+  }
+
+  Future<int> deleteIncoming(String source, String addressee) {
+    return (delete(bulletins)..where(
+          (b) =>
+              b.sourceCallsign.equals(source) & b.addressee.equals(addressee),
+        ))
+        .go();
+  }
+
+  /// Delete incoming bulletins whose `last_heard_at` is older than [cutoff].
+  Future<int> pruneIncomingOlderThan(DateTime cutoff) {
+    final cutoffMs = cutoff.millisecondsSinceEpoch;
+    return (delete(
+      bulletins,
+    )..where((b) => b.lastHeardAt.isSmallerThanValue(cutoffMs))).go();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Outgoing bulletins
+  // ---------------------------------------------------------------------------
+
+  Future<int> insertOutgoing(OutgoingBulletinsCompanion bulletin) =>
+      into(outgoingBulletins).insert(bulletin);
+
+  Future<int> updateOutgoingContent({
+    required int id,
+    String? addressee,
+    String? body,
+  }) {
+    return (update(outgoingBulletins)..where((o) => o.id.equals(id))).write(
+      OutgoingBulletinsCompanion(
+        addressee: addressee == null ? const Value.absent() : Value(addressee),
+        body: body == null ? const Value.absent() : Value(body),
+        lastTransmittedAt: const Value(null),
+        transmissionCount: const Value(0),
+      ),
+    );
+  }
+
+  Future<int> updateOutgoingSchedule({
+    required int id,
+    int? intervalSeconds,
+    DateTime? expiresAt,
+    bool? viaRf,
+    bool? viaAprsIs,
+  }) {
+    return (update(outgoingBulletins)..where((o) => o.id.equals(id))).write(
+      OutgoingBulletinsCompanion(
+        intervalSeconds: intervalSeconds == null
+            ? const Value.absent()
+            : Value(intervalSeconds),
+        expiresAt: expiresAt == null
+            ? const Value.absent()
+            : Value(expiresAt.millisecondsSinceEpoch),
+        viaRf: viaRf == null ? const Value.absent() : Value(viaRf),
+        viaAprsIs: viaAprsIs == null ? const Value.absent() : Value(viaAprsIs),
+      ),
+    );
+  }
+
+  Future<int> recordOutgoingTransmission(int id, DateTime ts) {
+    return customUpdate(
+      'UPDATE outgoing_bulletins '
+      'SET last_transmitted_at = ?, transmission_count = transmission_count + 1 '
+      'WHERE id = ?',
+      variables: [Variable<int>(ts.millisecondsSinceEpoch), Variable<int>(id)],
+      updates: {outgoingBulletins},
+    );
+  }
+
+  Future<int> setOutgoingEnabled(int id, bool enabled) {
+    return (update(outgoingBulletins)..where((o) => o.id.equals(id))).write(
+      OutgoingBulletinsCompanion(enabled: Value(enabled)),
+    );
+  }
+
+  Future<int> deleteOutgoing(int id) =>
+      (delete(outgoingBulletins)..where((o) => o.id.equals(id))).go();
+
+  Stream<List<OutgoingBulletinRow>> watchAllOutgoing() {
+    return (select(
+      outgoingBulletins,
+    )..orderBy([(o) => OrderingTerm.asc(o.createdAt)])).watch();
+  }
+
+  /// All currently-active outgoing bulletins (enabled, not yet expired).
+  /// Drives `BulletinScheduler` (replaces the SharedPreferences per-tick read).
+  Stream<List<OutgoingBulletinRow>> watchActiveOutgoing() {
+    return (select(
+      outgoingBulletins,
+    )..where((o) => o.enabled.equals(true))).watch();
+  }
+
+  /// One-shot read of all outgoing bulletins, oldest first. Used by `load()`
+  /// on the main isolate and by the background isolate's bulletin timer.
+  Future<List<OutgoingBulletinRow>> getAllOutgoing() {
+    return (select(
+      outgoingBulletins,
+    )..orderBy([(o) => OrderingTerm.asc(o.createdAt)])).get();
+  }
+}

--- a/lib/database/daos/bulletin_dao.g.dart
+++ b/lib/database/daos/bulletin_dao.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bulletin_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$BulletinDaoMixin on DatabaseAccessor<MeridianDatabase> {
+  $BulletinsTable get bulletins => attachedDatabase.bulletins;
+  $OutgoingBulletinsTable get outgoingBulletins =>
+      attachedDatabase.outgoingBulletins;
+  BulletinDaoManager get managers => BulletinDaoManager(this);
+}
+
+class BulletinDaoManager {
+  final _$BulletinDaoMixin _db;
+  BulletinDaoManager(this._db);
+  $$BulletinsTableTableManager get bulletins =>
+      $$BulletinsTableTableManager(_db.attachedDatabase, _db.bulletins);
+  $$OutgoingBulletinsTableTableManager get outgoingBulletins =>
+      $$OutgoingBulletinsTableTableManager(
+        _db.attachedDatabase,
+        _db.outgoingBulletins,
+      );
+}

--- a/lib/database/daos/message_dao.dart
+++ b/lib/database/daos/message_dao.dart
@@ -1,6 +1,6 @@
 import 'package:drift/drift.dart';
 
-import '../../services/message_service.dart' show MessageStatus;
+import '../../models/message_status.dart';
 import '../meridian_database.dart';
 import '../tables/conversations.dart';
 import '../tables/group_message_entries.dart';

--- a/lib/database/daos/message_dao.dart
+++ b/lib/database/daos/message_dao.dart
@@ -1,0 +1,142 @@
+import 'package:drift/drift.dart';
+
+import '../../services/message_service.dart' show MessageStatus;
+import '../meridian_database.dart';
+import '../tables/conversations.dart';
+import '../tables/group_message_entries.dart';
+import '../tables/message_entries.dart';
+
+part 'message_dao.g.dart';
+
+@DriftAccessor(tables: [Conversations, MessageEntries, GroupMessageEntries])
+class MessageDao extends DatabaseAccessor<MeridianDatabase>
+    with _$MessageDaoMixin {
+  MessageDao(super.db);
+
+  // ---------------------------------------------------------------------------
+  // Conversation upsert / unread tracking
+  // ---------------------------------------------------------------------------
+
+  Future<void> upsertConversation(ConversationsCompanion convo) =>
+      into(conversations).insertOnConflictUpdate(convo);
+
+  Future<int> incrementUnread(String peer) {
+    return customUpdate(
+      'UPDATE conversations '
+      'SET unread_count = unread_count + 1 '
+      'WHERE peer_callsign = ?',
+      variables: [Variable<String>(peer)],
+      updates: {conversations},
+    );
+  }
+
+  Future<int> markRead(String peer) {
+    return (update(conversations)..where((c) => c.peerCallsign.equals(peer)))
+        .write(const ConversationsCompanion(unreadCount: Value(0)));
+  }
+
+  Stream<List<ConversationRow>> watchAllConversations() => (select(
+    conversations,
+  )..orderBy([(c) => OrderingTerm.desc(c.lastMessageAt)])).watch();
+
+  // ---------------------------------------------------------------------------
+  // Message entries (direct + group via category column)
+  // ---------------------------------------------------------------------------
+
+  Future<void> insertEntry(MessageEntriesCompanion entry) =>
+      into(messageEntries).insert(entry, mode: InsertMode.insertOrReplace);
+
+  Future<void> updateEntryStatus({
+    required String localId,
+    required MessageStatus status,
+    int? retryCount,
+  }) {
+    return (update(messageEntries)..where((m) => m.id.equals(localId))).write(
+      MessageEntriesCompanion(
+        status: Value(status),
+        retryCount: retryCount == null
+            ? const Value.absent()
+            : Value(retryCount),
+      ),
+    );
+  }
+
+  Stream<List<MessageEntryRow>> watchEntriesForPeer(String peer) {
+    return (select(messageEntries)
+          ..where((m) => m.conversationPeer.equals(peer))
+          ..orderBy([(m) => OrderingTerm.asc(m.timestamp)]))
+        .watch();
+  }
+
+  Future<List<MessageEntryRow>> getEntriesForPeer(String peer) {
+    return (select(messageEntries)
+          ..where((m) => m.conversationPeer.equals(peer))
+          ..orderBy([(m) => OrderingTerm.asc(m.timestamp)]))
+        .get();
+  }
+
+  /// Demote in-flight messages (pending/retrying) to failed on startup.
+  /// Retry timers do not survive an app restart.
+  Future<int> demoteInFlightToFailed() {
+    return (update(messageEntries)..where(
+          (m) =>
+              m.status.equalsValue(MessageStatus.pending) |
+              m.status.equalsValue(MessageStatus.retrying),
+        ))
+        .write(
+          const MessageEntriesCompanion(status: Value(MessageStatus.failed)),
+        );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group messages (separate table)
+  // ---------------------------------------------------------------------------
+
+  Future<void> insertGroupEntry(GroupMessageEntriesCompanion entry) =>
+      into(groupMessageEntries).insert(entry, mode: InsertMode.insertOrReplace);
+
+  Stream<List<GroupMessageEntryRow>> watchGroupEntries(String groupName) {
+    return (select(groupMessageEntries)
+          ..where((g) => g.groupName.equals(groupName))
+          ..orderBy([(g) => OrderingTerm.asc(g.timestamp)]))
+        .watch();
+  }
+
+  /// Read all conversation rows (one-shot). Used by `loadHistory`.
+  Future<List<ConversationRow>> getAllConversations() =>
+      select(conversations).get();
+
+  // ---------------------------------------------------------------------------
+  // Retention pruning
+  // ---------------------------------------------------------------------------
+
+  /// Delete message + group-message rows older than [cutoff]. Returns the
+  /// total number of rows removed across both tables.
+  Future<int> pruneOlderThan(DateTime cutoff) async {
+    final cutoffMs = cutoff.millisecondsSinceEpoch;
+    final removedDirect = await (delete(
+      messageEntries,
+    )..where((m) => m.timestamp.isSmallerThanValue(cutoffMs))).go();
+    final removedGroup = await (delete(
+      groupMessageEntries,
+    )..where((g) => g.timestamp.isSmallerThanValue(cutoffMs))).go();
+    return removedDirect + removedGroup;
+  }
+
+  /// Drop conversation rows that no longer have any message entries — keeps
+  /// the thread list free of empty "ghost" rows after a retention sweep.
+  Future<int> pruneEmptyConversations() {
+    return customUpdate(
+      'DELETE FROM conversations WHERE peer_callsign NOT IN '
+      '(SELECT DISTINCT conversation_peer FROM message_entries)',
+      updates: {conversations},
+      updateKind: UpdateKind.delete,
+    );
+  }
+
+  Future<void> clearAll() async {
+    await delete(messageEntries).go();
+    await delete(groupMessageEntries).go();
+    await delete(conversations).go();
+  }
+}

--- a/lib/database/daos/message_dao.g.dart
+++ b/lib/database/daos/message_dao.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'message_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$MessageDaoMixin on DatabaseAccessor<MeridianDatabase> {
+  $ConversationsTable get conversations => attachedDatabase.conversations;
+  $MessageEntriesTable get messageEntries => attachedDatabase.messageEntries;
+  $GroupMessageEntriesTable get groupMessageEntries =>
+      attachedDatabase.groupMessageEntries;
+  MessageDaoManager get managers => MessageDaoManager(this);
+}
+
+class MessageDaoManager {
+  final _$MessageDaoMixin _db;
+  MessageDaoManager(this._db);
+  $$ConversationsTableTableManager get conversations =>
+      $$ConversationsTableTableManager(_db.attachedDatabase, _db.conversations);
+  $$MessageEntriesTableTableManager get messageEntries =>
+      $$MessageEntriesTableTableManager(
+        _db.attachedDatabase,
+        _db.messageEntries,
+      );
+  $$GroupMessageEntriesTableTableManager get groupMessageEntries =>
+      $$GroupMessageEntriesTableTableManager(
+        _db.attachedDatabase,
+        _db.groupMessageEntries,
+      );
+}

--- a/lib/database/daos/packet_dao.dart
+++ b/lib/database/daos/packet_dao.dart
@@ -1,0 +1,33 @@
+import 'package:drift/drift.dart';
+
+import '../meridian_database.dart';
+import '../tables/packets.dart';
+
+part 'packet_dao.g.dart';
+
+@DriftAccessor(tables: [Packets])
+class PacketDao extends DatabaseAccessor<MeridianDatabase>
+    with _$PacketDaoMixin {
+  PacketDao(super.db);
+
+  Future<int> insertPacket(PacketsCompanion packet) =>
+      into(packets).insert(packet);
+
+  /// Stream of the most-recent packets, newest first. Default limit matches
+  /// the in-memory rolling buffer cap previously used by `StationService`.
+  Stream<List<PacketRow>> watchRecent({int limit = 5000}) {
+    return (select(packets)
+          ..orderBy([(p) => OrderingTerm.desc(p.receivedAt)])
+          ..limit(limit))
+        .watch();
+  }
+
+  Future<int> pruneOlderThan(DateTime cutoff) {
+    final cutoffMs = cutoff.millisecondsSinceEpoch;
+    return (delete(
+      packets,
+    )..where((p) => p.receivedAt.isSmallerThanValue(cutoffMs))).go();
+  }
+
+  Future<void> clearAll() => delete(packets).go();
+}

--- a/lib/database/daos/packet_dao.g.dart
+++ b/lib/database/daos/packet_dao.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'packet_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$PacketDaoMixin on DatabaseAccessor<MeridianDatabase> {
+  $PacketsTable get packets => attachedDatabase.packets;
+  PacketDaoManager get managers => PacketDaoManager(this);
+}
+
+class PacketDaoManager {
+  final _$PacketDaoMixin _db;
+  PacketDaoManager(this._db);
+  $$PacketsTableTableManager get packets =>
+      $$PacketsTableTableManager(_db.attachedDatabase, _db.packets);
+}

--- a/lib/database/daos/station_dao.dart
+++ b/lib/database/daos/station_dao.dart
@@ -1,0 +1,112 @@
+import 'package:drift/drift.dart';
+
+import '../meridian_database.dart';
+import '../tables/position_history.dart';
+import '../tables/stations.dart';
+
+part 'station_dao.g.dart';
+
+@DriftAccessor(tables: [Stations, PositionHistory])
+class StationDao extends DatabaseAccessor<MeridianDatabase>
+    with _$StationDaoMixin {
+  StationDao(super.db);
+
+  /// Upsert a station by callsign.
+  Future<void> upsertStation(StationsCompanion station) =>
+      into(stations).insertOnConflictUpdate(station);
+
+  /// Append a position-history entry for an existing station.
+  Future<void> appendPositionHistory(PositionHistoryCompanion entry) =>
+      into(positionHistory).insert(entry);
+
+  /// Atomic upsert + previous-position append + per-station history cap in
+  /// one transaction. Preserves the merge semantics previously implemented
+  /// in `StationService._mergeStation`.
+  ///
+  /// When [previousPosition] is non-null it is appended before the upsert;
+  /// when [capHistoryAt] is non-null, any rows older than the most recent
+  /// [capHistoryAt] entries for this callsign are deleted in the same
+  /// transaction.
+  Future<void> upsertWithPositionHistory({
+    required StationsCompanion station,
+    PositionHistoryCompanion? previousPosition,
+    int? capHistoryAt,
+  }) {
+    return transaction(() async {
+      if (previousPosition != null) {
+        await into(positionHistory).insert(previousPosition);
+      }
+      await into(stations).insertOnConflictUpdate(station);
+      if (capHistoryAt != null && previousPosition != null) {
+        await _capHistoryFor(
+          callsign: previousPosition.callsign.value,
+          maxEntries: capHistoryAt,
+        );
+      }
+    });
+  }
+
+  Future<void> _capHistoryFor({
+    required String callsign,
+    required int maxEntries,
+  }) async {
+    await customStatement(
+      'DELETE FROM position_history '
+      'WHERE callsign = ? '
+      'AND id NOT IN ('
+      '  SELECT id FROM position_history '
+      '  WHERE callsign = ? '
+      '  ORDER BY timestamp DESC LIMIT ?'
+      ')',
+      [callsign, callsign, maxEntries],
+    );
+  }
+
+  /// Remove a station (and via FK cascade, its position history) by
+  /// callsign. Used by Object/Item "killed" packets.
+  Future<int> deleteByCallsign(String callsign) =>
+      (delete(stations)..where((s) => s.callsign.equals(callsign))).go();
+
+  Stream<List<StationRow>> watchAllStations() => select(stations).watch();
+
+  Stream<StationRow?> watchStation(String callsign) => (select(
+    stations,
+  )..where((s) => s.callsign.equals(callsign))).watchSingleOrNull();
+
+  /// One-shot read of a single station row (used inside the merge transaction).
+  Future<StationRow?> getStation(String callsign) => (select(
+    stations,
+  )..where((s) => s.callsign.equals(callsign))).getSingleOrNull();
+
+  Future<List<StationRow>> getAllStations() => select(stations).get();
+
+  Future<List<PositionHistoryRow>> getPositionHistory(String callsign) =>
+      (select(positionHistory)
+            ..where((p) => p.callsign.equals(callsign))
+            ..orderBy([(p) => OrderingTerm.asc(p.timestamp)]))
+          .get();
+
+  /// All position-history rows across every station, ordered by callsign
+  /// then ascending timestamp. Used to rebuild the in-memory cache without
+  /// issuing one query per station.
+  Future<List<PositionHistoryRow>> getAllPositionHistory() =>
+      (select(positionHistory)..orderBy([
+            (p) => OrderingTerm.asc(p.callsign),
+            (p) => OrderingTerm.asc(p.timestamp),
+          ]))
+          .get();
+
+  /// Delete stations whose `last_heard` is older than [cutoff].
+  /// Position-history rows for those stations are CASCADE-deleted.
+  Future<int> pruneOlderThan(DateTime cutoff) {
+    final cutoffMs = cutoff.millisecondsSinceEpoch;
+    return (delete(
+      stations,
+    )..where((s) => s.lastHeard.isSmallerThanValue(cutoffMs))).go();
+  }
+
+  Future<void> clearAll() async {
+    await delete(positionHistory).go();
+    await delete(stations).go();
+  }
+}

--- a/lib/database/daos/station_dao.g.dart
+++ b/lib/database/daos/station_dao.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'station_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$StationDaoMixin on DatabaseAccessor<MeridianDatabase> {
+  $StationsTable get stations => attachedDatabase.stations;
+  $PositionHistoryTable get positionHistory => attachedDatabase.positionHistory;
+  StationDaoManager get managers => StationDaoManager(this);
+}
+
+class StationDaoManager {
+  final _$StationDaoMixin _db;
+  StationDaoManager(this._db);
+  $$StationsTableTableManager get stations =>
+      $$StationsTableTableManager(_db.attachedDatabase, _db.stations);
+  $$PositionHistoryTableTableManager get positionHistory =>
+      $$PositionHistoryTableTableManager(
+        _db.attachedDatabase,
+        _db.positionHistory,
+      );
+}

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
+import 'package:drift/native.dart';
+import 'package:drift_flutter/drift_flutter.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:path_provider/path_provider.dart';
+
+import 'meridian_database.dart';
+
+/// Name under which the shared drift connect port is registered with
+/// `IsolateNameServer`. The Android foreground-service background isolate
+/// looks it up via [lookupBackgroundDatabasePort] to obtain a client
+/// connection on the same `meridian.db` opened by the main isolate.
+const String meridianDriftPortName = 'meridian_drift_port';
+
+/// Spawns a dedicated drift isolate that owns `meridian.db`, registers its
+/// connect port for cross-isolate use, and returns a main-isolate client
+/// connected through that port.
+///
+/// On web the cross-isolate machinery is a no-op (no `dart:isolate`,
+/// `flutter_foreground_task` is unavailable) — the database is opened directly
+/// through `drift_flutter`'s web backend.
+Future<MeridianDatabase> openMeridianDatabase() async {
+  if (kIsWeb) {
+    return MeridianDatabase(driftDatabase(name: 'meridian'));
+  }
+
+  IsolateNameServer.removePortNameMapping(meridianDriftPortName);
+
+  final dbFolder = await getApplicationDocumentsDirectory();
+  final dbPath = '${dbFolder.path}${Platform.pathSeparator}meridian.db';
+
+  final isolate = await DriftIsolate.spawn(
+    () => DatabaseConnection(NativeDatabase(File(dbPath))),
+  );
+
+  IsolateNameServer.registerPortWithName(
+    isolate.connectPort,
+    meridianDriftPortName,
+  );
+
+  return MeridianDatabase.connect(await isolate.connect());
+}
+
+/// Look up the shared drift connect port and open a client connection.
+///
+/// Called from the background isolate (`MeridianConnectionTask`). Returns
+/// `null` if no main-isolate registration is present — the caller should
+/// fall back to its legacy SharedPreferences path until the main isolate
+/// revives.
+Future<MeridianDatabase?> lookupBackgroundDatabasePort() async {
+  if (kIsWeb) return null;
+  final port = IsolateNameServer.lookupPortByName(meridianDriftPortName);
+  if (port == null) return null;
+  final isolate = DriftIsolate.fromConnectPort(port);
+  return MeridianDatabase.connect(await isolate.connect());
+}

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -5,7 +5,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/isolate.dart';
 import 'package:drift/native.dart';
 import 'package:drift_flutter/drift_flutter.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:path_provider/path_provider.dart';
 
 import 'meridian_database.dart';
@@ -37,10 +37,19 @@ Future<MeridianDatabase> openMeridianDatabase() async {
     () => DatabaseConnection(NativeDatabase(File(dbPath))),
   );
 
-  IsolateNameServer.registerPortWithName(
+  final registered = IsolateNameServer.registerPortWithName(
     isolate.connectPort,
     meridianDriftPortName,
   );
+  if (!registered) {
+    // The main-isolate DB still works, but the Android background isolate
+    // won't find the shared port — background bulletin/transmission writes
+    // would silently stop syncing. Surface it rather than failing quietly.
+    debugPrint(
+      'openMeridianDatabase: failed to register "$meridianDriftPortName" '
+      'with IsolateNameServer — background DB sharing is disabled.',
+    );
+  }
 
   return MeridianDatabase.connect(await isolate.connect());
 }

--- a/lib/database/meridian_database.dart
+++ b/lib/database/meridian_database.dart
@@ -1,0 +1,76 @@
+import 'package:drift/drift.dart';
+
+import '../core/packet/aprs_packet.dart';
+import '../core/packet/station.dart';
+import '../models/bulletin.dart';
+import '../models/message_category.dart';
+import '../services/message_service.dart' show MessageStatus;
+import 'converters/bulletin_transports_converter.dart';
+import 'daos/bulletin_dao.dart';
+import 'daos/message_dao.dart';
+import 'daos/packet_dao.dart';
+import 'daos/station_dao.dart';
+import 'tables/bulletins.dart';
+import 'tables/conversations.dart';
+import 'tables/group_message_entries.dart';
+import 'tables/message_entries.dart';
+import 'tables/outgoing_bulletins.dart';
+import 'tables/packets.dart';
+import 'tables/position_history.dart';
+import 'tables/stations.dart';
+
+part 'meridian_database.g.dart';
+
+@DriftDatabase(
+  tables: [
+    Stations,
+    PositionHistory,
+    Packets,
+    Conversations,
+    MessageEntries,
+    GroupMessageEntries,
+    Bulletins,
+    OutgoingBulletins,
+  ],
+  daos: [StationDao, PacketDao, MessageDao, BulletinDao],
+)
+class MeridianDatabase extends _$MeridianDatabase {
+  MeridianDatabase(super.executor);
+
+  MeridianDatabase.connect(DatabaseConnection super.connection) : super();
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) async {
+      await m.createAll();
+      await customStatement(
+        'CREATE INDEX position_history_callsign_timestamp '
+        'ON position_history(callsign, timestamp)',
+      );
+      await customStatement(
+        'CREATE INDEX packets_received_at ON packets(received_at)',
+      );
+      await customStatement(
+        'CREATE INDEX packets_source_callsign '
+        'ON packets(source_callsign)',
+      );
+      await customStatement(
+        'CREATE INDEX message_entries_conversation_peer_timestamp '
+        'ON message_entries(conversation_peer, timestamp)',
+      );
+      await customStatement(
+        'CREATE INDEX group_message_entries_group_name_timestamp '
+        'ON group_message_entries(group_name, timestamp)',
+      );
+      await customStatement(
+        'CREATE INDEX bulletins_last_heard_at ON bulletins(last_heard_at)',
+      );
+    },
+    beforeOpen: (details) async {
+      await customStatement('PRAGMA foreign_keys = ON');
+    },
+  );
+}

--- a/lib/database/meridian_database.dart
+++ b/lib/database/meridian_database.dart
@@ -4,7 +4,7 @@ import '../core/packet/aprs_packet.dart';
 import '../core/packet/station.dart';
 import '../models/bulletin.dart';
 import '../models/message_category.dart';
-import '../services/message_service.dart' show MessageStatus;
+import '../models/message_status.dart';
 import 'converters/bulletin_transports_converter.dart';
 import 'daos/bulletin_dao.dart';
 import 'daos/message_dao.dart';

--- a/lib/database/meridian_database.g.dart
+++ b/lib/database/meridian_database.g.dart
@@ -1,0 +1,7275 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'meridian_database.dart';
+
+// ignore_for_file: type=lint
+class $StationsTable extends Stations
+    with TableInfo<$StationsTable, StationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $StationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _callsignMeta = const VerificationMeta(
+    'callsign',
+  );
+  @override
+  late final GeneratedColumn<String> callsign = GeneratedColumn<String>(
+    'callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _symbolTableMeta = const VerificationMeta(
+    'symbolTable',
+  );
+  @override
+  late final GeneratedColumn<String> symbolTable = GeneratedColumn<String>(
+    'symbol_table',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _symbolCodeMeta = const VerificationMeta(
+    'symbolCode',
+  );
+  @override
+  late final GeneratedColumn<String> symbolCode = GeneratedColumn<String>(
+    'symbol_code',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _commentMeta = const VerificationMeta(
+    'comment',
+  );
+  @override
+  late final GeneratedColumn<String> comment = GeneratedColumn<String>(
+    'comment',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _rawPacketMeta = const VerificationMeta(
+    'rawPacket',
+  );
+  @override
+  late final GeneratedColumn<String> rawPacket = GeneratedColumn<String>(
+    'raw_packet',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deviceMeta = const VerificationMeta('device');
+  @override
+  late final GeneratedColumn<String> device = GeneratedColumn<String>(
+    'device',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastHeardMeta = const VerificationMeta(
+    'lastHeard',
+  );
+  @override
+  late final GeneratedColumn<int> lastHeard = GeneratedColumn<int>(
+    'last_heard',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<StationType, String> stationType =
+      GeneratedColumn<String>(
+        'station_type',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<StationType>($StationsTable.$converterstationType);
+  @override
+  late final GeneratedColumnWithTypeConverter<MessageCapability, String>
+  messageCapability =
+      GeneratedColumn<String>(
+        'message_capability',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<MessageCapability>(
+        $StationsTable.$convertermessageCapability,
+      );
+  static const VerificationMeta _capabilitiesMeta = const VerificationMeta(
+    'capabilities',
+  );
+  @override
+  late final GeneratedColumn<String> capabilities = GeneratedColumn<String>(
+    'capabilities',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _latMeta = const VerificationMeta('lat');
+  @override
+  late final GeneratedColumn<double> lat = GeneratedColumn<double>(
+    'lat',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lonMeta = const VerificationMeta('lon');
+  @override
+  late final GeneratedColumn<double> lon = GeneratedColumn<double>(
+    'lon',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    callsign,
+    symbolTable,
+    symbolCode,
+    comment,
+    rawPacket,
+    device,
+    lastHeard,
+    stationType,
+    messageCapability,
+    capabilities,
+    lat,
+    lon,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'stations';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<StationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('callsign')) {
+      context.handle(
+        _callsignMeta,
+        callsign.isAcceptableOrUnknown(data['callsign']!, _callsignMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_callsignMeta);
+    }
+    if (data.containsKey('symbol_table')) {
+      context.handle(
+        _symbolTableMeta,
+        symbolTable.isAcceptableOrUnknown(
+          data['symbol_table']!,
+          _symbolTableMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_symbolTableMeta);
+    }
+    if (data.containsKey('symbol_code')) {
+      context.handle(
+        _symbolCodeMeta,
+        symbolCode.isAcceptableOrUnknown(data['symbol_code']!, _symbolCodeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_symbolCodeMeta);
+    }
+    if (data.containsKey('comment')) {
+      context.handle(
+        _commentMeta,
+        comment.isAcceptableOrUnknown(data['comment']!, _commentMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_commentMeta);
+    }
+    if (data.containsKey('raw_packet')) {
+      context.handle(
+        _rawPacketMeta,
+        rawPacket.isAcceptableOrUnknown(data['raw_packet']!, _rawPacketMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_rawPacketMeta);
+    }
+    if (data.containsKey('device')) {
+      context.handle(
+        _deviceMeta,
+        device.isAcceptableOrUnknown(data['device']!, _deviceMeta),
+      );
+    }
+    if (data.containsKey('last_heard')) {
+      context.handle(
+        _lastHeardMeta,
+        lastHeard.isAcceptableOrUnknown(data['last_heard']!, _lastHeardMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_lastHeardMeta);
+    }
+    if (data.containsKey('capabilities')) {
+      context.handle(
+        _capabilitiesMeta,
+        capabilities.isAcceptableOrUnknown(
+          data['capabilities']!,
+          _capabilitiesMeta,
+        ),
+      );
+    }
+    if (data.containsKey('lat')) {
+      context.handle(
+        _latMeta,
+        lat.isAcceptableOrUnknown(data['lat']!, _latMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_latMeta);
+    }
+    if (data.containsKey('lon')) {
+      context.handle(
+        _lonMeta,
+        lon.isAcceptableOrUnknown(data['lon']!, _lonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_lonMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {callsign};
+  @override
+  StationRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return StationRow(
+      callsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}callsign'],
+      )!,
+      symbolTable: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}symbol_table'],
+      )!,
+      symbolCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}symbol_code'],
+      )!,
+      comment: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}comment'],
+      )!,
+      rawPacket: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}raw_packet'],
+      )!,
+      device: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}device'],
+      ),
+      lastHeard: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_heard'],
+      )!,
+      stationType: $StationsTable.$converterstationType.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}station_type'],
+        )!,
+      ),
+      messageCapability: $StationsTable.$convertermessageCapability.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}message_capability'],
+        )!,
+      ),
+      capabilities: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}capabilities'],
+      ),
+      lat: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}lat'],
+      )!,
+      lon: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}lon'],
+      )!,
+    );
+  }
+
+  @override
+  $StationsTable createAlias(String alias) {
+    return $StationsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<StationType, String, String> $converterstationType =
+      const EnumNameConverter(StationType.values);
+  static JsonTypeConverter2<MessageCapability, String, String>
+  $convertermessageCapability = const EnumNameConverter(
+    MessageCapability.values,
+  );
+}
+
+class StationRow extends DataClass implements Insertable<StationRow> {
+  final String callsign;
+  final String symbolTable;
+  final String symbolCode;
+  final String comment;
+  final String rawPacket;
+  final String? device;
+  final int lastHeard;
+  final StationType stationType;
+  final MessageCapability messageCapability;
+  final String? capabilities;
+  final double lat;
+  final double lon;
+  const StationRow({
+    required this.callsign,
+    required this.symbolTable,
+    required this.symbolCode,
+    required this.comment,
+    required this.rawPacket,
+    this.device,
+    required this.lastHeard,
+    required this.stationType,
+    required this.messageCapability,
+    this.capabilities,
+    required this.lat,
+    required this.lon,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['callsign'] = Variable<String>(callsign);
+    map['symbol_table'] = Variable<String>(symbolTable);
+    map['symbol_code'] = Variable<String>(symbolCode);
+    map['comment'] = Variable<String>(comment);
+    map['raw_packet'] = Variable<String>(rawPacket);
+    if (!nullToAbsent || device != null) {
+      map['device'] = Variable<String>(device);
+    }
+    map['last_heard'] = Variable<int>(lastHeard);
+    {
+      map['station_type'] = Variable<String>(
+        $StationsTable.$converterstationType.toSql(stationType),
+      );
+    }
+    {
+      map['message_capability'] = Variable<String>(
+        $StationsTable.$convertermessageCapability.toSql(messageCapability),
+      );
+    }
+    if (!nullToAbsent || capabilities != null) {
+      map['capabilities'] = Variable<String>(capabilities);
+    }
+    map['lat'] = Variable<double>(lat);
+    map['lon'] = Variable<double>(lon);
+    return map;
+  }
+
+  StationsCompanion toCompanion(bool nullToAbsent) {
+    return StationsCompanion(
+      callsign: Value(callsign),
+      symbolTable: Value(symbolTable),
+      symbolCode: Value(symbolCode),
+      comment: Value(comment),
+      rawPacket: Value(rawPacket),
+      device: device == null && nullToAbsent
+          ? const Value.absent()
+          : Value(device),
+      lastHeard: Value(lastHeard),
+      stationType: Value(stationType),
+      messageCapability: Value(messageCapability),
+      capabilities: capabilities == null && nullToAbsent
+          ? const Value.absent()
+          : Value(capabilities),
+      lat: Value(lat),
+      lon: Value(lon),
+    );
+  }
+
+  factory StationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return StationRow(
+      callsign: serializer.fromJson<String>(json['callsign']),
+      symbolTable: serializer.fromJson<String>(json['symbolTable']),
+      symbolCode: serializer.fromJson<String>(json['symbolCode']),
+      comment: serializer.fromJson<String>(json['comment']),
+      rawPacket: serializer.fromJson<String>(json['rawPacket']),
+      device: serializer.fromJson<String?>(json['device']),
+      lastHeard: serializer.fromJson<int>(json['lastHeard']),
+      stationType: $StationsTable.$converterstationType.fromJson(
+        serializer.fromJson<String>(json['stationType']),
+      ),
+      messageCapability: $StationsTable.$convertermessageCapability.fromJson(
+        serializer.fromJson<String>(json['messageCapability']),
+      ),
+      capabilities: serializer.fromJson<String?>(json['capabilities']),
+      lat: serializer.fromJson<double>(json['lat']),
+      lon: serializer.fromJson<double>(json['lon']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'callsign': serializer.toJson<String>(callsign),
+      'symbolTable': serializer.toJson<String>(symbolTable),
+      'symbolCode': serializer.toJson<String>(symbolCode),
+      'comment': serializer.toJson<String>(comment),
+      'rawPacket': serializer.toJson<String>(rawPacket),
+      'device': serializer.toJson<String?>(device),
+      'lastHeard': serializer.toJson<int>(lastHeard),
+      'stationType': serializer.toJson<String>(
+        $StationsTable.$converterstationType.toJson(stationType),
+      ),
+      'messageCapability': serializer.toJson<String>(
+        $StationsTable.$convertermessageCapability.toJson(messageCapability),
+      ),
+      'capabilities': serializer.toJson<String?>(capabilities),
+      'lat': serializer.toJson<double>(lat),
+      'lon': serializer.toJson<double>(lon),
+    };
+  }
+
+  StationRow copyWith({
+    String? callsign,
+    String? symbolTable,
+    String? symbolCode,
+    String? comment,
+    String? rawPacket,
+    Value<String?> device = const Value.absent(),
+    int? lastHeard,
+    StationType? stationType,
+    MessageCapability? messageCapability,
+    Value<String?> capabilities = const Value.absent(),
+    double? lat,
+    double? lon,
+  }) => StationRow(
+    callsign: callsign ?? this.callsign,
+    symbolTable: symbolTable ?? this.symbolTable,
+    symbolCode: symbolCode ?? this.symbolCode,
+    comment: comment ?? this.comment,
+    rawPacket: rawPacket ?? this.rawPacket,
+    device: device.present ? device.value : this.device,
+    lastHeard: lastHeard ?? this.lastHeard,
+    stationType: stationType ?? this.stationType,
+    messageCapability: messageCapability ?? this.messageCapability,
+    capabilities: capabilities.present ? capabilities.value : this.capabilities,
+    lat: lat ?? this.lat,
+    lon: lon ?? this.lon,
+  );
+  StationRow copyWithCompanion(StationsCompanion data) {
+    return StationRow(
+      callsign: data.callsign.present ? data.callsign.value : this.callsign,
+      symbolTable: data.symbolTable.present
+          ? data.symbolTable.value
+          : this.symbolTable,
+      symbolCode: data.symbolCode.present
+          ? data.symbolCode.value
+          : this.symbolCode,
+      comment: data.comment.present ? data.comment.value : this.comment,
+      rawPacket: data.rawPacket.present ? data.rawPacket.value : this.rawPacket,
+      device: data.device.present ? data.device.value : this.device,
+      lastHeard: data.lastHeard.present ? data.lastHeard.value : this.lastHeard,
+      stationType: data.stationType.present
+          ? data.stationType.value
+          : this.stationType,
+      messageCapability: data.messageCapability.present
+          ? data.messageCapability.value
+          : this.messageCapability,
+      capabilities: data.capabilities.present
+          ? data.capabilities.value
+          : this.capabilities,
+      lat: data.lat.present ? data.lat.value : this.lat,
+      lon: data.lon.present ? data.lon.value : this.lon,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('StationRow(')
+          ..write('callsign: $callsign, ')
+          ..write('symbolTable: $symbolTable, ')
+          ..write('symbolCode: $symbolCode, ')
+          ..write('comment: $comment, ')
+          ..write('rawPacket: $rawPacket, ')
+          ..write('device: $device, ')
+          ..write('lastHeard: $lastHeard, ')
+          ..write('stationType: $stationType, ')
+          ..write('messageCapability: $messageCapability, ')
+          ..write('capabilities: $capabilities, ')
+          ..write('lat: $lat, ')
+          ..write('lon: $lon')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    callsign,
+    symbolTable,
+    symbolCode,
+    comment,
+    rawPacket,
+    device,
+    lastHeard,
+    stationType,
+    messageCapability,
+    capabilities,
+    lat,
+    lon,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is StationRow &&
+          other.callsign == this.callsign &&
+          other.symbolTable == this.symbolTable &&
+          other.symbolCode == this.symbolCode &&
+          other.comment == this.comment &&
+          other.rawPacket == this.rawPacket &&
+          other.device == this.device &&
+          other.lastHeard == this.lastHeard &&
+          other.stationType == this.stationType &&
+          other.messageCapability == this.messageCapability &&
+          other.capabilities == this.capabilities &&
+          other.lat == this.lat &&
+          other.lon == this.lon);
+}
+
+class StationsCompanion extends UpdateCompanion<StationRow> {
+  final Value<String> callsign;
+  final Value<String> symbolTable;
+  final Value<String> symbolCode;
+  final Value<String> comment;
+  final Value<String> rawPacket;
+  final Value<String?> device;
+  final Value<int> lastHeard;
+  final Value<StationType> stationType;
+  final Value<MessageCapability> messageCapability;
+  final Value<String?> capabilities;
+  final Value<double> lat;
+  final Value<double> lon;
+  final Value<int> rowid;
+  const StationsCompanion({
+    this.callsign = const Value.absent(),
+    this.symbolTable = const Value.absent(),
+    this.symbolCode = const Value.absent(),
+    this.comment = const Value.absent(),
+    this.rawPacket = const Value.absent(),
+    this.device = const Value.absent(),
+    this.lastHeard = const Value.absent(),
+    this.stationType = const Value.absent(),
+    this.messageCapability = const Value.absent(),
+    this.capabilities = const Value.absent(),
+    this.lat = const Value.absent(),
+    this.lon = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  StationsCompanion.insert({
+    required String callsign,
+    required String symbolTable,
+    required String symbolCode,
+    required String comment,
+    required String rawPacket,
+    this.device = const Value.absent(),
+    required int lastHeard,
+    required StationType stationType,
+    required MessageCapability messageCapability,
+    this.capabilities = const Value.absent(),
+    required double lat,
+    required double lon,
+    this.rowid = const Value.absent(),
+  }) : callsign = Value(callsign),
+       symbolTable = Value(symbolTable),
+       symbolCode = Value(symbolCode),
+       comment = Value(comment),
+       rawPacket = Value(rawPacket),
+       lastHeard = Value(lastHeard),
+       stationType = Value(stationType),
+       messageCapability = Value(messageCapability),
+       lat = Value(lat),
+       lon = Value(lon);
+  static Insertable<StationRow> custom({
+    Expression<String>? callsign,
+    Expression<String>? symbolTable,
+    Expression<String>? symbolCode,
+    Expression<String>? comment,
+    Expression<String>? rawPacket,
+    Expression<String>? device,
+    Expression<int>? lastHeard,
+    Expression<String>? stationType,
+    Expression<String>? messageCapability,
+    Expression<String>? capabilities,
+    Expression<double>? lat,
+    Expression<double>? lon,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (callsign != null) 'callsign': callsign,
+      if (symbolTable != null) 'symbol_table': symbolTable,
+      if (symbolCode != null) 'symbol_code': symbolCode,
+      if (comment != null) 'comment': comment,
+      if (rawPacket != null) 'raw_packet': rawPacket,
+      if (device != null) 'device': device,
+      if (lastHeard != null) 'last_heard': lastHeard,
+      if (stationType != null) 'station_type': stationType,
+      if (messageCapability != null) 'message_capability': messageCapability,
+      if (capabilities != null) 'capabilities': capabilities,
+      if (lat != null) 'lat': lat,
+      if (lon != null) 'lon': lon,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  StationsCompanion copyWith({
+    Value<String>? callsign,
+    Value<String>? symbolTable,
+    Value<String>? symbolCode,
+    Value<String>? comment,
+    Value<String>? rawPacket,
+    Value<String?>? device,
+    Value<int>? lastHeard,
+    Value<StationType>? stationType,
+    Value<MessageCapability>? messageCapability,
+    Value<String?>? capabilities,
+    Value<double>? lat,
+    Value<double>? lon,
+    Value<int>? rowid,
+  }) {
+    return StationsCompanion(
+      callsign: callsign ?? this.callsign,
+      symbolTable: symbolTable ?? this.symbolTable,
+      symbolCode: symbolCode ?? this.symbolCode,
+      comment: comment ?? this.comment,
+      rawPacket: rawPacket ?? this.rawPacket,
+      device: device ?? this.device,
+      lastHeard: lastHeard ?? this.lastHeard,
+      stationType: stationType ?? this.stationType,
+      messageCapability: messageCapability ?? this.messageCapability,
+      capabilities: capabilities ?? this.capabilities,
+      lat: lat ?? this.lat,
+      lon: lon ?? this.lon,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (callsign.present) {
+      map['callsign'] = Variable<String>(callsign.value);
+    }
+    if (symbolTable.present) {
+      map['symbol_table'] = Variable<String>(symbolTable.value);
+    }
+    if (symbolCode.present) {
+      map['symbol_code'] = Variable<String>(symbolCode.value);
+    }
+    if (comment.present) {
+      map['comment'] = Variable<String>(comment.value);
+    }
+    if (rawPacket.present) {
+      map['raw_packet'] = Variable<String>(rawPacket.value);
+    }
+    if (device.present) {
+      map['device'] = Variable<String>(device.value);
+    }
+    if (lastHeard.present) {
+      map['last_heard'] = Variable<int>(lastHeard.value);
+    }
+    if (stationType.present) {
+      map['station_type'] = Variable<String>(
+        $StationsTable.$converterstationType.toSql(stationType.value),
+      );
+    }
+    if (messageCapability.present) {
+      map['message_capability'] = Variable<String>(
+        $StationsTable.$convertermessageCapability.toSql(
+          messageCapability.value,
+        ),
+      );
+    }
+    if (capabilities.present) {
+      map['capabilities'] = Variable<String>(capabilities.value);
+    }
+    if (lat.present) {
+      map['lat'] = Variable<double>(lat.value);
+    }
+    if (lon.present) {
+      map['lon'] = Variable<double>(lon.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('StationsCompanion(')
+          ..write('callsign: $callsign, ')
+          ..write('symbolTable: $symbolTable, ')
+          ..write('symbolCode: $symbolCode, ')
+          ..write('comment: $comment, ')
+          ..write('rawPacket: $rawPacket, ')
+          ..write('device: $device, ')
+          ..write('lastHeard: $lastHeard, ')
+          ..write('stationType: $stationType, ')
+          ..write('messageCapability: $messageCapability, ')
+          ..write('capabilities: $capabilities, ')
+          ..write('lat: $lat, ')
+          ..write('lon: $lon, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PositionHistoryTable extends PositionHistory
+    with TableInfo<$PositionHistoryTable, PositionHistoryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PositionHistoryTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _callsignMeta = const VerificationMeta(
+    'callsign',
+  );
+  @override
+  late final GeneratedColumn<String> callsign = GeneratedColumn<String>(
+    'callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES stations (callsign) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _latitudeMeta = const VerificationMeta(
+    'latitude',
+  );
+  @override
+  late final GeneratedColumn<double> latitude = GeneratedColumn<double>(
+    'latitude',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _longitudeMeta = const VerificationMeta(
+    'longitude',
+  );
+  @override
+  late final GeneratedColumn<double> longitude = GeneratedColumn<double>(
+    'longitude',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<int> timestamp = GeneratedColumn<int>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    callsign,
+    latitude,
+    longitude,
+    timestamp,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'position_history';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PositionHistoryRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('callsign')) {
+      context.handle(
+        _callsignMeta,
+        callsign.isAcceptableOrUnknown(data['callsign']!, _callsignMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_callsignMeta);
+    }
+    if (data.containsKey('latitude')) {
+      context.handle(
+        _latitudeMeta,
+        latitude.isAcceptableOrUnknown(data['latitude']!, _latitudeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_latitudeMeta);
+    }
+    if (data.containsKey('longitude')) {
+      context.handle(
+        _longitudeMeta,
+        longitude.isAcceptableOrUnknown(data['longitude']!, _longitudeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_longitudeMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PositionHistoryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PositionHistoryRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      callsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}callsign'],
+      )!,
+      latitude: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}latitude'],
+      )!,
+      longitude: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}longitude'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}timestamp'],
+      )!,
+    );
+  }
+
+  @override
+  $PositionHistoryTable createAlias(String alias) {
+    return $PositionHistoryTable(attachedDatabase, alias);
+  }
+}
+
+class PositionHistoryRow extends DataClass
+    implements Insertable<PositionHistoryRow> {
+  final int id;
+  final String callsign;
+  final double latitude;
+  final double longitude;
+  final int timestamp;
+  const PositionHistoryRow({
+    required this.id,
+    required this.callsign,
+    required this.latitude,
+    required this.longitude,
+    required this.timestamp,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['callsign'] = Variable<String>(callsign);
+    map['latitude'] = Variable<double>(latitude);
+    map['longitude'] = Variable<double>(longitude);
+    map['timestamp'] = Variable<int>(timestamp);
+    return map;
+  }
+
+  PositionHistoryCompanion toCompanion(bool nullToAbsent) {
+    return PositionHistoryCompanion(
+      id: Value(id),
+      callsign: Value(callsign),
+      latitude: Value(latitude),
+      longitude: Value(longitude),
+      timestamp: Value(timestamp),
+    );
+  }
+
+  factory PositionHistoryRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PositionHistoryRow(
+      id: serializer.fromJson<int>(json['id']),
+      callsign: serializer.fromJson<String>(json['callsign']),
+      latitude: serializer.fromJson<double>(json['latitude']),
+      longitude: serializer.fromJson<double>(json['longitude']),
+      timestamp: serializer.fromJson<int>(json['timestamp']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'callsign': serializer.toJson<String>(callsign),
+      'latitude': serializer.toJson<double>(latitude),
+      'longitude': serializer.toJson<double>(longitude),
+      'timestamp': serializer.toJson<int>(timestamp),
+    };
+  }
+
+  PositionHistoryRow copyWith({
+    int? id,
+    String? callsign,
+    double? latitude,
+    double? longitude,
+    int? timestamp,
+  }) => PositionHistoryRow(
+    id: id ?? this.id,
+    callsign: callsign ?? this.callsign,
+    latitude: latitude ?? this.latitude,
+    longitude: longitude ?? this.longitude,
+    timestamp: timestamp ?? this.timestamp,
+  );
+  PositionHistoryRow copyWithCompanion(PositionHistoryCompanion data) {
+    return PositionHistoryRow(
+      id: data.id.present ? data.id.value : this.id,
+      callsign: data.callsign.present ? data.callsign.value : this.callsign,
+      latitude: data.latitude.present ? data.latitude.value : this.latitude,
+      longitude: data.longitude.present ? data.longitude.value : this.longitude,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PositionHistoryRow(')
+          ..write('id: $id, ')
+          ..write('callsign: $callsign, ')
+          ..write('latitude: $latitude, ')
+          ..write('longitude: $longitude, ')
+          ..write('timestamp: $timestamp')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, callsign, latitude, longitude, timestamp);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PositionHistoryRow &&
+          other.id == this.id &&
+          other.callsign == this.callsign &&
+          other.latitude == this.latitude &&
+          other.longitude == this.longitude &&
+          other.timestamp == this.timestamp);
+}
+
+class PositionHistoryCompanion extends UpdateCompanion<PositionHistoryRow> {
+  final Value<int> id;
+  final Value<String> callsign;
+  final Value<double> latitude;
+  final Value<double> longitude;
+  final Value<int> timestamp;
+  const PositionHistoryCompanion({
+    this.id = const Value.absent(),
+    this.callsign = const Value.absent(),
+    this.latitude = const Value.absent(),
+    this.longitude = const Value.absent(),
+    this.timestamp = const Value.absent(),
+  });
+  PositionHistoryCompanion.insert({
+    this.id = const Value.absent(),
+    required String callsign,
+    required double latitude,
+    required double longitude,
+    required int timestamp,
+  }) : callsign = Value(callsign),
+       latitude = Value(latitude),
+       longitude = Value(longitude),
+       timestamp = Value(timestamp);
+  static Insertable<PositionHistoryRow> custom({
+    Expression<int>? id,
+    Expression<String>? callsign,
+    Expression<double>? latitude,
+    Expression<double>? longitude,
+    Expression<int>? timestamp,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (callsign != null) 'callsign': callsign,
+      if (latitude != null) 'latitude': latitude,
+      if (longitude != null) 'longitude': longitude,
+      if (timestamp != null) 'timestamp': timestamp,
+    });
+  }
+
+  PositionHistoryCompanion copyWith({
+    Value<int>? id,
+    Value<String>? callsign,
+    Value<double>? latitude,
+    Value<double>? longitude,
+    Value<int>? timestamp,
+  }) {
+    return PositionHistoryCompanion(
+      id: id ?? this.id,
+      callsign: callsign ?? this.callsign,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (callsign.present) {
+      map['callsign'] = Variable<String>(callsign.value);
+    }
+    if (latitude.present) {
+      map['latitude'] = Variable<double>(latitude.value);
+    }
+    if (longitude.present) {
+      map['longitude'] = Variable<double>(longitude.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<int>(timestamp.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PositionHistoryCompanion(')
+          ..write('id: $id, ')
+          ..write('callsign: $callsign, ')
+          ..write('latitude: $latitude, ')
+          ..write('longitude: $longitude, ')
+          ..write('timestamp: $timestamp')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PacketsTable extends Packets with TableInfo<$PacketsTable, PacketRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PacketsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _rawLineMeta = const VerificationMeta(
+    'rawLine',
+  );
+  @override
+  late final GeneratedColumn<String> rawLine = GeneratedColumn<String>(
+    'raw_line',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<PacketTypeTag, String>
+  packetType = GeneratedColumn<String>(
+    'packet_type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<PacketTypeTag>($PacketsTable.$converterpacketType);
+  static const VerificationMeta _sourceCallsignMeta = const VerificationMeta(
+    'sourceCallsign',
+  );
+  @override
+  late final GeneratedColumn<String> sourceCallsign = GeneratedColumn<String>(
+    'source_callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _destinationMeta = const VerificationMeta(
+    'destination',
+  );
+  @override
+  late final GeneratedColumn<String> destination = GeneratedColumn<String>(
+    'destination',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _receivedAtMeta = const VerificationMeta(
+    'receivedAt',
+  );
+  @override
+  late final GeneratedColumn<int> receivedAt = GeneratedColumn<int>(
+    'received_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _isOutgoingMeta = const VerificationMeta(
+    'isOutgoing',
+  );
+  @override
+  late final GeneratedColumn<bool> isOutgoing = GeneratedColumn<bool>(
+    'is_outgoing',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_outgoing" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<PacketSource, String>
+  sourceChannel = GeneratedColumn<String>(
+    'source_channel',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<PacketSource>($PacketsTable.$convertersourceChannel);
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    rawLine,
+    packetType,
+    sourceCallsign,
+    destination,
+    receivedAt,
+    isOutgoing,
+    sourceChannel,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'packets';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PacketRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('raw_line')) {
+      context.handle(
+        _rawLineMeta,
+        rawLine.isAcceptableOrUnknown(data['raw_line']!, _rawLineMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_rawLineMeta);
+    }
+    if (data.containsKey('source_callsign')) {
+      context.handle(
+        _sourceCallsignMeta,
+        sourceCallsign.isAcceptableOrUnknown(
+          data['source_callsign']!,
+          _sourceCallsignMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_sourceCallsignMeta);
+    }
+    if (data.containsKey('destination')) {
+      context.handle(
+        _destinationMeta,
+        destination.isAcceptableOrUnknown(
+          data['destination']!,
+          _destinationMeta,
+        ),
+      );
+    }
+    if (data.containsKey('received_at')) {
+      context.handle(
+        _receivedAtMeta,
+        receivedAt.isAcceptableOrUnknown(data['received_at']!, _receivedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_receivedAtMeta);
+    }
+    if (data.containsKey('is_outgoing')) {
+      context.handle(
+        _isOutgoingMeta,
+        isOutgoing.isAcceptableOrUnknown(data['is_outgoing']!, _isOutgoingMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  PacketRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PacketRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      rawLine: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}raw_line'],
+      )!,
+      packetType: $PacketsTable.$converterpacketType.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}packet_type'],
+        )!,
+      ),
+      sourceCallsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}source_callsign'],
+      )!,
+      destination: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}destination'],
+      ),
+      receivedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}received_at'],
+      )!,
+      isOutgoing: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_outgoing'],
+      )!,
+      sourceChannel: $PacketsTable.$convertersourceChannel.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source_channel'],
+        )!,
+      ),
+    );
+  }
+
+  @override
+  $PacketsTable createAlias(String alias) {
+    return $PacketsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<PacketTypeTag, String, String>
+  $converterpacketType = const EnumNameConverter(PacketTypeTag.values);
+  static JsonTypeConverter2<PacketSource, String, String>
+  $convertersourceChannel = const EnumNameConverter(PacketSource.values);
+}
+
+class PacketRow extends DataClass implements Insertable<PacketRow> {
+  final int id;
+  final String rawLine;
+  final PacketTypeTag packetType;
+  final String sourceCallsign;
+  final String? destination;
+  final int receivedAt;
+  final bool isOutgoing;
+  final PacketSource sourceChannel;
+  const PacketRow({
+    required this.id,
+    required this.rawLine,
+    required this.packetType,
+    required this.sourceCallsign,
+    this.destination,
+    required this.receivedAt,
+    required this.isOutgoing,
+    required this.sourceChannel,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['raw_line'] = Variable<String>(rawLine);
+    {
+      map['packet_type'] = Variable<String>(
+        $PacketsTable.$converterpacketType.toSql(packetType),
+      );
+    }
+    map['source_callsign'] = Variable<String>(sourceCallsign);
+    if (!nullToAbsent || destination != null) {
+      map['destination'] = Variable<String>(destination);
+    }
+    map['received_at'] = Variable<int>(receivedAt);
+    map['is_outgoing'] = Variable<bool>(isOutgoing);
+    {
+      map['source_channel'] = Variable<String>(
+        $PacketsTable.$convertersourceChannel.toSql(sourceChannel),
+      );
+    }
+    return map;
+  }
+
+  PacketsCompanion toCompanion(bool nullToAbsent) {
+    return PacketsCompanion(
+      id: Value(id),
+      rawLine: Value(rawLine),
+      packetType: Value(packetType),
+      sourceCallsign: Value(sourceCallsign),
+      destination: destination == null && nullToAbsent
+          ? const Value.absent()
+          : Value(destination),
+      receivedAt: Value(receivedAt),
+      isOutgoing: Value(isOutgoing),
+      sourceChannel: Value(sourceChannel),
+    );
+  }
+
+  factory PacketRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PacketRow(
+      id: serializer.fromJson<int>(json['id']),
+      rawLine: serializer.fromJson<String>(json['rawLine']),
+      packetType: $PacketsTable.$converterpacketType.fromJson(
+        serializer.fromJson<String>(json['packetType']),
+      ),
+      sourceCallsign: serializer.fromJson<String>(json['sourceCallsign']),
+      destination: serializer.fromJson<String?>(json['destination']),
+      receivedAt: serializer.fromJson<int>(json['receivedAt']),
+      isOutgoing: serializer.fromJson<bool>(json['isOutgoing']),
+      sourceChannel: $PacketsTable.$convertersourceChannel.fromJson(
+        serializer.fromJson<String>(json['sourceChannel']),
+      ),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'rawLine': serializer.toJson<String>(rawLine),
+      'packetType': serializer.toJson<String>(
+        $PacketsTable.$converterpacketType.toJson(packetType),
+      ),
+      'sourceCallsign': serializer.toJson<String>(sourceCallsign),
+      'destination': serializer.toJson<String?>(destination),
+      'receivedAt': serializer.toJson<int>(receivedAt),
+      'isOutgoing': serializer.toJson<bool>(isOutgoing),
+      'sourceChannel': serializer.toJson<String>(
+        $PacketsTable.$convertersourceChannel.toJson(sourceChannel),
+      ),
+    };
+  }
+
+  PacketRow copyWith({
+    int? id,
+    String? rawLine,
+    PacketTypeTag? packetType,
+    String? sourceCallsign,
+    Value<String?> destination = const Value.absent(),
+    int? receivedAt,
+    bool? isOutgoing,
+    PacketSource? sourceChannel,
+  }) => PacketRow(
+    id: id ?? this.id,
+    rawLine: rawLine ?? this.rawLine,
+    packetType: packetType ?? this.packetType,
+    sourceCallsign: sourceCallsign ?? this.sourceCallsign,
+    destination: destination.present ? destination.value : this.destination,
+    receivedAt: receivedAt ?? this.receivedAt,
+    isOutgoing: isOutgoing ?? this.isOutgoing,
+    sourceChannel: sourceChannel ?? this.sourceChannel,
+  );
+  PacketRow copyWithCompanion(PacketsCompanion data) {
+    return PacketRow(
+      id: data.id.present ? data.id.value : this.id,
+      rawLine: data.rawLine.present ? data.rawLine.value : this.rawLine,
+      packetType: data.packetType.present
+          ? data.packetType.value
+          : this.packetType,
+      sourceCallsign: data.sourceCallsign.present
+          ? data.sourceCallsign.value
+          : this.sourceCallsign,
+      destination: data.destination.present
+          ? data.destination.value
+          : this.destination,
+      receivedAt: data.receivedAt.present
+          ? data.receivedAt.value
+          : this.receivedAt,
+      isOutgoing: data.isOutgoing.present
+          ? data.isOutgoing.value
+          : this.isOutgoing,
+      sourceChannel: data.sourceChannel.present
+          ? data.sourceChannel.value
+          : this.sourceChannel,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PacketRow(')
+          ..write('id: $id, ')
+          ..write('rawLine: $rawLine, ')
+          ..write('packetType: $packetType, ')
+          ..write('sourceCallsign: $sourceCallsign, ')
+          ..write('destination: $destination, ')
+          ..write('receivedAt: $receivedAt, ')
+          ..write('isOutgoing: $isOutgoing, ')
+          ..write('sourceChannel: $sourceChannel')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    rawLine,
+    packetType,
+    sourceCallsign,
+    destination,
+    receivedAt,
+    isOutgoing,
+    sourceChannel,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PacketRow &&
+          other.id == this.id &&
+          other.rawLine == this.rawLine &&
+          other.packetType == this.packetType &&
+          other.sourceCallsign == this.sourceCallsign &&
+          other.destination == this.destination &&
+          other.receivedAt == this.receivedAt &&
+          other.isOutgoing == this.isOutgoing &&
+          other.sourceChannel == this.sourceChannel);
+}
+
+class PacketsCompanion extends UpdateCompanion<PacketRow> {
+  final Value<int> id;
+  final Value<String> rawLine;
+  final Value<PacketTypeTag> packetType;
+  final Value<String> sourceCallsign;
+  final Value<String?> destination;
+  final Value<int> receivedAt;
+  final Value<bool> isOutgoing;
+  final Value<PacketSource> sourceChannel;
+  const PacketsCompanion({
+    this.id = const Value.absent(),
+    this.rawLine = const Value.absent(),
+    this.packetType = const Value.absent(),
+    this.sourceCallsign = const Value.absent(),
+    this.destination = const Value.absent(),
+    this.receivedAt = const Value.absent(),
+    this.isOutgoing = const Value.absent(),
+    this.sourceChannel = const Value.absent(),
+  });
+  PacketsCompanion.insert({
+    this.id = const Value.absent(),
+    required String rawLine,
+    required PacketTypeTag packetType,
+    required String sourceCallsign,
+    this.destination = const Value.absent(),
+    required int receivedAt,
+    this.isOutgoing = const Value.absent(),
+    required PacketSource sourceChannel,
+  }) : rawLine = Value(rawLine),
+       packetType = Value(packetType),
+       sourceCallsign = Value(sourceCallsign),
+       receivedAt = Value(receivedAt),
+       sourceChannel = Value(sourceChannel);
+  static Insertable<PacketRow> custom({
+    Expression<int>? id,
+    Expression<String>? rawLine,
+    Expression<String>? packetType,
+    Expression<String>? sourceCallsign,
+    Expression<String>? destination,
+    Expression<int>? receivedAt,
+    Expression<bool>? isOutgoing,
+    Expression<String>? sourceChannel,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (rawLine != null) 'raw_line': rawLine,
+      if (packetType != null) 'packet_type': packetType,
+      if (sourceCallsign != null) 'source_callsign': sourceCallsign,
+      if (destination != null) 'destination': destination,
+      if (receivedAt != null) 'received_at': receivedAt,
+      if (isOutgoing != null) 'is_outgoing': isOutgoing,
+      if (sourceChannel != null) 'source_channel': sourceChannel,
+    });
+  }
+
+  PacketsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? rawLine,
+    Value<PacketTypeTag>? packetType,
+    Value<String>? sourceCallsign,
+    Value<String?>? destination,
+    Value<int>? receivedAt,
+    Value<bool>? isOutgoing,
+    Value<PacketSource>? sourceChannel,
+  }) {
+    return PacketsCompanion(
+      id: id ?? this.id,
+      rawLine: rawLine ?? this.rawLine,
+      packetType: packetType ?? this.packetType,
+      sourceCallsign: sourceCallsign ?? this.sourceCallsign,
+      destination: destination ?? this.destination,
+      receivedAt: receivedAt ?? this.receivedAt,
+      isOutgoing: isOutgoing ?? this.isOutgoing,
+      sourceChannel: sourceChannel ?? this.sourceChannel,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (rawLine.present) {
+      map['raw_line'] = Variable<String>(rawLine.value);
+    }
+    if (packetType.present) {
+      map['packet_type'] = Variable<String>(
+        $PacketsTable.$converterpacketType.toSql(packetType.value),
+      );
+    }
+    if (sourceCallsign.present) {
+      map['source_callsign'] = Variable<String>(sourceCallsign.value);
+    }
+    if (destination.present) {
+      map['destination'] = Variable<String>(destination.value);
+    }
+    if (receivedAt.present) {
+      map['received_at'] = Variable<int>(receivedAt.value);
+    }
+    if (isOutgoing.present) {
+      map['is_outgoing'] = Variable<bool>(isOutgoing.value);
+    }
+    if (sourceChannel.present) {
+      map['source_channel'] = Variable<String>(
+        $PacketsTable.$convertersourceChannel.toSql(sourceChannel.value),
+      );
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PacketsCompanion(')
+          ..write('id: $id, ')
+          ..write('rawLine: $rawLine, ')
+          ..write('packetType: $packetType, ')
+          ..write('sourceCallsign: $sourceCallsign, ')
+          ..write('destination: $destination, ')
+          ..write('receivedAt: $receivedAt, ')
+          ..write('isOutgoing: $isOutgoing, ')
+          ..write('sourceChannel: $sourceChannel')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ConversationsTable extends Conversations
+    with TableInfo<$ConversationsTable, ConversationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ConversationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _peerCallsignMeta = const VerificationMeta(
+    'peerCallsign',
+  );
+  @override
+  late final GeneratedColumn<String> peerCallsign = GeneratedColumn<String>(
+    'peer_callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastMessageAtMeta = const VerificationMeta(
+    'lastMessageAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastMessageAt = GeneratedColumn<int>(
+    'last_message_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _unreadCountMeta = const VerificationMeta(
+    'unreadCount',
+  );
+  @override
+  late final GeneratedColumn<int> unreadCount = GeneratedColumn<int>(
+    'unread_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    peerCallsign,
+    lastMessageAt,
+    unreadCount,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'conversations';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ConversationRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('peer_callsign')) {
+      context.handle(
+        _peerCallsignMeta,
+        peerCallsign.isAcceptableOrUnknown(
+          data['peer_callsign']!,
+          _peerCallsignMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_peerCallsignMeta);
+    }
+    if (data.containsKey('last_message_at')) {
+      context.handle(
+        _lastMessageAtMeta,
+        lastMessageAt.isAcceptableOrUnknown(
+          data['last_message_at']!,
+          _lastMessageAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_lastMessageAtMeta);
+    }
+    if (data.containsKey('unread_count')) {
+      context.handle(
+        _unreadCountMeta,
+        unreadCount.isAcceptableOrUnknown(
+          data['unread_count']!,
+          _unreadCountMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {peerCallsign};
+  @override
+  ConversationRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ConversationRow(
+      peerCallsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}peer_callsign'],
+      )!,
+      lastMessageAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_message_at'],
+      )!,
+      unreadCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}unread_count'],
+      )!,
+    );
+  }
+
+  @override
+  $ConversationsTable createAlias(String alias) {
+    return $ConversationsTable(attachedDatabase, alias);
+  }
+}
+
+class ConversationRow extends DataClass implements Insertable<ConversationRow> {
+  final String peerCallsign;
+  final int lastMessageAt;
+  final int unreadCount;
+  const ConversationRow({
+    required this.peerCallsign,
+    required this.lastMessageAt,
+    required this.unreadCount,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['peer_callsign'] = Variable<String>(peerCallsign);
+    map['last_message_at'] = Variable<int>(lastMessageAt);
+    map['unread_count'] = Variable<int>(unreadCount);
+    return map;
+  }
+
+  ConversationsCompanion toCompanion(bool nullToAbsent) {
+    return ConversationsCompanion(
+      peerCallsign: Value(peerCallsign),
+      lastMessageAt: Value(lastMessageAt),
+      unreadCount: Value(unreadCount),
+    );
+  }
+
+  factory ConversationRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ConversationRow(
+      peerCallsign: serializer.fromJson<String>(json['peerCallsign']),
+      lastMessageAt: serializer.fromJson<int>(json['lastMessageAt']),
+      unreadCount: serializer.fromJson<int>(json['unreadCount']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'peerCallsign': serializer.toJson<String>(peerCallsign),
+      'lastMessageAt': serializer.toJson<int>(lastMessageAt),
+      'unreadCount': serializer.toJson<int>(unreadCount),
+    };
+  }
+
+  ConversationRow copyWith({
+    String? peerCallsign,
+    int? lastMessageAt,
+    int? unreadCount,
+  }) => ConversationRow(
+    peerCallsign: peerCallsign ?? this.peerCallsign,
+    lastMessageAt: lastMessageAt ?? this.lastMessageAt,
+    unreadCount: unreadCount ?? this.unreadCount,
+  );
+  ConversationRow copyWithCompanion(ConversationsCompanion data) {
+    return ConversationRow(
+      peerCallsign: data.peerCallsign.present
+          ? data.peerCallsign.value
+          : this.peerCallsign,
+      lastMessageAt: data.lastMessageAt.present
+          ? data.lastMessageAt.value
+          : this.lastMessageAt,
+      unreadCount: data.unreadCount.present
+          ? data.unreadCount.value
+          : this.unreadCount,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ConversationRow(')
+          ..write('peerCallsign: $peerCallsign, ')
+          ..write('lastMessageAt: $lastMessageAt, ')
+          ..write('unreadCount: $unreadCount')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(peerCallsign, lastMessageAt, unreadCount);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ConversationRow &&
+          other.peerCallsign == this.peerCallsign &&
+          other.lastMessageAt == this.lastMessageAt &&
+          other.unreadCount == this.unreadCount);
+}
+
+class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
+  final Value<String> peerCallsign;
+  final Value<int> lastMessageAt;
+  final Value<int> unreadCount;
+  final Value<int> rowid;
+  const ConversationsCompanion({
+    this.peerCallsign = const Value.absent(),
+    this.lastMessageAt = const Value.absent(),
+    this.unreadCount = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ConversationsCompanion.insert({
+    required String peerCallsign,
+    required int lastMessageAt,
+    this.unreadCount = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : peerCallsign = Value(peerCallsign),
+       lastMessageAt = Value(lastMessageAt);
+  static Insertable<ConversationRow> custom({
+    Expression<String>? peerCallsign,
+    Expression<int>? lastMessageAt,
+    Expression<int>? unreadCount,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (peerCallsign != null) 'peer_callsign': peerCallsign,
+      if (lastMessageAt != null) 'last_message_at': lastMessageAt,
+      if (unreadCount != null) 'unread_count': unreadCount,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ConversationsCompanion copyWith({
+    Value<String>? peerCallsign,
+    Value<int>? lastMessageAt,
+    Value<int>? unreadCount,
+    Value<int>? rowid,
+  }) {
+    return ConversationsCompanion(
+      peerCallsign: peerCallsign ?? this.peerCallsign,
+      lastMessageAt: lastMessageAt ?? this.lastMessageAt,
+      unreadCount: unreadCount ?? this.unreadCount,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (peerCallsign.present) {
+      map['peer_callsign'] = Variable<String>(peerCallsign.value);
+    }
+    if (lastMessageAt.present) {
+      map['last_message_at'] = Variable<int>(lastMessageAt.value);
+    }
+    if (unreadCount.present) {
+      map['unread_count'] = Variable<int>(unreadCount.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ConversationsCompanion(')
+          ..write('peerCallsign: $peerCallsign, ')
+          ..write('lastMessageAt: $lastMessageAt, ')
+          ..write('unreadCount: $unreadCount, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $MessageEntriesTable extends MessageEntries
+    with TableInfo<$MessageEntriesTable, MessageEntryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $MessageEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _conversationPeerMeta = const VerificationMeta(
+    'conversationPeer',
+  );
+  @override
+  late final GeneratedColumn<String> conversationPeer = GeneratedColumn<String>(
+    'conversation_peer',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES conversations (peer_callsign) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _fromCallsignMeta = const VerificationMeta(
+    'fromCallsign',
+  );
+  @override
+  late final GeneratedColumn<String> fromCallsign = GeneratedColumn<String>(
+    'from_callsign',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _addresseeMeta = const VerificationMeta(
+    'addressee',
+  );
+  @override
+  late final GeneratedColumn<String> addressee = GeneratedColumn<String>(
+    'addressee',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+    'body',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<int> timestamp = GeneratedColumn<int>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _isOutgoingMeta = const VerificationMeta(
+    'isOutgoing',
+  );
+  @override
+  late final GeneratedColumn<bool> isOutgoing = GeneratedColumn<bool>(
+    'is_outgoing',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_outgoing" IN (0, 1))',
+    ),
+  );
+  static const VerificationMeta _wireIdMeta = const VerificationMeta('wireId');
+  @override
+  late final GeneratedColumn<String> wireId = GeneratedColumn<String>(
+    'wire_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<MessageStatus, String> status =
+      GeneratedColumn<String>(
+        'status',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<MessageStatus>($MessageEntriesTable.$converterstatus);
+  static const VerificationMeta _retryCountMeta = const VerificationMeta(
+    'retryCount',
+  );
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<MessageCategory, String>
+  category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<MessageCategory>($MessageEntriesTable.$convertercategory);
+  static const VerificationMeta _groupNameMeta = const VerificationMeta(
+    'groupName',
+  );
+  @override
+  late final GeneratedColumn<String> groupName = GeneratedColumn<String>(
+    'group_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    conversationPeer,
+    fromCallsign,
+    addressee,
+    body,
+    timestamp,
+    isOutgoing,
+    wireId,
+    status,
+    retryCount,
+    category,
+    groupName,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'message_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<MessageEntryRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('conversation_peer')) {
+      context.handle(
+        _conversationPeerMeta,
+        conversationPeer.isAcceptableOrUnknown(
+          data['conversation_peer']!,
+          _conversationPeerMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_conversationPeerMeta);
+    }
+    if (data.containsKey('from_callsign')) {
+      context.handle(
+        _fromCallsignMeta,
+        fromCallsign.isAcceptableOrUnknown(
+          data['from_callsign']!,
+          _fromCallsignMeta,
+        ),
+      );
+    }
+    if (data.containsKey('addressee')) {
+      context.handle(
+        _addresseeMeta,
+        addressee.isAcceptableOrUnknown(data['addressee']!, _addresseeMeta),
+      );
+    }
+    if (data.containsKey('body')) {
+      context.handle(
+        _bodyMeta,
+        body.isAcceptableOrUnknown(data['body']!, _bodyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('is_outgoing')) {
+      context.handle(
+        _isOutgoingMeta,
+        isOutgoing.isAcceptableOrUnknown(data['is_outgoing']!, _isOutgoingMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_isOutgoingMeta);
+    }
+    if (data.containsKey('wire_id')) {
+      context.handle(
+        _wireIdMeta,
+        wireId.isAcceptableOrUnknown(data['wire_id']!, _wireIdMeta),
+      );
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+        _retryCountMeta,
+        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
+      );
+    }
+    if (data.containsKey('group_name')) {
+      context.handle(
+        _groupNameMeta,
+        groupName.isAcceptableOrUnknown(data['group_name']!, _groupNameMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  MessageEntryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MessageEntryRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      conversationPeer: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}conversation_peer'],
+      )!,
+      fromCallsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}from_callsign'],
+      ),
+      addressee: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}addressee'],
+      ),
+      body: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}body'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}timestamp'],
+      )!,
+      isOutgoing: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_outgoing'],
+      )!,
+      wireId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}wire_id'],
+      ),
+      status: $MessageEntriesTable.$converterstatus.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}status'],
+        )!,
+      ),
+      retryCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_count'],
+      )!,
+      category: $MessageEntriesTable.$convertercategory.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}category'],
+        )!,
+      ),
+      groupName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}group_name'],
+      ),
+    );
+  }
+
+  @override
+  $MessageEntriesTable createAlias(String alias) {
+    return $MessageEntriesTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<MessageStatus, String, String> $converterstatus =
+      const EnumNameConverter(MessageStatus.values);
+  static JsonTypeConverter2<MessageCategory, String, String>
+  $convertercategory = const EnumNameConverter(MessageCategory.values);
+}
+
+class MessageEntryRow extends DataClass implements Insertable<MessageEntryRow> {
+  final String id;
+  final String conversationPeer;
+  final String? fromCallsign;
+  final String? addressee;
+  final String body;
+  final int timestamp;
+  final bool isOutgoing;
+  final String? wireId;
+  final MessageStatus status;
+  final int retryCount;
+  final MessageCategory category;
+  final String? groupName;
+  const MessageEntryRow({
+    required this.id,
+    required this.conversationPeer,
+    this.fromCallsign,
+    this.addressee,
+    required this.body,
+    required this.timestamp,
+    required this.isOutgoing,
+    this.wireId,
+    required this.status,
+    required this.retryCount,
+    required this.category,
+    this.groupName,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['conversation_peer'] = Variable<String>(conversationPeer);
+    if (!nullToAbsent || fromCallsign != null) {
+      map['from_callsign'] = Variable<String>(fromCallsign);
+    }
+    if (!nullToAbsent || addressee != null) {
+      map['addressee'] = Variable<String>(addressee);
+    }
+    map['body'] = Variable<String>(body);
+    map['timestamp'] = Variable<int>(timestamp);
+    map['is_outgoing'] = Variable<bool>(isOutgoing);
+    if (!nullToAbsent || wireId != null) {
+      map['wire_id'] = Variable<String>(wireId);
+    }
+    {
+      map['status'] = Variable<String>(
+        $MessageEntriesTable.$converterstatus.toSql(status),
+      );
+    }
+    map['retry_count'] = Variable<int>(retryCount);
+    {
+      map['category'] = Variable<String>(
+        $MessageEntriesTable.$convertercategory.toSql(category),
+      );
+    }
+    if (!nullToAbsent || groupName != null) {
+      map['group_name'] = Variable<String>(groupName);
+    }
+    return map;
+  }
+
+  MessageEntriesCompanion toCompanion(bool nullToAbsent) {
+    return MessageEntriesCompanion(
+      id: Value(id),
+      conversationPeer: Value(conversationPeer),
+      fromCallsign: fromCallsign == null && nullToAbsent
+          ? const Value.absent()
+          : Value(fromCallsign),
+      addressee: addressee == null && nullToAbsent
+          ? const Value.absent()
+          : Value(addressee),
+      body: Value(body),
+      timestamp: Value(timestamp),
+      isOutgoing: Value(isOutgoing),
+      wireId: wireId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(wireId),
+      status: Value(status),
+      retryCount: Value(retryCount),
+      category: Value(category),
+      groupName: groupName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(groupName),
+    );
+  }
+
+  factory MessageEntryRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MessageEntryRow(
+      id: serializer.fromJson<String>(json['id']),
+      conversationPeer: serializer.fromJson<String>(json['conversationPeer']),
+      fromCallsign: serializer.fromJson<String?>(json['fromCallsign']),
+      addressee: serializer.fromJson<String?>(json['addressee']),
+      body: serializer.fromJson<String>(json['body']),
+      timestamp: serializer.fromJson<int>(json['timestamp']),
+      isOutgoing: serializer.fromJson<bool>(json['isOutgoing']),
+      wireId: serializer.fromJson<String?>(json['wireId']),
+      status: $MessageEntriesTable.$converterstatus.fromJson(
+        serializer.fromJson<String>(json['status']),
+      ),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      category: $MessageEntriesTable.$convertercategory.fromJson(
+        serializer.fromJson<String>(json['category']),
+      ),
+      groupName: serializer.fromJson<String?>(json['groupName']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'conversationPeer': serializer.toJson<String>(conversationPeer),
+      'fromCallsign': serializer.toJson<String?>(fromCallsign),
+      'addressee': serializer.toJson<String?>(addressee),
+      'body': serializer.toJson<String>(body),
+      'timestamp': serializer.toJson<int>(timestamp),
+      'isOutgoing': serializer.toJson<bool>(isOutgoing),
+      'wireId': serializer.toJson<String?>(wireId),
+      'status': serializer.toJson<String>(
+        $MessageEntriesTable.$converterstatus.toJson(status),
+      ),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'category': serializer.toJson<String>(
+        $MessageEntriesTable.$convertercategory.toJson(category),
+      ),
+      'groupName': serializer.toJson<String?>(groupName),
+    };
+  }
+
+  MessageEntryRow copyWith({
+    String? id,
+    String? conversationPeer,
+    Value<String?> fromCallsign = const Value.absent(),
+    Value<String?> addressee = const Value.absent(),
+    String? body,
+    int? timestamp,
+    bool? isOutgoing,
+    Value<String?> wireId = const Value.absent(),
+    MessageStatus? status,
+    int? retryCount,
+    MessageCategory? category,
+    Value<String?> groupName = const Value.absent(),
+  }) => MessageEntryRow(
+    id: id ?? this.id,
+    conversationPeer: conversationPeer ?? this.conversationPeer,
+    fromCallsign: fromCallsign.present ? fromCallsign.value : this.fromCallsign,
+    addressee: addressee.present ? addressee.value : this.addressee,
+    body: body ?? this.body,
+    timestamp: timestamp ?? this.timestamp,
+    isOutgoing: isOutgoing ?? this.isOutgoing,
+    wireId: wireId.present ? wireId.value : this.wireId,
+    status: status ?? this.status,
+    retryCount: retryCount ?? this.retryCount,
+    category: category ?? this.category,
+    groupName: groupName.present ? groupName.value : this.groupName,
+  );
+  MessageEntryRow copyWithCompanion(MessageEntriesCompanion data) {
+    return MessageEntryRow(
+      id: data.id.present ? data.id.value : this.id,
+      conversationPeer: data.conversationPeer.present
+          ? data.conversationPeer.value
+          : this.conversationPeer,
+      fromCallsign: data.fromCallsign.present
+          ? data.fromCallsign.value
+          : this.fromCallsign,
+      addressee: data.addressee.present ? data.addressee.value : this.addressee,
+      body: data.body.present ? data.body.value : this.body,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      isOutgoing: data.isOutgoing.present
+          ? data.isOutgoing.value
+          : this.isOutgoing,
+      wireId: data.wireId.present ? data.wireId.value : this.wireId,
+      status: data.status.present ? data.status.value : this.status,
+      retryCount: data.retryCount.present
+          ? data.retryCount.value
+          : this.retryCount,
+      category: data.category.present ? data.category.value : this.category,
+      groupName: data.groupName.present ? data.groupName.value : this.groupName,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MessageEntryRow(')
+          ..write('id: $id, ')
+          ..write('conversationPeer: $conversationPeer, ')
+          ..write('fromCallsign: $fromCallsign, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('isOutgoing: $isOutgoing, ')
+          ..write('wireId: $wireId, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('category: $category, ')
+          ..write('groupName: $groupName')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    conversationPeer,
+    fromCallsign,
+    addressee,
+    body,
+    timestamp,
+    isOutgoing,
+    wireId,
+    status,
+    retryCount,
+    category,
+    groupName,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MessageEntryRow &&
+          other.id == this.id &&
+          other.conversationPeer == this.conversationPeer &&
+          other.fromCallsign == this.fromCallsign &&
+          other.addressee == this.addressee &&
+          other.body == this.body &&
+          other.timestamp == this.timestamp &&
+          other.isOutgoing == this.isOutgoing &&
+          other.wireId == this.wireId &&
+          other.status == this.status &&
+          other.retryCount == this.retryCount &&
+          other.category == this.category &&
+          other.groupName == this.groupName);
+}
+
+class MessageEntriesCompanion extends UpdateCompanion<MessageEntryRow> {
+  final Value<String> id;
+  final Value<String> conversationPeer;
+  final Value<String?> fromCallsign;
+  final Value<String?> addressee;
+  final Value<String> body;
+  final Value<int> timestamp;
+  final Value<bool> isOutgoing;
+  final Value<String?> wireId;
+  final Value<MessageStatus> status;
+  final Value<int> retryCount;
+  final Value<MessageCategory> category;
+  final Value<String?> groupName;
+  final Value<int> rowid;
+  const MessageEntriesCompanion({
+    this.id = const Value.absent(),
+    this.conversationPeer = const Value.absent(),
+    this.fromCallsign = const Value.absent(),
+    this.addressee = const Value.absent(),
+    this.body = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.isOutgoing = const Value.absent(),
+    this.wireId = const Value.absent(),
+    this.status = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.category = const Value.absent(),
+    this.groupName = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  MessageEntriesCompanion.insert({
+    required String id,
+    required String conversationPeer,
+    this.fromCallsign = const Value.absent(),
+    this.addressee = const Value.absent(),
+    required String body,
+    required int timestamp,
+    required bool isOutgoing,
+    this.wireId = const Value.absent(),
+    required MessageStatus status,
+    this.retryCount = const Value.absent(),
+    required MessageCategory category,
+    this.groupName = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       conversationPeer = Value(conversationPeer),
+       body = Value(body),
+       timestamp = Value(timestamp),
+       isOutgoing = Value(isOutgoing),
+       status = Value(status),
+       category = Value(category);
+  static Insertable<MessageEntryRow> custom({
+    Expression<String>? id,
+    Expression<String>? conversationPeer,
+    Expression<String>? fromCallsign,
+    Expression<String>? addressee,
+    Expression<String>? body,
+    Expression<int>? timestamp,
+    Expression<bool>? isOutgoing,
+    Expression<String>? wireId,
+    Expression<String>? status,
+    Expression<int>? retryCount,
+    Expression<String>? category,
+    Expression<String>? groupName,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (conversationPeer != null) 'conversation_peer': conversationPeer,
+      if (fromCallsign != null) 'from_callsign': fromCallsign,
+      if (addressee != null) 'addressee': addressee,
+      if (body != null) 'body': body,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (isOutgoing != null) 'is_outgoing': isOutgoing,
+      if (wireId != null) 'wire_id': wireId,
+      if (status != null) 'status': status,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (category != null) 'category': category,
+      if (groupName != null) 'group_name': groupName,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  MessageEntriesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? conversationPeer,
+    Value<String?>? fromCallsign,
+    Value<String?>? addressee,
+    Value<String>? body,
+    Value<int>? timestamp,
+    Value<bool>? isOutgoing,
+    Value<String?>? wireId,
+    Value<MessageStatus>? status,
+    Value<int>? retryCount,
+    Value<MessageCategory>? category,
+    Value<String?>? groupName,
+    Value<int>? rowid,
+  }) {
+    return MessageEntriesCompanion(
+      id: id ?? this.id,
+      conversationPeer: conversationPeer ?? this.conversationPeer,
+      fromCallsign: fromCallsign ?? this.fromCallsign,
+      addressee: addressee ?? this.addressee,
+      body: body ?? this.body,
+      timestamp: timestamp ?? this.timestamp,
+      isOutgoing: isOutgoing ?? this.isOutgoing,
+      wireId: wireId ?? this.wireId,
+      status: status ?? this.status,
+      retryCount: retryCount ?? this.retryCount,
+      category: category ?? this.category,
+      groupName: groupName ?? this.groupName,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (conversationPeer.present) {
+      map['conversation_peer'] = Variable<String>(conversationPeer.value);
+    }
+    if (fromCallsign.present) {
+      map['from_callsign'] = Variable<String>(fromCallsign.value);
+    }
+    if (addressee.present) {
+      map['addressee'] = Variable<String>(addressee.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<int>(timestamp.value);
+    }
+    if (isOutgoing.present) {
+      map['is_outgoing'] = Variable<bool>(isOutgoing.value);
+    }
+    if (wireId.present) {
+      map['wire_id'] = Variable<String>(wireId.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(
+        $MessageEntriesTable.$converterstatus.toSql(status.value),
+      );
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(
+        $MessageEntriesTable.$convertercategory.toSql(category.value),
+      );
+    }
+    if (groupName.present) {
+      map['group_name'] = Variable<String>(groupName.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MessageEntriesCompanion(')
+          ..write('id: $id, ')
+          ..write('conversationPeer: $conversationPeer, ')
+          ..write('fromCallsign: $fromCallsign, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('isOutgoing: $isOutgoing, ')
+          ..write('wireId: $wireId, ')
+          ..write('status: $status, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('category: $category, ')
+          ..write('groupName: $groupName, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $GroupMessageEntriesTable extends GroupMessageEntries
+    with TableInfo<$GroupMessageEntriesTable, GroupMessageEntryRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $GroupMessageEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _groupNameMeta = const VerificationMeta(
+    'groupName',
+  );
+  @override
+  late final GeneratedColumn<String> groupName = GeneratedColumn<String>(
+    'group_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fromCallsignMeta = const VerificationMeta(
+    'fromCallsign',
+  );
+  @override
+  late final GeneratedColumn<String> fromCallsign = GeneratedColumn<String>(
+    'from_callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+    'body',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<int> timestamp = GeneratedColumn<int>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    groupName,
+    fromCallsign,
+    body,
+    timestamp,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'group_message_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<GroupMessageEntryRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('group_name')) {
+      context.handle(
+        _groupNameMeta,
+        groupName.isAcceptableOrUnknown(data['group_name']!, _groupNameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_groupNameMeta);
+    }
+    if (data.containsKey('from_callsign')) {
+      context.handle(
+        _fromCallsignMeta,
+        fromCallsign.isAcceptableOrUnknown(
+          data['from_callsign']!,
+          _fromCallsignMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_fromCallsignMeta);
+    }
+    if (data.containsKey('body')) {
+      context.handle(
+        _bodyMeta,
+        body.isAcceptableOrUnknown(data['body']!, _bodyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  GroupMessageEntryRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return GroupMessageEntryRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      groupName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}group_name'],
+      )!,
+      fromCallsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}from_callsign'],
+      )!,
+      body: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}body'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}timestamp'],
+      )!,
+    );
+  }
+
+  @override
+  $GroupMessageEntriesTable createAlias(String alias) {
+    return $GroupMessageEntriesTable(attachedDatabase, alias);
+  }
+}
+
+class GroupMessageEntryRow extends DataClass
+    implements Insertable<GroupMessageEntryRow> {
+  final String id;
+  final String groupName;
+  final String fromCallsign;
+  final String body;
+  final int timestamp;
+  const GroupMessageEntryRow({
+    required this.id,
+    required this.groupName,
+    required this.fromCallsign,
+    required this.body,
+    required this.timestamp,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['group_name'] = Variable<String>(groupName);
+    map['from_callsign'] = Variable<String>(fromCallsign);
+    map['body'] = Variable<String>(body);
+    map['timestamp'] = Variable<int>(timestamp);
+    return map;
+  }
+
+  GroupMessageEntriesCompanion toCompanion(bool nullToAbsent) {
+    return GroupMessageEntriesCompanion(
+      id: Value(id),
+      groupName: Value(groupName),
+      fromCallsign: Value(fromCallsign),
+      body: Value(body),
+      timestamp: Value(timestamp),
+    );
+  }
+
+  factory GroupMessageEntryRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return GroupMessageEntryRow(
+      id: serializer.fromJson<String>(json['id']),
+      groupName: serializer.fromJson<String>(json['groupName']),
+      fromCallsign: serializer.fromJson<String>(json['fromCallsign']),
+      body: serializer.fromJson<String>(json['body']),
+      timestamp: serializer.fromJson<int>(json['timestamp']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'groupName': serializer.toJson<String>(groupName),
+      'fromCallsign': serializer.toJson<String>(fromCallsign),
+      'body': serializer.toJson<String>(body),
+      'timestamp': serializer.toJson<int>(timestamp),
+    };
+  }
+
+  GroupMessageEntryRow copyWith({
+    String? id,
+    String? groupName,
+    String? fromCallsign,
+    String? body,
+    int? timestamp,
+  }) => GroupMessageEntryRow(
+    id: id ?? this.id,
+    groupName: groupName ?? this.groupName,
+    fromCallsign: fromCallsign ?? this.fromCallsign,
+    body: body ?? this.body,
+    timestamp: timestamp ?? this.timestamp,
+  );
+  GroupMessageEntryRow copyWithCompanion(GroupMessageEntriesCompanion data) {
+    return GroupMessageEntryRow(
+      id: data.id.present ? data.id.value : this.id,
+      groupName: data.groupName.present ? data.groupName.value : this.groupName,
+      fromCallsign: data.fromCallsign.present
+          ? data.fromCallsign.value
+          : this.fromCallsign,
+      body: data.body.present ? data.body.value : this.body,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('GroupMessageEntryRow(')
+          ..write('id: $id, ')
+          ..write('groupName: $groupName, ')
+          ..write('fromCallsign: $fromCallsign, ')
+          ..write('body: $body, ')
+          ..write('timestamp: $timestamp')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, groupName, fromCallsign, body, timestamp);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is GroupMessageEntryRow &&
+          other.id == this.id &&
+          other.groupName == this.groupName &&
+          other.fromCallsign == this.fromCallsign &&
+          other.body == this.body &&
+          other.timestamp == this.timestamp);
+}
+
+class GroupMessageEntriesCompanion
+    extends UpdateCompanion<GroupMessageEntryRow> {
+  final Value<String> id;
+  final Value<String> groupName;
+  final Value<String> fromCallsign;
+  final Value<String> body;
+  final Value<int> timestamp;
+  final Value<int> rowid;
+  const GroupMessageEntriesCompanion({
+    this.id = const Value.absent(),
+    this.groupName = const Value.absent(),
+    this.fromCallsign = const Value.absent(),
+    this.body = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  GroupMessageEntriesCompanion.insert({
+    required String id,
+    required String groupName,
+    required String fromCallsign,
+    required String body,
+    required int timestamp,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       groupName = Value(groupName),
+       fromCallsign = Value(fromCallsign),
+       body = Value(body),
+       timestamp = Value(timestamp);
+  static Insertable<GroupMessageEntryRow> custom({
+    Expression<String>? id,
+    Expression<String>? groupName,
+    Expression<String>? fromCallsign,
+    Expression<String>? body,
+    Expression<int>? timestamp,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (groupName != null) 'group_name': groupName,
+      if (fromCallsign != null) 'from_callsign': fromCallsign,
+      if (body != null) 'body': body,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  GroupMessageEntriesCompanion copyWith({
+    Value<String>? id,
+    Value<String>? groupName,
+    Value<String>? fromCallsign,
+    Value<String>? body,
+    Value<int>? timestamp,
+    Value<int>? rowid,
+  }) {
+    return GroupMessageEntriesCompanion(
+      id: id ?? this.id,
+      groupName: groupName ?? this.groupName,
+      fromCallsign: fromCallsign ?? this.fromCallsign,
+      body: body ?? this.body,
+      timestamp: timestamp ?? this.timestamp,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (groupName.present) {
+      map['group_name'] = Variable<String>(groupName.value);
+    }
+    if (fromCallsign.present) {
+      map['from_callsign'] = Variable<String>(fromCallsign.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<int>(timestamp.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('GroupMessageEntriesCompanion(')
+          ..write('id: $id, ')
+          ..write('groupName: $groupName, ')
+          ..write('fromCallsign: $fromCallsign, ')
+          ..write('body: $body, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $BulletinsTable extends Bulletins
+    with TableInfo<$BulletinsTable, BulletinRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $BulletinsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _sourceCallsignMeta = const VerificationMeta(
+    'sourceCallsign',
+  );
+  @override
+  late final GeneratedColumn<String> sourceCallsign = GeneratedColumn<String>(
+    'source_callsign',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _addresseeMeta = const VerificationMeta(
+    'addressee',
+  );
+  @override
+  late final GeneratedColumn<String> addressee = GeneratedColumn<String>(
+    'addressee',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+    'body',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _firstHeardAtMeta = const VerificationMeta(
+    'firstHeardAt',
+  );
+  @override
+  late final GeneratedColumn<int> firstHeardAt = GeneratedColumn<int>(
+    'first_heard_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastHeardAtMeta = const VerificationMeta(
+    'lastHeardAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastHeardAt = GeneratedColumn<int>(
+    'last_heard_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _heardCountMeta = const VerificationMeta(
+    'heardCount',
+  );
+  @override
+  late final GeneratedColumn<int> heardCount = GeneratedColumn<int>(
+    'heard_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(1),
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<BulletinCategory, String>
+  category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  ).withConverter<BulletinCategory>($BulletinsTable.$convertercategory);
+  static const VerificationMeta _lineNumberMeta = const VerificationMeta(
+    'lineNumber',
+  );
+  @override
+  late final GeneratedColumn<String> lineNumber = GeneratedColumn<String>(
+    'line_number',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _groupNameMeta = const VerificationMeta(
+    'groupName',
+  );
+  @override
+  late final GeneratedColumn<String> groupName = GeneratedColumn<String>(
+    'group_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Set<BulletinTransport>, String>
+  transports = GeneratedColumn<String>(
+    'transports',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  ).withConverter<Set<BulletinTransport>>($BulletinsTable.$convertertransports);
+  static const VerificationMeta _receivedLatMeta = const VerificationMeta(
+    'receivedLat',
+  );
+  @override
+  late final GeneratedColumn<double> receivedLat = GeneratedColumn<double>(
+    'received_lat',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _receivedLonMeta = const VerificationMeta(
+    'receivedLon',
+  );
+  @override
+  late final GeneratedColumn<double> receivedLon = GeneratedColumn<double>(
+    'received_lon',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isReadMeta = const VerificationMeta('isRead');
+  @override
+  late final GeneratedColumn<bool> isRead = GeneratedColumn<bool>(
+    'is_read',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_read" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    sourceCallsign,
+    addressee,
+    body,
+    firstHeardAt,
+    lastHeardAt,
+    heardCount,
+    category,
+    lineNumber,
+    groupName,
+    transports,
+    receivedLat,
+    receivedLon,
+    isRead,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'bulletins';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<BulletinRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('source_callsign')) {
+      context.handle(
+        _sourceCallsignMeta,
+        sourceCallsign.isAcceptableOrUnknown(
+          data['source_callsign']!,
+          _sourceCallsignMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_sourceCallsignMeta);
+    }
+    if (data.containsKey('addressee')) {
+      context.handle(
+        _addresseeMeta,
+        addressee.isAcceptableOrUnknown(data['addressee']!, _addresseeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_addresseeMeta);
+    }
+    if (data.containsKey('body')) {
+      context.handle(
+        _bodyMeta,
+        body.isAcceptableOrUnknown(data['body']!, _bodyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
+    }
+    if (data.containsKey('first_heard_at')) {
+      context.handle(
+        _firstHeardAtMeta,
+        firstHeardAt.isAcceptableOrUnknown(
+          data['first_heard_at']!,
+          _firstHeardAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_firstHeardAtMeta);
+    }
+    if (data.containsKey('last_heard_at')) {
+      context.handle(
+        _lastHeardAtMeta,
+        lastHeardAt.isAcceptableOrUnknown(
+          data['last_heard_at']!,
+          _lastHeardAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_lastHeardAtMeta);
+    }
+    if (data.containsKey('heard_count')) {
+      context.handle(
+        _heardCountMeta,
+        heardCount.isAcceptableOrUnknown(data['heard_count']!, _heardCountMeta),
+      );
+    }
+    if (data.containsKey('line_number')) {
+      context.handle(
+        _lineNumberMeta,
+        lineNumber.isAcceptableOrUnknown(data['line_number']!, _lineNumberMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_lineNumberMeta);
+    }
+    if (data.containsKey('group_name')) {
+      context.handle(
+        _groupNameMeta,
+        groupName.isAcceptableOrUnknown(data['group_name']!, _groupNameMeta),
+      );
+    }
+    if (data.containsKey('received_lat')) {
+      context.handle(
+        _receivedLatMeta,
+        receivedLat.isAcceptableOrUnknown(
+          data['received_lat']!,
+          _receivedLatMeta,
+        ),
+      );
+    }
+    if (data.containsKey('received_lon')) {
+      context.handle(
+        _receivedLonMeta,
+        receivedLon.isAcceptableOrUnknown(
+          data['received_lon']!,
+          _receivedLonMeta,
+        ),
+      );
+    }
+    if (data.containsKey('is_read')) {
+      context.handle(
+        _isReadMeta,
+        isRead.isAcceptableOrUnknown(data['is_read']!, _isReadMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {sourceCallsign, addressee};
+  @override
+  BulletinRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return BulletinRow(
+      sourceCallsign: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}source_callsign'],
+      )!,
+      addressee: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}addressee'],
+      )!,
+      body: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}body'],
+      )!,
+      firstHeardAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}first_heard_at'],
+      )!,
+      lastHeardAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_heard_at'],
+      )!,
+      heardCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}heard_count'],
+      )!,
+      category: $BulletinsTable.$convertercategory.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}category'],
+        )!,
+      ),
+      lineNumber: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}line_number'],
+      )!,
+      groupName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}group_name'],
+      ),
+      transports: $BulletinsTable.$convertertransports.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}transports'],
+        )!,
+      ),
+      receivedLat: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}received_lat'],
+      ),
+      receivedLon: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}received_lon'],
+      ),
+      isRead: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_read'],
+      )!,
+    );
+  }
+
+  @override
+  $BulletinsTable createAlias(String alias) {
+    return $BulletinsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<BulletinCategory, String, String>
+  $convertercategory = const EnumNameConverter(BulletinCategory.values);
+  static TypeConverter<Set<BulletinTransport>, String> $convertertransports =
+      const BulletinTransportsConverter();
+}
+
+class BulletinRow extends DataClass implements Insertable<BulletinRow> {
+  final String sourceCallsign;
+  final String addressee;
+  final String body;
+  final int firstHeardAt;
+  final int lastHeardAt;
+  final int heardCount;
+  final BulletinCategory category;
+  final String lineNumber;
+  final String? groupName;
+  final Set<BulletinTransport> transports;
+  final double? receivedLat;
+  final double? receivedLon;
+  final bool isRead;
+  const BulletinRow({
+    required this.sourceCallsign,
+    required this.addressee,
+    required this.body,
+    required this.firstHeardAt,
+    required this.lastHeardAt,
+    required this.heardCount,
+    required this.category,
+    required this.lineNumber,
+    this.groupName,
+    required this.transports,
+    this.receivedLat,
+    this.receivedLon,
+    required this.isRead,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['source_callsign'] = Variable<String>(sourceCallsign);
+    map['addressee'] = Variable<String>(addressee);
+    map['body'] = Variable<String>(body);
+    map['first_heard_at'] = Variable<int>(firstHeardAt);
+    map['last_heard_at'] = Variable<int>(lastHeardAt);
+    map['heard_count'] = Variable<int>(heardCount);
+    {
+      map['category'] = Variable<String>(
+        $BulletinsTable.$convertercategory.toSql(category),
+      );
+    }
+    map['line_number'] = Variable<String>(lineNumber);
+    if (!nullToAbsent || groupName != null) {
+      map['group_name'] = Variable<String>(groupName);
+    }
+    {
+      map['transports'] = Variable<String>(
+        $BulletinsTable.$convertertransports.toSql(transports),
+      );
+    }
+    if (!nullToAbsent || receivedLat != null) {
+      map['received_lat'] = Variable<double>(receivedLat);
+    }
+    if (!nullToAbsent || receivedLon != null) {
+      map['received_lon'] = Variable<double>(receivedLon);
+    }
+    map['is_read'] = Variable<bool>(isRead);
+    return map;
+  }
+
+  BulletinsCompanion toCompanion(bool nullToAbsent) {
+    return BulletinsCompanion(
+      sourceCallsign: Value(sourceCallsign),
+      addressee: Value(addressee),
+      body: Value(body),
+      firstHeardAt: Value(firstHeardAt),
+      lastHeardAt: Value(lastHeardAt),
+      heardCount: Value(heardCount),
+      category: Value(category),
+      lineNumber: Value(lineNumber),
+      groupName: groupName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(groupName),
+      transports: Value(transports),
+      receivedLat: receivedLat == null && nullToAbsent
+          ? const Value.absent()
+          : Value(receivedLat),
+      receivedLon: receivedLon == null && nullToAbsent
+          ? const Value.absent()
+          : Value(receivedLon),
+      isRead: Value(isRead),
+    );
+  }
+
+  factory BulletinRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return BulletinRow(
+      sourceCallsign: serializer.fromJson<String>(json['sourceCallsign']),
+      addressee: serializer.fromJson<String>(json['addressee']),
+      body: serializer.fromJson<String>(json['body']),
+      firstHeardAt: serializer.fromJson<int>(json['firstHeardAt']),
+      lastHeardAt: serializer.fromJson<int>(json['lastHeardAt']),
+      heardCount: serializer.fromJson<int>(json['heardCount']),
+      category: $BulletinsTable.$convertercategory.fromJson(
+        serializer.fromJson<String>(json['category']),
+      ),
+      lineNumber: serializer.fromJson<String>(json['lineNumber']),
+      groupName: serializer.fromJson<String?>(json['groupName']),
+      transports: serializer.fromJson<Set<BulletinTransport>>(
+        json['transports'],
+      ),
+      receivedLat: serializer.fromJson<double?>(json['receivedLat']),
+      receivedLon: serializer.fromJson<double?>(json['receivedLon']),
+      isRead: serializer.fromJson<bool>(json['isRead']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'sourceCallsign': serializer.toJson<String>(sourceCallsign),
+      'addressee': serializer.toJson<String>(addressee),
+      'body': serializer.toJson<String>(body),
+      'firstHeardAt': serializer.toJson<int>(firstHeardAt),
+      'lastHeardAt': serializer.toJson<int>(lastHeardAt),
+      'heardCount': serializer.toJson<int>(heardCount),
+      'category': serializer.toJson<String>(
+        $BulletinsTable.$convertercategory.toJson(category),
+      ),
+      'lineNumber': serializer.toJson<String>(lineNumber),
+      'groupName': serializer.toJson<String?>(groupName),
+      'transports': serializer.toJson<Set<BulletinTransport>>(transports),
+      'receivedLat': serializer.toJson<double?>(receivedLat),
+      'receivedLon': serializer.toJson<double?>(receivedLon),
+      'isRead': serializer.toJson<bool>(isRead),
+    };
+  }
+
+  BulletinRow copyWith({
+    String? sourceCallsign,
+    String? addressee,
+    String? body,
+    int? firstHeardAt,
+    int? lastHeardAt,
+    int? heardCount,
+    BulletinCategory? category,
+    String? lineNumber,
+    Value<String?> groupName = const Value.absent(),
+    Set<BulletinTransport>? transports,
+    Value<double?> receivedLat = const Value.absent(),
+    Value<double?> receivedLon = const Value.absent(),
+    bool? isRead,
+  }) => BulletinRow(
+    sourceCallsign: sourceCallsign ?? this.sourceCallsign,
+    addressee: addressee ?? this.addressee,
+    body: body ?? this.body,
+    firstHeardAt: firstHeardAt ?? this.firstHeardAt,
+    lastHeardAt: lastHeardAt ?? this.lastHeardAt,
+    heardCount: heardCount ?? this.heardCount,
+    category: category ?? this.category,
+    lineNumber: lineNumber ?? this.lineNumber,
+    groupName: groupName.present ? groupName.value : this.groupName,
+    transports: transports ?? this.transports,
+    receivedLat: receivedLat.present ? receivedLat.value : this.receivedLat,
+    receivedLon: receivedLon.present ? receivedLon.value : this.receivedLon,
+    isRead: isRead ?? this.isRead,
+  );
+  BulletinRow copyWithCompanion(BulletinsCompanion data) {
+    return BulletinRow(
+      sourceCallsign: data.sourceCallsign.present
+          ? data.sourceCallsign.value
+          : this.sourceCallsign,
+      addressee: data.addressee.present ? data.addressee.value : this.addressee,
+      body: data.body.present ? data.body.value : this.body,
+      firstHeardAt: data.firstHeardAt.present
+          ? data.firstHeardAt.value
+          : this.firstHeardAt,
+      lastHeardAt: data.lastHeardAt.present
+          ? data.lastHeardAt.value
+          : this.lastHeardAt,
+      heardCount: data.heardCount.present
+          ? data.heardCount.value
+          : this.heardCount,
+      category: data.category.present ? data.category.value : this.category,
+      lineNumber: data.lineNumber.present
+          ? data.lineNumber.value
+          : this.lineNumber,
+      groupName: data.groupName.present ? data.groupName.value : this.groupName,
+      transports: data.transports.present
+          ? data.transports.value
+          : this.transports,
+      receivedLat: data.receivedLat.present
+          ? data.receivedLat.value
+          : this.receivedLat,
+      receivedLon: data.receivedLon.present
+          ? data.receivedLon.value
+          : this.receivedLon,
+      isRead: data.isRead.present ? data.isRead.value : this.isRead,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BulletinRow(')
+          ..write('sourceCallsign: $sourceCallsign, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('firstHeardAt: $firstHeardAt, ')
+          ..write('lastHeardAt: $lastHeardAt, ')
+          ..write('heardCount: $heardCount, ')
+          ..write('category: $category, ')
+          ..write('lineNumber: $lineNumber, ')
+          ..write('groupName: $groupName, ')
+          ..write('transports: $transports, ')
+          ..write('receivedLat: $receivedLat, ')
+          ..write('receivedLon: $receivedLon, ')
+          ..write('isRead: $isRead')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    sourceCallsign,
+    addressee,
+    body,
+    firstHeardAt,
+    lastHeardAt,
+    heardCount,
+    category,
+    lineNumber,
+    groupName,
+    transports,
+    receivedLat,
+    receivedLon,
+    isRead,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is BulletinRow &&
+          other.sourceCallsign == this.sourceCallsign &&
+          other.addressee == this.addressee &&
+          other.body == this.body &&
+          other.firstHeardAt == this.firstHeardAt &&
+          other.lastHeardAt == this.lastHeardAt &&
+          other.heardCount == this.heardCount &&
+          other.category == this.category &&
+          other.lineNumber == this.lineNumber &&
+          other.groupName == this.groupName &&
+          other.transports == this.transports &&
+          other.receivedLat == this.receivedLat &&
+          other.receivedLon == this.receivedLon &&
+          other.isRead == this.isRead);
+}
+
+class BulletinsCompanion extends UpdateCompanion<BulletinRow> {
+  final Value<String> sourceCallsign;
+  final Value<String> addressee;
+  final Value<String> body;
+  final Value<int> firstHeardAt;
+  final Value<int> lastHeardAt;
+  final Value<int> heardCount;
+  final Value<BulletinCategory> category;
+  final Value<String> lineNumber;
+  final Value<String?> groupName;
+  final Value<Set<BulletinTransport>> transports;
+  final Value<double?> receivedLat;
+  final Value<double?> receivedLon;
+  final Value<bool> isRead;
+  final Value<int> rowid;
+  const BulletinsCompanion({
+    this.sourceCallsign = const Value.absent(),
+    this.addressee = const Value.absent(),
+    this.body = const Value.absent(),
+    this.firstHeardAt = const Value.absent(),
+    this.lastHeardAt = const Value.absent(),
+    this.heardCount = const Value.absent(),
+    this.category = const Value.absent(),
+    this.lineNumber = const Value.absent(),
+    this.groupName = const Value.absent(),
+    this.transports = const Value.absent(),
+    this.receivedLat = const Value.absent(),
+    this.receivedLon = const Value.absent(),
+    this.isRead = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  BulletinsCompanion.insert({
+    required String sourceCallsign,
+    required String addressee,
+    required String body,
+    required int firstHeardAt,
+    required int lastHeardAt,
+    this.heardCount = const Value.absent(),
+    required BulletinCategory category,
+    required String lineNumber,
+    this.groupName = const Value.absent(),
+    this.transports = const Value.absent(),
+    this.receivedLat = const Value.absent(),
+    this.receivedLon = const Value.absent(),
+    this.isRead = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : sourceCallsign = Value(sourceCallsign),
+       addressee = Value(addressee),
+       body = Value(body),
+       firstHeardAt = Value(firstHeardAt),
+       lastHeardAt = Value(lastHeardAt),
+       category = Value(category),
+       lineNumber = Value(lineNumber);
+  static Insertable<BulletinRow> custom({
+    Expression<String>? sourceCallsign,
+    Expression<String>? addressee,
+    Expression<String>? body,
+    Expression<int>? firstHeardAt,
+    Expression<int>? lastHeardAt,
+    Expression<int>? heardCount,
+    Expression<String>? category,
+    Expression<String>? lineNumber,
+    Expression<String>? groupName,
+    Expression<String>? transports,
+    Expression<double>? receivedLat,
+    Expression<double>? receivedLon,
+    Expression<bool>? isRead,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (sourceCallsign != null) 'source_callsign': sourceCallsign,
+      if (addressee != null) 'addressee': addressee,
+      if (body != null) 'body': body,
+      if (firstHeardAt != null) 'first_heard_at': firstHeardAt,
+      if (lastHeardAt != null) 'last_heard_at': lastHeardAt,
+      if (heardCount != null) 'heard_count': heardCount,
+      if (category != null) 'category': category,
+      if (lineNumber != null) 'line_number': lineNumber,
+      if (groupName != null) 'group_name': groupName,
+      if (transports != null) 'transports': transports,
+      if (receivedLat != null) 'received_lat': receivedLat,
+      if (receivedLon != null) 'received_lon': receivedLon,
+      if (isRead != null) 'is_read': isRead,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  BulletinsCompanion copyWith({
+    Value<String>? sourceCallsign,
+    Value<String>? addressee,
+    Value<String>? body,
+    Value<int>? firstHeardAt,
+    Value<int>? lastHeardAt,
+    Value<int>? heardCount,
+    Value<BulletinCategory>? category,
+    Value<String>? lineNumber,
+    Value<String?>? groupName,
+    Value<Set<BulletinTransport>>? transports,
+    Value<double?>? receivedLat,
+    Value<double?>? receivedLon,
+    Value<bool>? isRead,
+    Value<int>? rowid,
+  }) {
+    return BulletinsCompanion(
+      sourceCallsign: sourceCallsign ?? this.sourceCallsign,
+      addressee: addressee ?? this.addressee,
+      body: body ?? this.body,
+      firstHeardAt: firstHeardAt ?? this.firstHeardAt,
+      lastHeardAt: lastHeardAt ?? this.lastHeardAt,
+      heardCount: heardCount ?? this.heardCount,
+      category: category ?? this.category,
+      lineNumber: lineNumber ?? this.lineNumber,
+      groupName: groupName ?? this.groupName,
+      transports: transports ?? this.transports,
+      receivedLat: receivedLat ?? this.receivedLat,
+      receivedLon: receivedLon ?? this.receivedLon,
+      isRead: isRead ?? this.isRead,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (sourceCallsign.present) {
+      map['source_callsign'] = Variable<String>(sourceCallsign.value);
+    }
+    if (addressee.present) {
+      map['addressee'] = Variable<String>(addressee.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    if (firstHeardAt.present) {
+      map['first_heard_at'] = Variable<int>(firstHeardAt.value);
+    }
+    if (lastHeardAt.present) {
+      map['last_heard_at'] = Variable<int>(lastHeardAt.value);
+    }
+    if (heardCount.present) {
+      map['heard_count'] = Variable<int>(heardCount.value);
+    }
+    if (category.present) {
+      map['category'] = Variable<String>(
+        $BulletinsTable.$convertercategory.toSql(category.value),
+      );
+    }
+    if (lineNumber.present) {
+      map['line_number'] = Variable<String>(lineNumber.value);
+    }
+    if (groupName.present) {
+      map['group_name'] = Variable<String>(groupName.value);
+    }
+    if (transports.present) {
+      map['transports'] = Variable<String>(
+        $BulletinsTable.$convertertransports.toSql(transports.value),
+      );
+    }
+    if (receivedLat.present) {
+      map['received_lat'] = Variable<double>(receivedLat.value);
+    }
+    if (receivedLon.present) {
+      map['received_lon'] = Variable<double>(receivedLon.value);
+    }
+    if (isRead.present) {
+      map['is_read'] = Variable<bool>(isRead.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BulletinsCompanion(')
+          ..write('sourceCallsign: $sourceCallsign, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('firstHeardAt: $firstHeardAt, ')
+          ..write('lastHeardAt: $lastHeardAt, ')
+          ..write('heardCount: $heardCount, ')
+          ..write('category: $category, ')
+          ..write('lineNumber: $lineNumber, ')
+          ..write('groupName: $groupName, ')
+          ..write('transports: $transports, ')
+          ..write('receivedLat: $receivedLat, ')
+          ..write('receivedLon: $receivedLon, ')
+          ..write('isRead: $isRead, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $OutgoingBulletinsTable extends OutgoingBulletins
+    with TableInfo<$OutgoingBulletinsTable, OutgoingBulletinRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $OutgoingBulletinsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _addresseeMeta = const VerificationMeta(
+    'addressee',
+  );
+  @override
+  late final GeneratedColumn<String> addressee = GeneratedColumn<String>(
+    'addressee',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _bodyMeta = const VerificationMeta('body');
+  @override
+  late final GeneratedColumn<String> body = GeneratedColumn<String>(
+    'body',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _intervalSecondsMeta = const VerificationMeta(
+    'intervalSeconds',
+  );
+  @override
+  late final GeneratedColumn<int> intervalSeconds = GeneratedColumn<int>(
+    'interval_seconds',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _transmissionCountMeta = const VerificationMeta(
+    'transmissionCount',
+  );
+  @override
+  late final GeneratedColumn<int> transmissionCount = GeneratedColumn<int>(
+    'transmission_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _expiresAtMeta = const VerificationMeta(
+    'expiresAt',
+  );
+  @override
+  late final GeneratedColumn<int> expiresAt = GeneratedColumn<int>(
+    'expires_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _lastTransmittedAtMeta = const VerificationMeta(
+    'lastTransmittedAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastTransmittedAt = GeneratedColumn<int>(
+    'last_transmitted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _viaRfMeta = const VerificationMeta('viaRf');
+  @override
+  late final GeneratedColumn<bool> viaRf = GeneratedColumn<bool>(
+    'via_rf',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("via_rf" IN (0, 1))',
+    ),
+    defaultValue: const Constant(true),
+  );
+  static const VerificationMeta _viaAprsIsMeta = const VerificationMeta(
+    'viaAprsIs',
+  );
+  @override
+  late final GeneratedColumn<bool> viaAprsIs = GeneratedColumn<bool>(
+    'via_aprs_is',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("via_aprs_is" IN (0, 1))',
+    ),
+    defaultValue: const Constant(true),
+  );
+  static const VerificationMeta _enabledMeta = const VerificationMeta(
+    'enabled',
+  );
+  @override
+  late final GeneratedColumn<bool> enabled = GeneratedColumn<bool>(
+    'enabled',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("enabled" IN (0, 1))',
+    ),
+    defaultValue: const Constant(true),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    addressee,
+    body,
+    intervalSeconds,
+    transmissionCount,
+    expiresAt,
+    createdAt,
+    lastTransmittedAt,
+    viaRf,
+    viaAprsIs,
+    enabled,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'outgoing_bulletins';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<OutgoingBulletinRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('addressee')) {
+      context.handle(
+        _addresseeMeta,
+        addressee.isAcceptableOrUnknown(data['addressee']!, _addresseeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_addresseeMeta);
+    }
+    if (data.containsKey('body')) {
+      context.handle(
+        _bodyMeta,
+        body.isAcceptableOrUnknown(data['body']!, _bodyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_bodyMeta);
+    }
+    if (data.containsKey('interval_seconds')) {
+      context.handle(
+        _intervalSecondsMeta,
+        intervalSeconds.isAcceptableOrUnknown(
+          data['interval_seconds']!,
+          _intervalSecondsMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_intervalSecondsMeta);
+    }
+    if (data.containsKey('transmission_count')) {
+      context.handle(
+        _transmissionCountMeta,
+        transmissionCount.isAcceptableOrUnknown(
+          data['transmission_count']!,
+          _transmissionCountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('expires_at')) {
+      context.handle(
+        _expiresAtMeta,
+        expiresAt.isAcceptableOrUnknown(data['expires_at']!, _expiresAtMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('last_transmitted_at')) {
+      context.handle(
+        _lastTransmittedAtMeta,
+        lastTransmittedAt.isAcceptableOrUnknown(
+          data['last_transmitted_at']!,
+          _lastTransmittedAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('via_rf')) {
+      context.handle(
+        _viaRfMeta,
+        viaRf.isAcceptableOrUnknown(data['via_rf']!, _viaRfMeta),
+      );
+    }
+    if (data.containsKey('via_aprs_is')) {
+      context.handle(
+        _viaAprsIsMeta,
+        viaAprsIs.isAcceptableOrUnknown(data['via_aprs_is']!, _viaAprsIsMeta),
+      );
+    }
+    if (data.containsKey('enabled')) {
+      context.handle(
+        _enabledMeta,
+        enabled.isAcceptableOrUnknown(data['enabled']!, _enabledMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  OutgoingBulletinRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return OutgoingBulletinRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      addressee: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}addressee'],
+      )!,
+      body: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}body'],
+      )!,
+      intervalSeconds: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}interval_seconds'],
+      )!,
+      transmissionCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}transmission_count'],
+      )!,
+      expiresAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}expires_at'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      lastTransmittedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_transmitted_at'],
+      ),
+      viaRf: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}via_rf'],
+      )!,
+      viaAprsIs: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}via_aprs_is'],
+      )!,
+      enabled: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}enabled'],
+      )!,
+    );
+  }
+
+  @override
+  $OutgoingBulletinsTable createAlias(String alias) {
+    return $OutgoingBulletinsTable(attachedDatabase, alias);
+  }
+}
+
+class OutgoingBulletinRow extends DataClass
+    implements Insertable<OutgoingBulletinRow> {
+  final int id;
+  final String addressee;
+  final String body;
+  final int intervalSeconds;
+  final int transmissionCount;
+  final int? expiresAt;
+  final int createdAt;
+  final int? lastTransmittedAt;
+  final bool viaRf;
+  final bool viaAprsIs;
+  final bool enabled;
+  const OutgoingBulletinRow({
+    required this.id,
+    required this.addressee,
+    required this.body,
+    required this.intervalSeconds,
+    required this.transmissionCount,
+    this.expiresAt,
+    required this.createdAt,
+    this.lastTransmittedAt,
+    required this.viaRf,
+    required this.viaAprsIs,
+    required this.enabled,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['addressee'] = Variable<String>(addressee);
+    map['body'] = Variable<String>(body);
+    map['interval_seconds'] = Variable<int>(intervalSeconds);
+    map['transmission_count'] = Variable<int>(transmissionCount);
+    if (!nullToAbsent || expiresAt != null) {
+      map['expires_at'] = Variable<int>(expiresAt);
+    }
+    map['created_at'] = Variable<int>(createdAt);
+    if (!nullToAbsent || lastTransmittedAt != null) {
+      map['last_transmitted_at'] = Variable<int>(lastTransmittedAt);
+    }
+    map['via_rf'] = Variable<bool>(viaRf);
+    map['via_aprs_is'] = Variable<bool>(viaAprsIs);
+    map['enabled'] = Variable<bool>(enabled);
+    return map;
+  }
+
+  OutgoingBulletinsCompanion toCompanion(bool nullToAbsent) {
+    return OutgoingBulletinsCompanion(
+      id: Value(id),
+      addressee: Value(addressee),
+      body: Value(body),
+      intervalSeconds: Value(intervalSeconds),
+      transmissionCount: Value(transmissionCount),
+      expiresAt: expiresAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(expiresAt),
+      createdAt: Value(createdAt),
+      lastTransmittedAt: lastTransmittedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastTransmittedAt),
+      viaRf: Value(viaRf),
+      viaAprsIs: Value(viaAprsIs),
+      enabled: Value(enabled),
+    );
+  }
+
+  factory OutgoingBulletinRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return OutgoingBulletinRow(
+      id: serializer.fromJson<int>(json['id']),
+      addressee: serializer.fromJson<String>(json['addressee']),
+      body: serializer.fromJson<String>(json['body']),
+      intervalSeconds: serializer.fromJson<int>(json['intervalSeconds']),
+      transmissionCount: serializer.fromJson<int>(json['transmissionCount']),
+      expiresAt: serializer.fromJson<int?>(json['expiresAt']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      lastTransmittedAt: serializer.fromJson<int?>(json['lastTransmittedAt']),
+      viaRf: serializer.fromJson<bool>(json['viaRf']),
+      viaAprsIs: serializer.fromJson<bool>(json['viaAprsIs']),
+      enabled: serializer.fromJson<bool>(json['enabled']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'addressee': serializer.toJson<String>(addressee),
+      'body': serializer.toJson<String>(body),
+      'intervalSeconds': serializer.toJson<int>(intervalSeconds),
+      'transmissionCount': serializer.toJson<int>(transmissionCount),
+      'expiresAt': serializer.toJson<int?>(expiresAt),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'lastTransmittedAt': serializer.toJson<int?>(lastTransmittedAt),
+      'viaRf': serializer.toJson<bool>(viaRf),
+      'viaAprsIs': serializer.toJson<bool>(viaAprsIs),
+      'enabled': serializer.toJson<bool>(enabled),
+    };
+  }
+
+  OutgoingBulletinRow copyWith({
+    int? id,
+    String? addressee,
+    String? body,
+    int? intervalSeconds,
+    int? transmissionCount,
+    Value<int?> expiresAt = const Value.absent(),
+    int? createdAt,
+    Value<int?> lastTransmittedAt = const Value.absent(),
+    bool? viaRf,
+    bool? viaAprsIs,
+    bool? enabled,
+  }) => OutgoingBulletinRow(
+    id: id ?? this.id,
+    addressee: addressee ?? this.addressee,
+    body: body ?? this.body,
+    intervalSeconds: intervalSeconds ?? this.intervalSeconds,
+    transmissionCount: transmissionCount ?? this.transmissionCount,
+    expiresAt: expiresAt.present ? expiresAt.value : this.expiresAt,
+    createdAt: createdAt ?? this.createdAt,
+    lastTransmittedAt: lastTransmittedAt.present
+        ? lastTransmittedAt.value
+        : this.lastTransmittedAt,
+    viaRf: viaRf ?? this.viaRf,
+    viaAprsIs: viaAprsIs ?? this.viaAprsIs,
+    enabled: enabled ?? this.enabled,
+  );
+  OutgoingBulletinRow copyWithCompanion(OutgoingBulletinsCompanion data) {
+    return OutgoingBulletinRow(
+      id: data.id.present ? data.id.value : this.id,
+      addressee: data.addressee.present ? data.addressee.value : this.addressee,
+      body: data.body.present ? data.body.value : this.body,
+      intervalSeconds: data.intervalSeconds.present
+          ? data.intervalSeconds.value
+          : this.intervalSeconds,
+      transmissionCount: data.transmissionCount.present
+          ? data.transmissionCount.value
+          : this.transmissionCount,
+      expiresAt: data.expiresAt.present ? data.expiresAt.value : this.expiresAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      lastTransmittedAt: data.lastTransmittedAt.present
+          ? data.lastTransmittedAt.value
+          : this.lastTransmittedAt,
+      viaRf: data.viaRf.present ? data.viaRf.value : this.viaRf,
+      viaAprsIs: data.viaAprsIs.present ? data.viaAprsIs.value : this.viaAprsIs,
+      enabled: data.enabled.present ? data.enabled.value : this.enabled,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('OutgoingBulletinRow(')
+          ..write('id: $id, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('intervalSeconds: $intervalSeconds, ')
+          ..write('transmissionCount: $transmissionCount, ')
+          ..write('expiresAt: $expiresAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastTransmittedAt: $lastTransmittedAt, ')
+          ..write('viaRf: $viaRf, ')
+          ..write('viaAprsIs: $viaAprsIs, ')
+          ..write('enabled: $enabled')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    addressee,
+    body,
+    intervalSeconds,
+    transmissionCount,
+    expiresAt,
+    createdAt,
+    lastTransmittedAt,
+    viaRf,
+    viaAprsIs,
+    enabled,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is OutgoingBulletinRow &&
+          other.id == this.id &&
+          other.addressee == this.addressee &&
+          other.body == this.body &&
+          other.intervalSeconds == this.intervalSeconds &&
+          other.transmissionCount == this.transmissionCount &&
+          other.expiresAt == this.expiresAt &&
+          other.createdAt == this.createdAt &&
+          other.lastTransmittedAt == this.lastTransmittedAt &&
+          other.viaRf == this.viaRf &&
+          other.viaAprsIs == this.viaAprsIs &&
+          other.enabled == this.enabled);
+}
+
+class OutgoingBulletinsCompanion extends UpdateCompanion<OutgoingBulletinRow> {
+  final Value<int> id;
+  final Value<String> addressee;
+  final Value<String> body;
+  final Value<int> intervalSeconds;
+  final Value<int> transmissionCount;
+  final Value<int?> expiresAt;
+  final Value<int> createdAt;
+  final Value<int?> lastTransmittedAt;
+  final Value<bool> viaRf;
+  final Value<bool> viaAprsIs;
+  final Value<bool> enabled;
+  const OutgoingBulletinsCompanion({
+    this.id = const Value.absent(),
+    this.addressee = const Value.absent(),
+    this.body = const Value.absent(),
+    this.intervalSeconds = const Value.absent(),
+    this.transmissionCount = const Value.absent(),
+    this.expiresAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.lastTransmittedAt = const Value.absent(),
+    this.viaRf = const Value.absent(),
+    this.viaAprsIs = const Value.absent(),
+    this.enabled = const Value.absent(),
+  });
+  OutgoingBulletinsCompanion.insert({
+    this.id = const Value.absent(),
+    required String addressee,
+    required String body,
+    required int intervalSeconds,
+    this.transmissionCount = const Value.absent(),
+    this.expiresAt = const Value.absent(),
+    required int createdAt,
+    this.lastTransmittedAt = const Value.absent(),
+    this.viaRf = const Value.absent(),
+    this.viaAprsIs = const Value.absent(),
+    this.enabled = const Value.absent(),
+  }) : addressee = Value(addressee),
+       body = Value(body),
+       intervalSeconds = Value(intervalSeconds),
+       createdAt = Value(createdAt);
+  static Insertable<OutgoingBulletinRow> custom({
+    Expression<int>? id,
+    Expression<String>? addressee,
+    Expression<String>? body,
+    Expression<int>? intervalSeconds,
+    Expression<int>? transmissionCount,
+    Expression<int>? expiresAt,
+    Expression<int>? createdAt,
+    Expression<int>? lastTransmittedAt,
+    Expression<bool>? viaRf,
+    Expression<bool>? viaAprsIs,
+    Expression<bool>? enabled,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (addressee != null) 'addressee': addressee,
+      if (body != null) 'body': body,
+      if (intervalSeconds != null) 'interval_seconds': intervalSeconds,
+      if (transmissionCount != null) 'transmission_count': transmissionCount,
+      if (expiresAt != null) 'expires_at': expiresAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (lastTransmittedAt != null) 'last_transmitted_at': lastTransmittedAt,
+      if (viaRf != null) 'via_rf': viaRf,
+      if (viaAprsIs != null) 'via_aprs_is': viaAprsIs,
+      if (enabled != null) 'enabled': enabled,
+    });
+  }
+
+  OutgoingBulletinsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? addressee,
+    Value<String>? body,
+    Value<int>? intervalSeconds,
+    Value<int>? transmissionCount,
+    Value<int?>? expiresAt,
+    Value<int>? createdAt,
+    Value<int?>? lastTransmittedAt,
+    Value<bool>? viaRf,
+    Value<bool>? viaAprsIs,
+    Value<bool>? enabled,
+  }) {
+    return OutgoingBulletinsCompanion(
+      id: id ?? this.id,
+      addressee: addressee ?? this.addressee,
+      body: body ?? this.body,
+      intervalSeconds: intervalSeconds ?? this.intervalSeconds,
+      transmissionCount: transmissionCount ?? this.transmissionCount,
+      expiresAt: expiresAt ?? this.expiresAt,
+      createdAt: createdAt ?? this.createdAt,
+      lastTransmittedAt: lastTransmittedAt ?? this.lastTransmittedAt,
+      viaRf: viaRf ?? this.viaRf,
+      viaAprsIs: viaAprsIs ?? this.viaAprsIs,
+      enabled: enabled ?? this.enabled,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (addressee.present) {
+      map['addressee'] = Variable<String>(addressee.value);
+    }
+    if (body.present) {
+      map['body'] = Variable<String>(body.value);
+    }
+    if (intervalSeconds.present) {
+      map['interval_seconds'] = Variable<int>(intervalSeconds.value);
+    }
+    if (transmissionCount.present) {
+      map['transmission_count'] = Variable<int>(transmissionCount.value);
+    }
+    if (expiresAt.present) {
+      map['expires_at'] = Variable<int>(expiresAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (lastTransmittedAt.present) {
+      map['last_transmitted_at'] = Variable<int>(lastTransmittedAt.value);
+    }
+    if (viaRf.present) {
+      map['via_rf'] = Variable<bool>(viaRf.value);
+    }
+    if (viaAprsIs.present) {
+      map['via_aprs_is'] = Variable<bool>(viaAprsIs.value);
+    }
+    if (enabled.present) {
+      map['enabled'] = Variable<bool>(enabled.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('OutgoingBulletinsCompanion(')
+          ..write('id: $id, ')
+          ..write('addressee: $addressee, ')
+          ..write('body: $body, ')
+          ..write('intervalSeconds: $intervalSeconds, ')
+          ..write('transmissionCount: $transmissionCount, ')
+          ..write('expiresAt: $expiresAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('lastTransmittedAt: $lastTransmittedAt, ')
+          ..write('viaRf: $viaRf, ')
+          ..write('viaAprsIs: $viaAprsIs, ')
+          ..write('enabled: $enabled')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$MeridianDatabase extends GeneratedDatabase {
+  _$MeridianDatabase(QueryExecutor e) : super(e);
+  $MeridianDatabaseManager get managers => $MeridianDatabaseManager(this);
+  late final $StationsTable stations = $StationsTable(this);
+  late final $PositionHistoryTable positionHistory = $PositionHistoryTable(
+    this,
+  );
+  late final $PacketsTable packets = $PacketsTable(this);
+  late final $ConversationsTable conversations = $ConversationsTable(this);
+  late final $MessageEntriesTable messageEntries = $MessageEntriesTable(this);
+  late final $GroupMessageEntriesTable groupMessageEntries =
+      $GroupMessageEntriesTable(this);
+  late final $BulletinsTable bulletins = $BulletinsTable(this);
+  late final $OutgoingBulletinsTable outgoingBulletins =
+      $OutgoingBulletinsTable(this);
+  late final StationDao stationDao = StationDao(this as MeridianDatabase);
+  late final PacketDao packetDao = PacketDao(this as MeridianDatabase);
+  late final MessageDao messageDao = MessageDao(this as MeridianDatabase);
+  late final BulletinDao bulletinDao = BulletinDao(this as MeridianDatabase);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    stations,
+    positionHistory,
+    packets,
+    conversations,
+    messageEntries,
+    groupMessageEntries,
+    bulletins,
+    outgoingBulletins,
+  ];
+  @override
+  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'stations',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('position_history', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'conversations',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('message_entries', kind: UpdateKind.delete)],
+    ),
+  ]);
+}
+
+typedef $$StationsTableCreateCompanionBuilder =
+    StationsCompanion Function({
+      required String callsign,
+      required String symbolTable,
+      required String symbolCode,
+      required String comment,
+      required String rawPacket,
+      Value<String?> device,
+      required int lastHeard,
+      required StationType stationType,
+      required MessageCapability messageCapability,
+      Value<String?> capabilities,
+      required double lat,
+      required double lon,
+      Value<int> rowid,
+    });
+typedef $$StationsTableUpdateCompanionBuilder =
+    StationsCompanion Function({
+      Value<String> callsign,
+      Value<String> symbolTable,
+      Value<String> symbolCode,
+      Value<String> comment,
+      Value<String> rawPacket,
+      Value<String?> device,
+      Value<int> lastHeard,
+      Value<StationType> stationType,
+      Value<MessageCapability> messageCapability,
+      Value<String?> capabilities,
+      Value<double> lat,
+      Value<double> lon,
+      Value<int> rowid,
+    });
+
+final class $$StationsTableReferences
+    extends BaseReferences<_$MeridianDatabase, $StationsTable, StationRow> {
+  $$StationsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$PositionHistoryTable, List<PositionHistoryRow>>
+  _positionHistoryRefsTable(_$MeridianDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.positionHistory,
+        aliasName: $_aliasNameGenerator(
+          db.stations.callsign,
+          db.positionHistory.callsign,
+        ),
+      );
+
+  $$PositionHistoryTableProcessedTableManager get positionHistoryRefs {
+    final manager =
+        $$PositionHistoryTableTableManager($_db, $_db.positionHistory).filter(
+          (f) =>
+              f.callsign.callsign.sqlEquals($_itemColumn<String>('callsign')!),
+        );
+
+    final cache = $_typedResult.readTableOrNull(
+      _positionHistoryRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$StationsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $StationsTable> {
+  $$StationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get callsign => $composableBuilder(
+    column: $table.callsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get symbolTable => $composableBuilder(
+    column: $table.symbolTable,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get symbolCode => $composableBuilder(
+    column: $table.symbolCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get comment => $composableBuilder(
+    column: $table.comment,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get rawPacket => $composableBuilder(
+    column: $table.rawPacket,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get device => $composableBuilder(
+    column: $table.device,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastHeard => $composableBuilder(
+    column: $table.lastHeard,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<StationType, StationType, String>
+  get stationType => $composableBuilder(
+    column: $table.stationType,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<MessageCapability, MessageCapability, String>
+  get messageCapability => $composableBuilder(
+    column: $table.messageCapability,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get capabilities => $composableBuilder(
+    column: $table.capabilities,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get lat => $composableBuilder(
+    column: $table.lat,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get lon => $composableBuilder(
+    column: $table.lon,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> positionHistoryRefs(
+    Expression<bool> Function($$PositionHistoryTableFilterComposer f) f,
+  ) {
+    final $$PositionHistoryTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.callsign,
+      referencedTable: $db.positionHistory,
+      getReferencedColumn: (t) => t.callsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PositionHistoryTableFilterComposer(
+            $db: $db,
+            $table: $db.positionHistory,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$StationsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $StationsTable> {
+  $$StationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get callsign => $composableBuilder(
+    column: $table.callsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get symbolTable => $composableBuilder(
+    column: $table.symbolTable,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get symbolCode => $composableBuilder(
+    column: $table.symbolCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get comment => $composableBuilder(
+    column: $table.comment,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get rawPacket => $composableBuilder(
+    column: $table.rawPacket,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get device => $composableBuilder(
+    column: $table.device,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastHeard => $composableBuilder(
+    column: $table.lastHeard,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get stationType => $composableBuilder(
+    column: $table.stationType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get messageCapability => $composableBuilder(
+    column: $table.messageCapability,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get capabilities => $composableBuilder(
+    column: $table.capabilities,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get lat => $composableBuilder(
+    column: $table.lat,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get lon => $composableBuilder(
+    column: $table.lon,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$StationsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $StationsTable> {
+  $$StationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get callsign =>
+      $composableBuilder(column: $table.callsign, builder: (column) => column);
+
+  GeneratedColumn<String> get symbolTable => $composableBuilder(
+    column: $table.symbolTable,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get symbolCode => $composableBuilder(
+    column: $table.symbolCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get comment =>
+      $composableBuilder(column: $table.comment, builder: (column) => column);
+
+  GeneratedColumn<String> get rawPacket =>
+      $composableBuilder(column: $table.rawPacket, builder: (column) => column);
+
+  GeneratedColumn<String> get device =>
+      $composableBuilder(column: $table.device, builder: (column) => column);
+
+  GeneratedColumn<int> get lastHeard =>
+      $composableBuilder(column: $table.lastHeard, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<StationType, String> get stationType =>
+      $composableBuilder(
+        column: $table.stationType,
+        builder: (column) => column,
+      );
+
+  GeneratedColumnWithTypeConverter<MessageCapability, String>
+  get messageCapability => $composableBuilder(
+    column: $table.messageCapability,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get capabilities => $composableBuilder(
+    column: $table.capabilities,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get lat =>
+      $composableBuilder(column: $table.lat, builder: (column) => column);
+
+  GeneratedColumn<double> get lon =>
+      $composableBuilder(column: $table.lon, builder: (column) => column);
+
+  Expression<T> positionHistoryRefs<T extends Object>(
+    Expression<T> Function($$PositionHistoryTableAnnotationComposer a) f,
+  ) {
+    final $$PositionHistoryTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.callsign,
+      referencedTable: $db.positionHistory,
+      getReferencedColumn: (t) => t.callsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PositionHistoryTableAnnotationComposer(
+            $db: $db,
+            $table: $db.positionHistory,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$StationsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $StationsTable,
+          StationRow,
+          $$StationsTableFilterComposer,
+          $$StationsTableOrderingComposer,
+          $$StationsTableAnnotationComposer,
+          $$StationsTableCreateCompanionBuilder,
+          $$StationsTableUpdateCompanionBuilder,
+          (StationRow, $$StationsTableReferences),
+          StationRow,
+          PrefetchHooks Function({bool positionHistoryRefs})
+        > {
+  $$StationsTableTableManager(_$MeridianDatabase db, $StationsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$StationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$StationsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$StationsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> callsign = const Value.absent(),
+                Value<String> symbolTable = const Value.absent(),
+                Value<String> symbolCode = const Value.absent(),
+                Value<String> comment = const Value.absent(),
+                Value<String> rawPacket = const Value.absent(),
+                Value<String?> device = const Value.absent(),
+                Value<int> lastHeard = const Value.absent(),
+                Value<StationType> stationType = const Value.absent(),
+                Value<MessageCapability> messageCapability =
+                    const Value.absent(),
+                Value<String?> capabilities = const Value.absent(),
+                Value<double> lat = const Value.absent(),
+                Value<double> lon = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => StationsCompanion(
+                callsign: callsign,
+                symbolTable: symbolTable,
+                symbolCode: symbolCode,
+                comment: comment,
+                rawPacket: rawPacket,
+                device: device,
+                lastHeard: lastHeard,
+                stationType: stationType,
+                messageCapability: messageCapability,
+                capabilities: capabilities,
+                lat: lat,
+                lon: lon,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String callsign,
+                required String symbolTable,
+                required String symbolCode,
+                required String comment,
+                required String rawPacket,
+                Value<String?> device = const Value.absent(),
+                required int lastHeard,
+                required StationType stationType,
+                required MessageCapability messageCapability,
+                Value<String?> capabilities = const Value.absent(),
+                required double lat,
+                required double lon,
+                Value<int> rowid = const Value.absent(),
+              }) => StationsCompanion.insert(
+                callsign: callsign,
+                symbolTable: symbolTable,
+                symbolCode: symbolCode,
+                comment: comment,
+                rawPacket: rawPacket,
+                device: device,
+                lastHeard: lastHeard,
+                stationType: stationType,
+                messageCapability: messageCapability,
+                capabilities: capabilities,
+                lat: lat,
+                lon: lon,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$StationsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({positionHistoryRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (positionHistoryRefs) db.positionHistory,
+              ],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (positionHistoryRefs)
+                    await $_getPrefetchedData<
+                      StationRow,
+                      $StationsTable,
+                      PositionHistoryRow
+                    >(
+                      currentTable: table,
+                      referencedTable: $$StationsTableReferences
+                          ._positionHistoryRefsTable(db),
+                      managerFromTypedResult: (p0) => $$StationsTableReferences(
+                        db,
+                        table,
+                        p0,
+                      ).positionHistoryRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where(
+                            (e) => e.callsign == item.callsign,
+                          ),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$StationsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $StationsTable,
+      StationRow,
+      $$StationsTableFilterComposer,
+      $$StationsTableOrderingComposer,
+      $$StationsTableAnnotationComposer,
+      $$StationsTableCreateCompanionBuilder,
+      $$StationsTableUpdateCompanionBuilder,
+      (StationRow, $$StationsTableReferences),
+      StationRow,
+      PrefetchHooks Function({bool positionHistoryRefs})
+    >;
+typedef $$PositionHistoryTableCreateCompanionBuilder =
+    PositionHistoryCompanion Function({
+      Value<int> id,
+      required String callsign,
+      required double latitude,
+      required double longitude,
+      required int timestamp,
+    });
+typedef $$PositionHistoryTableUpdateCompanionBuilder =
+    PositionHistoryCompanion Function({
+      Value<int> id,
+      Value<String> callsign,
+      Value<double> latitude,
+      Value<double> longitude,
+      Value<int> timestamp,
+    });
+
+final class $$PositionHistoryTableReferences
+    extends
+        BaseReferences<
+          _$MeridianDatabase,
+          $PositionHistoryTable,
+          PositionHistoryRow
+        > {
+  $$PositionHistoryTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $StationsTable _callsignTable(_$MeridianDatabase db) =>
+      db.stations.createAlias(
+        $_aliasNameGenerator(db.positionHistory.callsign, db.stations.callsign),
+      );
+
+  $$StationsTableProcessedTableManager get callsign {
+    final $_column = $_itemColumn<String>('callsign')!;
+
+    final manager = $$StationsTableTableManager(
+      $_db,
+      $_db.stations,
+    ).filter((f) => f.callsign.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_callsignTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$PositionHistoryTableFilterComposer
+    extends Composer<_$MeridianDatabase, $PositionHistoryTable> {
+  $$PositionHistoryTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get latitude => $composableBuilder(
+    column: $table.latitude,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get longitude => $composableBuilder(
+    column: $table.longitude,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$StationsTableFilterComposer get callsign {
+    final $$StationsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.callsign,
+      referencedTable: $db.stations,
+      getReferencedColumn: (t) => t.callsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StationsTableFilterComposer(
+            $db: $db,
+            $table: $db.stations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PositionHistoryTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $PositionHistoryTable> {
+  $$PositionHistoryTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get latitude => $composableBuilder(
+    column: $table.latitude,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get longitude => $composableBuilder(
+    column: $table.longitude,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$StationsTableOrderingComposer get callsign {
+    final $$StationsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.callsign,
+      referencedTable: $db.stations,
+      getReferencedColumn: (t) => t.callsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StationsTableOrderingComposer(
+            $db: $db,
+            $table: $db.stations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PositionHistoryTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $PositionHistoryTable> {
+  $$PositionHistoryTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<double> get latitude =>
+      $composableBuilder(column: $table.latitude, builder: (column) => column);
+
+  GeneratedColumn<double> get longitude =>
+      $composableBuilder(column: $table.longitude, builder: (column) => column);
+
+  GeneratedColumn<int> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  $$StationsTableAnnotationComposer get callsign {
+    final $$StationsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.callsign,
+      referencedTable: $db.stations,
+      getReferencedColumn: (t) => t.callsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$StationsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.stations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PositionHistoryTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $PositionHistoryTable,
+          PositionHistoryRow,
+          $$PositionHistoryTableFilterComposer,
+          $$PositionHistoryTableOrderingComposer,
+          $$PositionHistoryTableAnnotationComposer,
+          $$PositionHistoryTableCreateCompanionBuilder,
+          $$PositionHistoryTableUpdateCompanionBuilder,
+          (PositionHistoryRow, $$PositionHistoryTableReferences),
+          PositionHistoryRow,
+          PrefetchHooks Function({bool callsign})
+        > {
+  $$PositionHistoryTableTableManager(
+    _$MeridianDatabase db,
+    $PositionHistoryTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PositionHistoryTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PositionHistoryTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PositionHistoryTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> callsign = const Value.absent(),
+                Value<double> latitude = const Value.absent(),
+                Value<double> longitude = const Value.absent(),
+                Value<int> timestamp = const Value.absent(),
+              }) => PositionHistoryCompanion(
+                id: id,
+                callsign: callsign,
+                latitude: latitude,
+                longitude: longitude,
+                timestamp: timestamp,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String callsign,
+                required double latitude,
+                required double longitude,
+                required int timestamp,
+              }) => PositionHistoryCompanion.insert(
+                id: id,
+                callsign: callsign,
+                latitude: latitude,
+                longitude: longitude,
+                timestamp: timestamp,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$PositionHistoryTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({callsign = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (callsign) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.callsign,
+                                referencedTable:
+                                    $$PositionHistoryTableReferences
+                                        ._callsignTable(db),
+                                referencedColumn:
+                                    $$PositionHistoryTableReferences
+                                        ._callsignTable(db)
+                                        .callsign,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$PositionHistoryTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $PositionHistoryTable,
+      PositionHistoryRow,
+      $$PositionHistoryTableFilterComposer,
+      $$PositionHistoryTableOrderingComposer,
+      $$PositionHistoryTableAnnotationComposer,
+      $$PositionHistoryTableCreateCompanionBuilder,
+      $$PositionHistoryTableUpdateCompanionBuilder,
+      (PositionHistoryRow, $$PositionHistoryTableReferences),
+      PositionHistoryRow,
+      PrefetchHooks Function({bool callsign})
+    >;
+typedef $$PacketsTableCreateCompanionBuilder =
+    PacketsCompanion Function({
+      Value<int> id,
+      required String rawLine,
+      required PacketTypeTag packetType,
+      required String sourceCallsign,
+      Value<String?> destination,
+      required int receivedAt,
+      Value<bool> isOutgoing,
+      required PacketSource sourceChannel,
+    });
+typedef $$PacketsTableUpdateCompanionBuilder =
+    PacketsCompanion Function({
+      Value<int> id,
+      Value<String> rawLine,
+      Value<PacketTypeTag> packetType,
+      Value<String> sourceCallsign,
+      Value<String?> destination,
+      Value<int> receivedAt,
+      Value<bool> isOutgoing,
+      Value<PacketSource> sourceChannel,
+    });
+
+class $$PacketsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $PacketsTable> {
+  $$PacketsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get rawLine => $composableBuilder(
+    column: $table.rawLine,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<PacketTypeTag, PacketTypeTag, String>
+  get packetType => $composableBuilder(
+    column: $table.packetType,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get destination => $composableBuilder(
+    column: $table.destination,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get receivedAt => $composableBuilder(
+    column: $table.receivedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<PacketSource, PacketSource, String>
+  get sourceChannel => $composableBuilder(
+    column: $table.sourceChannel,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+}
+
+class $$PacketsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $PacketsTable> {
+  $$PacketsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get rawLine => $composableBuilder(
+    column: $table.rawLine,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get packetType => $composableBuilder(
+    column: $table.packetType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get destination => $composableBuilder(
+    column: $table.destination,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get receivedAt => $composableBuilder(
+    column: $table.receivedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get sourceChannel => $composableBuilder(
+    column: $table.sourceChannel,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PacketsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $PacketsTable> {
+  $$PacketsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get rawLine =>
+      $composableBuilder(column: $table.rawLine, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<PacketTypeTag, String> get packetType =>
+      $composableBuilder(
+        column: $table.packetType,
+        builder: (column) => column,
+      );
+
+  GeneratedColumn<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get destination => $composableBuilder(
+    column: $table.destination,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get receivedAt => $composableBuilder(
+    column: $table.receivedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<PacketSource, String> get sourceChannel =>
+      $composableBuilder(
+        column: $table.sourceChannel,
+        builder: (column) => column,
+      );
+}
+
+class $$PacketsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $PacketsTable,
+          PacketRow,
+          $$PacketsTableFilterComposer,
+          $$PacketsTableOrderingComposer,
+          $$PacketsTableAnnotationComposer,
+          $$PacketsTableCreateCompanionBuilder,
+          $$PacketsTableUpdateCompanionBuilder,
+          (
+            PacketRow,
+            BaseReferences<_$MeridianDatabase, $PacketsTable, PacketRow>,
+          ),
+          PacketRow,
+          PrefetchHooks Function()
+        > {
+  $$PacketsTableTableManager(_$MeridianDatabase db, $PacketsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PacketsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PacketsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PacketsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> rawLine = const Value.absent(),
+                Value<PacketTypeTag> packetType = const Value.absent(),
+                Value<String> sourceCallsign = const Value.absent(),
+                Value<String?> destination = const Value.absent(),
+                Value<int> receivedAt = const Value.absent(),
+                Value<bool> isOutgoing = const Value.absent(),
+                Value<PacketSource> sourceChannel = const Value.absent(),
+              }) => PacketsCompanion(
+                id: id,
+                rawLine: rawLine,
+                packetType: packetType,
+                sourceCallsign: sourceCallsign,
+                destination: destination,
+                receivedAt: receivedAt,
+                isOutgoing: isOutgoing,
+                sourceChannel: sourceChannel,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String rawLine,
+                required PacketTypeTag packetType,
+                required String sourceCallsign,
+                Value<String?> destination = const Value.absent(),
+                required int receivedAt,
+                Value<bool> isOutgoing = const Value.absent(),
+                required PacketSource sourceChannel,
+              }) => PacketsCompanion.insert(
+                id: id,
+                rawLine: rawLine,
+                packetType: packetType,
+                sourceCallsign: sourceCallsign,
+                destination: destination,
+                receivedAt: receivedAt,
+                isOutgoing: isOutgoing,
+                sourceChannel: sourceChannel,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PacketsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $PacketsTable,
+      PacketRow,
+      $$PacketsTableFilterComposer,
+      $$PacketsTableOrderingComposer,
+      $$PacketsTableAnnotationComposer,
+      $$PacketsTableCreateCompanionBuilder,
+      $$PacketsTableUpdateCompanionBuilder,
+      (PacketRow, BaseReferences<_$MeridianDatabase, $PacketsTable, PacketRow>),
+      PacketRow,
+      PrefetchHooks Function()
+    >;
+typedef $$ConversationsTableCreateCompanionBuilder =
+    ConversationsCompanion Function({
+      required String peerCallsign,
+      required int lastMessageAt,
+      Value<int> unreadCount,
+      Value<int> rowid,
+    });
+typedef $$ConversationsTableUpdateCompanionBuilder =
+    ConversationsCompanion Function({
+      Value<String> peerCallsign,
+      Value<int> lastMessageAt,
+      Value<int> unreadCount,
+      Value<int> rowid,
+    });
+
+final class $$ConversationsTableReferences
+    extends
+        BaseReferences<
+          _$MeridianDatabase,
+          $ConversationsTable,
+          ConversationRow
+        > {
+  $$ConversationsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static MultiTypedResultKey<$MessageEntriesTable, List<MessageEntryRow>>
+  _messageEntriesRefsTable(_$MeridianDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.messageEntries,
+        aliasName: $_aliasNameGenerator(
+          db.conversations.peerCallsign,
+          db.messageEntries.conversationPeer,
+        ),
+      );
+
+  $$MessageEntriesTableProcessedTableManager get messageEntriesRefs {
+    final manager = $$MessageEntriesTableTableManager($_db, $_db.messageEntries)
+        .filter(
+          (f) => f.conversationPeer.peerCallsign.sqlEquals(
+            $_itemColumn<String>('peer_callsign')!,
+          ),
+        );
+
+    final cache = $_typedResult.readTableOrNull(_messageEntriesRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$ConversationsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $ConversationsTable> {
+  $$ConversationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get peerCallsign => $composableBuilder(
+    column: $table.peerCallsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastMessageAt => $composableBuilder(
+    column: $table.lastMessageAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get unreadCount => $composableBuilder(
+    column: $table.unreadCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> messageEntriesRefs(
+    Expression<bool> Function($$MessageEntriesTableFilterComposer f) f,
+  ) {
+    final $$MessageEntriesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.peerCallsign,
+      referencedTable: $db.messageEntries,
+      getReferencedColumn: (t) => t.conversationPeer,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessageEntriesTableFilterComposer(
+            $db: $db,
+            $table: $db.messageEntries,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ConversationsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $ConversationsTable> {
+  $$ConversationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get peerCallsign => $composableBuilder(
+    column: $table.peerCallsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastMessageAt => $composableBuilder(
+    column: $table.lastMessageAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get unreadCount => $composableBuilder(
+    column: $table.unreadCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ConversationsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $ConversationsTable> {
+  $$ConversationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get peerCallsign => $composableBuilder(
+    column: $table.peerCallsign,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get lastMessageAt => $composableBuilder(
+    column: $table.lastMessageAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get unreadCount => $composableBuilder(
+    column: $table.unreadCount,
+    builder: (column) => column,
+  );
+
+  Expression<T> messageEntriesRefs<T extends Object>(
+    Expression<T> Function($$MessageEntriesTableAnnotationComposer a) f,
+  ) {
+    final $$MessageEntriesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.peerCallsign,
+      referencedTable: $db.messageEntries,
+      getReferencedColumn: (t) => t.conversationPeer,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$MessageEntriesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.messageEntries,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ConversationsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $ConversationsTable,
+          ConversationRow,
+          $$ConversationsTableFilterComposer,
+          $$ConversationsTableOrderingComposer,
+          $$ConversationsTableAnnotationComposer,
+          $$ConversationsTableCreateCompanionBuilder,
+          $$ConversationsTableUpdateCompanionBuilder,
+          (ConversationRow, $$ConversationsTableReferences),
+          ConversationRow,
+          PrefetchHooks Function({bool messageEntriesRefs})
+        > {
+  $$ConversationsTableTableManager(
+    _$MeridianDatabase db,
+    $ConversationsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ConversationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ConversationsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ConversationsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> peerCallsign = const Value.absent(),
+                Value<int> lastMessageAt = const Value.absent(),
+                Value<int> unreadCount = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ConversationsCompanion(
+                peerCallsign: peerCallsign,
+                lastMessageAt: lastMessageAt,
+                unreadCount: unreadCount,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String peerCallsign,
+                required int lastMessageAt,
+                Value<int> unreadCount = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ConversationsCompanion.insert(
+                peerCallsign: peerCallsign,
+                lastMessageAt: lastMessageAt,
+                unreadCount: unreadCount,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$ConversationsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({messageEntriesRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (messageEntriesRefs) db.messageEntries,
+              ],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (messageEntriesRefs)
+                    await $_getPrefetchedData<
+                      ConversationRow,
+                      $ConversationsTable,
+                      MessageEntryRow
+                    >(
+                      currentTable: table,
+                      referencedTable: $$ConversationsTableReferences
+                          ._messageEntriesRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$ConversationsTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).messageEntriesRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where(
+                            (e) => e.conversationPeer == item.peerCallsign,
+                          ),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$ConversationsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $ConversationsTable,
+      ConversationRow,
+      $$ConversationsTableFilterComposer,
+      $$ConversationsTableOrderingComposer,
+      $$ConversationsTableAnnotationComposer,
+      $$ConversationsTableCreateCompanionBuilder,
+      $$ConversationsTableUpdateCompanionBuilder,
+      (ConversationRow, $$ConversationsTableReferences),
+      ConversationRow,
+      PrefetchHooks Function({bool messageEntriesRefs})
+    >;
+typedef $$MessageEntriesTableCreateCompanionBuilder =
+    MessageEntriesCompanion Function({
+      required String id,
+      required String conversationPeer,
+      Value<String?> fromCallsign,
+      Value<String?> addressee,
+      required String body,
+      required int timestamp,
+      required bool isOutgoing,
+      Value<String?> wireId,
+      required MessageStatus status,
+      Value<int> retryCount,
+      required MessageCategory category,
+      Value<String?> groupName,
+      Value<int> rowid,
+    });
+typedef $$MessageEntriesTableUpdateCompanionBuilder =
+    MessageEntriesCompanion Function({
+      Value<String> id,
+      Value<String> conversationPeer,
+      Value<String?> fromCallsign,
+      Value<String?> addressee,
+      Value<String> body,
+      Value<int> timestamp,
+      Value<bool> isOutgoing,
+      Value<String?> wireId,
+      Value<MessageStatus> status,
+      Value<int> retryCount,
+      Value<MessageCategory> category,
+      Value<String?> groupName,
+      Value<int> rowid,
+    });
+
+final class $$MessageEntriesTableReferences
+    extends
+        BaseReferences<
+          _$MeridianDatabase,
+          $MessageEntriesTable,
+          MessageEntryRow
+        > {
+  $$MessageEntriesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $ConversationsTable _conversationPeerTable(_$MeridianDatabase db) =>
+      db.conversations.createAlias(
+        $_aliasNameGenerator(
+          db.messageEntries.conversationPeer,
+          db.conversations.peerCallsign,
+        ),
+      );
+
+  $$ConversationsTableProcessedTableManager get conversationPeer {
+    final $_column = $_itemColumn<String>('conversation_peer')!;
+
+    final manager = $$ConversationsTableTableManager(
+      $_db,
+      $_db.conversations,
+    ).filter((f) => f.peerCallsign.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_conversationPeerTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$MessageEntriesTableFilterComposer
+    extends Composer<_$MeridianDatabase, $MessageEntriesTable> {
+  $$MessageEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get wireId => $composableBuilder(
+    column: $table.wireId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<MessageStatus, MessageStatus, String>
+  get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<MessageCategory, MessageCategory, String>
+  get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$ConversationsTableFilterComposer get conversationPeer {
+    final $$ConversationsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationPeer,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.peerCallsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableFilterComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$MessageEntriesTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $MessageEntriesTable> {
+  $$MessageEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get wireId => $composableBuilder(
+    column: $table.wireId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$ConversationsTableOrderingComposer get conversationPeer {
+    final $$ConversationsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationPeer,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.peerCallsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableOrderingComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$MessageEntriesTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $MessageEntriesTable> {
+  $$MessageEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get addressee =>
+      $composableBuilder(column: $table.addressee, builder: (column) => column);
+
+  GeneratedColumn<String> get body =>
+      $composableBuilder(column: $table.body, builder: (column) => column);
+
+  GeneratedColumn<int> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumn<bool> get isOutgoing => $composableBuilder(
+    column: $table.isOutgoing,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get wireId =>
+      $composableBuilder(column: $table.wireId, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<MessageStatus, String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<MessageCategory, String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get groupName =>
+      $composableBuilder(column: $table.groupName, builder: (column) => column);
+
+  $$ConversationsTableAnnotationComposer get conversationPeer {
+    final $$ConversationsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.conversationPeer,
+      referencedTable: $db.conversations,
+      getReferencedColumn: (t) => t.peerCallsign,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ConversationsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.conversations,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$MessageEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $MessageEntriesTable,
+          MessageEntryRow,
+          $$MessageEntriesTableFilterComposer,
+          $$MessageEntriesTableOrderingComposer,
+          $$MessageEntriesTableAnnotationComposer,
+          $$MessageEntriesTableCreateCompanionBuilder,
+          $$MessageEntriesTableUpdateCompanionBuilder,
+          (MessageEntryRow, $$MessageEntriesTableReferences),
+          MessageEntryRow,
+          PrefetchHooks Function({bool conversationPeer})
+        > {
+  $$MessageEntriesTableTableManager(
+    _$MeridianDatabase db,
+    $MessageEntriesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$MessageEntriesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$MessageEntriesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$MessageEntriesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> conversationPeer = const Value.absent(),
+                Value<String?> fromCallsign = const Value.absent(),
+                Value<String?> addressee = const Value.absent(),
+                Value<String> body = const Value.absent(),
+                Value<int> timestamp = const Value.absent(),
+                Value<bool> isOutgoing = const Value.absent(),
+                Value<String?> wireId = const Value.absent(),
+                Value<MessageStatus> status = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<MessageCategory> category = const Value.absent(),
+                Value<String?> groupName = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => MessageEntriesCompanion(
+                id: id,
+                conversationPeer: conversationPeer,
+                fromCallsign: fromCallsign,
+                addressee: addressee,
+                body: body,
+                timestamp: timestamp,
+                isOutgoing: isOutgoing,
+                wireId: wireId,
+                status: status,
+                retryCount: retryCount,
+                category: category,
+                groupName: groupName,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String conversationPeer,
+                Value<String?> fromCallsign = const Value.absent(),
+                Value<String?> addressee = const Value.absent(),
+                required String body,
+                required int timestamp,
+                required bool isOutgoing,
+                Value<String?> wireId = const Value.absent(),
+                required MessageStatus status,
+                Value<int> retryCount = const Value.absent(),
+                required MessageCategory category,
+                Value<String?> groupName = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => MessageEntriesCompanion.insert(
+                id: id,
+                conversationPeer: conversationPeer,
+                fromCallsign: fromCallsign,
+                addressee: addressee,
+                body: body,
+                timestamp: timestamp,
+                isOutgoing: isOutgoing,
+                wireId: wireId,
+                status: status,
+                retryCount: retryCount,
+                category: category,
+                groupName: groupName,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$MessageEntriesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({conversationPeer = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (conversationPeer) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.conversationPeer,
+                                referencedTable: $$MessageEntriesTableReferences
+                                    ._conversationPeerTable(db),
+                                referencedColumn:
+                                    $$MessageEntriesTableReferences
+                                        ._conversationPeerTable(db)
+                                        .peerCallsign,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$MessageEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $MessageEntriesTable,
+      MessageEntryRow,
+      $$MessageEntriesTableFilterComposer,
+      $$MessageEntriesTableOrderingComposer,
+      $$MessageEntriesTableAnnotationComposer,
+      $$MessageEntriesTableCreateCompanionBuilder,
+      $$MessageEntriesTableUpdateCompanionBuilder,
+      (MessageEntryRow, $$MessageEntriesTableReferences),
+      MessageEntryRow,
+      PrefetchHooks Function({bool conversationPeer})
+    >;
+typedef $$GroupMessageEntriesTableCreateCompanionBuilder =
+    GroupMessageEntriesCompanion Function({
+      required String id,
+      required String groupName,
+      required String fromCallsign,
+      required String body,
+      required int timestamp,
+      Value<int> rowid,
+    });
+typedef $$GroupMessageEntriesTableUpdateCompanionBuilder =
+    GroupMessageEntriesCompanion Function({
+      Value<String> id,
+      Value<String> groupName,
+      Value<String> fromCallsign,
+      Value<String> body,
+      Value<int> timestamp,
+      Value<int> rowid,
+    });
+
+class $$GroupMessageEntriesTableFilterComposer
+    extends Composer<_$MeridianDatabase, $GroupMessageEntriesTable> {
+  $$GroupMessageEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$GroupMessageEntriesTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $GroupMessageEntriesTable> {
+  $$GroupMessageEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$GroupMessageEntriesTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $GroupMessageEntriesTable> {
+  $$GroupMessageEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get groupName =>
+      $composableBuilder(column: $table.groupName, builder: (column) => column);
+
+  GeneratedColumn<String> get fromCallsign => $composableBuilder(
+    column: $table.fromCallsign,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get body =>
+      $composableBuilder(column: $table.body, builder: (column) => column);
+
+  GeneratedColumn<int> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+}
+
+class $$GroupMessageEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $GroupMessageEntriesTable,
+          GroupMessageEntryRow,
+          $$GroupMessageEntriesTableFilterComposer,
+          $$GroupMessageEntriesTableOrderingComposer,
+          $$GroupMessageEntriesTableAnnotationComposer,
+          $$GroupMessageEntriesTableCreateCompanionBuilder,
+          $$GroupMessageEntriesTableUpdateCompanionBuilder,
+          (
+            GroupMessageEntryRow,
+            BaseReferences<
+              _$MeridianDatabase,
+              $GroupMessageEntriesTable,
+              GroupMessageEntryRow
+            >,
+          ),
+          GroupMessageEntryRow,
+          PrefetchHooks Function()
+        > {
+  $$GroupMessageEntriesTableTableManager(
+    _$MeridianDatabase db,
+    $GroupMessageEntriesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$GroupMessageEntriesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$GroupMessageEntriesTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$GroupMessageEntriesTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> groupName = const Value.absent(),
+                Value<String> fromCallsign = const Value.absent(),
+                Value<String> body = const Value.absent(),
+                Value<int> timestamp = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => GroupMessageEntriesCompanion(
+                id: id,
+                groupName: groupName,
+                fromCallsign: fromCallsign,
+                body: body,
+                timestamp: timestamp,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String groupName,
+                required String fromCallsign,
+                required String body,
+                required int timestamp,
+                Value<int> rowid = const Value.absent(),
+              }) => GroupMessageEntriesCompanion.insert(
+                id: id,
+                groupName: groupName,
+                fromCallsign: fromCallsign,
+                body: body,
+                timestamp: timestamp,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$GroupMessageEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $GroupMessageEntriesTable,
+      GroupMessageEntryRow,
+      $$GroupMessageEntriesTableFilterComposer,
+      $$GroupMessageEntriesTableOrderingComposer,
+      $$GroupMessageEntriesTableAnnotationComposer,
+      $$GroupMessageEntriesTableCreateCompanionBuilder,
+      $$GroupMessageEntriesTableUpdateCompanionBuilder,
+      (
+        GroupMessageEntryRow,
+        BaseReferences<
+          _$MeridianDatabase,
+          $GroupMessageEntriesTable,
+          GroupMessageEntryRow
+        >,
+      ),
+      GroupMessageEntryRow,
+      PrefetchHooks Function()
+    >;
+typedef $$BulletinsTableCreateCompanionBuilder =
+    BulletinsCompanion Function({
+      required String sourceCallsign,
+      required String addressee,
+      required String body,
+      required int firstHeardAt,
+      required int lastHeardAt,
+      Value<int> heardCount,
+      required BulletinCategory category,
+      required String lineNumber,
+      Value<String?> groupName,
+      Value<Set<BulletinTransport>> transports,
+      Value<double?> receivedLat,
+      Value<double?> receivedLon,
+      Value<bool> isRead,
+      Value<int> rowid,
+    });
+typedef $$BulletinsTableUpdateCompanionBuilder =
+    BulletinsCompanion Function({
+      Value<String> sourceCallsign,
+      Value<String> addressee,
+      Value<String> body,
+      Value<int> firstHeardAt,
+      Value<int> lastHeardAt,
+      Value<int> heardCount,
+      Value<BulletinCategory> category,
+      Value<String> lineNumber,
+      Value<String?> groupName,
+      Value<Set<BulletinTransport>> transports,
+      Value<double?> receivedLat,
+      Value<double?> receivedLon,
+      Value<bool> isRead,
+      Value<int> rowid,
+    });
+
+class $$BulletinsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $BulletinsTable> {
+  $$BulletinsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get firstHeardAt => $composableBuilder(
+    column: $table.firstHeardAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastHeardAt => $composableBuilder(
+    column: $table.lastHeardAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get heardCount => $composableBuilder(
+    column: $table.heardCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<BulletinCategory, BulletinCategory, String>
+  get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get lineNumber => $composableBuilder(
+    column: $table.lineNumber,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<
+    Set<BulletinTransport>,
+    Set<BulletinTransport>,
+    String
+  >
+  get transports => $composableBuilder(
+    column: $table.transports,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<double> get receivedLat => $composableBuilder(
+    column: $table.receivedLat,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get receivedLon => $composableBuilder(
+    column: $table.receivedLon,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isRead => $composableBuilder(
+    column: $table.isRead,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$BulletinsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $BulletinsTable> {
+  $$BulletinsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get firstHeardAt => $composableBuilder(
+    column: $table.firstHeardAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastHeardAt => $composableBuilder(
+    column: $table.lastHeardAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get heardCount => $composableBuilder(
+    column: $table.heardCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lineNumber => $composableBuilder(
+    column: $table.lineNumber,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get groupName => $composableBuilder(
+    column: $table.groupName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get transports => $composableBuilder(
+    column: $table.transports,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get receivedLat => $composableBuilder(
+    column: $table.receivedLat,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get receivedLon => $composableBuilder(
+    column: $table.receivedLon,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isRead => $composableBuilder(
+    column: $table.isRead,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$BulletinsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $BulletinsTable> {
+  $$BulletinsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get sourceCallsign => $composableBuilder(
+    column: $table.sourceCallsign,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get addressee =>
+      $composableBuilder(column: $table.addressee, builder: (column) => column);
+
+  GeneratedColumn<String> get body =>
+      $composableBuilder(column: $table.body, builder: (column) => column);
+
+  GeneratedColumn<int> get firstHeardAt => $composableBuilder(
+    column: $table.firstHeardAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get lastHeardAt => $composableBuilder(
+    column: $table.lastHeardAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get heardCount => $composableBuilder(
+    column: $table.heardCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<BulletinCategory, String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get lineNumber => $composableBuilder(
+    column: $table.lineNumber,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get groupName =>
+      $composableBuilder(column: $table.groupName, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Set<BulletinTransport>, String>
+  get transports => $composableBuilder(
+    column: $table.transports,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get receivedLat => $composableBuilder(
+    column: $table.receivedLat,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get receivedLon => $composableBuilder(
+    column: $table.receivedLon,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isRead =>
+      $composableBuilder(column: $table.isRead, builder: (column) => column);
+}
+
+class $$BulletinsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $BulletinsTable,
+          BulletinRow,
+          $$BulletinsTableFilterComposer,
+          $$BulletinsTableOrderingComposer,
+          $$BulletinsTableAnnotationComposer,
+          $$BulletinsTableCreateCompanionBuilder,
+          $$BulletinsTableUpdateCompanionBuilder,
+          (
+            BulletinRow,
+            BaseReferences<_$MeridianDatabase, $BulletinsTable, BulletinRow>,
+          ),
+          BulletinRow,
+          PrefetchHooks Function()
+        > {
+  $$BulletinsTableTableManager(_$MeridianDatabase db, $BulletinsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$BulletinsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BulletinsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BulletinsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> sourceCallsign = const Value.absent(),
+                Value<String> addressee = const Value.absent(),
+                Value<String> body = const Value.absent(),
+                Value<int> firstHeardAt = const Value.absent(),
+                Value<int> lastHeardAt = const Value.absent(),
+                Value<int> heardCount = const Value.absent(),
+                Value<BulletinCategory> category = const Value.absent(),
+                Value<String> lineNumber = const Value.absent(),
+                Value<String?> groupName = const Value.absent(),
+                Value<Set<BulletinTransport>> transports = const Value.absent(),
+                Value<double?> receivedLat = const Value.absent(),
+                Value<double?> receivedLon = const Value.absent(),
+                Value<bool> isRead = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BulletinsCompanion(
+                sourceCallsign: sourceCallsign,
+                addressee: addressee,
+                body: body,
+                firstHeardAt: firstHeardAt,
+                lastHeardAt: lastHeardAt,
+                heardCount: heardCount,
+                category: category,
+                lineNumber: lineNumber,
+                groupName: groupName,
+                transports: transports,
+                receivedLat: receivedLat,
+                receivedLon: receivedLon,
+                isRead: isRead,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String sourceCallsign,
+                required String addressee,
+                required String body,
+                required int firstHeardAt,
+                required int lastHeardAt,
+                Value<int> heardCount = const Value.absent(),
+                required BulletinCategory category,
+                required String lineNumber,
+                Value<String?> groupName = const Value.absent(),
+                Value<Set<BulletinTransport>> transports = const Value.absent(),
+                Value<double?> receivedLat = const Value.absent(),
+                Value<double?> receivedLon = const Value.absent(),
+                Value<bool> isRead = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => BulletinsCompanion.insert(
+                sourceCallsign: sourceCallsign,
+                addressee: addressee,
+                body: body,
+                firstHeardAt: firstHeardAt,
+                lastHeardAt: lastHeardAt,
+                heardCount: heardCount,
+                category: category,
+                lineNumber: lineNumber,
+                groupName: groupName,
+                transports: transports,
+                receivedLat: receivedLat,
+                receivedLon: receivedLon,
+                isRead: isRead,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$BulletinsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $BulletinsTable,
+      BulletinRow,
+      $$BulletinsTableFilterComposer,
+      $$BulletinsTableOrderingComposer,
+      $$BulletinsTableAnnotationComposer,
+      $$BulletinsTableCreateCompanionBuilder,
+      $$BulletinsTableUpdateCompanionBuilder,
+      (
+        BulletinRow,
+        BaseReferences<_$MeridianDatabase, $BulletinsTable, BulletinRow>,
+      ),
+      BulletinRow,
+      PrefetchHooks Function()
+    >;
+typedef $$OutgoingBulletinsTableCreateCompanionBuilder =
+    OutgoingBulletinsCompanion Function({
+      Value<int> id,
+      required String addressee,
+      required String body,
+      required int intervalSeconds,
+      Value<int> transmissionCount,
+      Value<int?> expiresAt,
+      required int createdAt,
+      Value<int?> lastTransmittedAt,
+      Value<bool> viaRf,
+      Value<bool> viaAprsIs,
+      Value<bool> enabled,
+    });
+typedef $$OutgoingBulletinsTableUpdateCompanionBuilder =
+    OutgoingBulletinsCompanion Function({
+      Value<int> id,
+      Value<String> addressee,
+      Value<String> body,
+      Value<int> intervalSeconds,
+      Value<int> transmissionCount,
+      Value<int?> expiresAt,
+      Value<int> createdAt,
+      Value<int?> lastTransmittedAt,
+      Value<bool> viaRf,
+      Value<bool> viaAprsIs,
+      Value<bool> enabled,
+    });
+
+class $$OutgoingBulletinsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $OutgoingBulletinsTable> {
+  $$OutgoingBulletinsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get intervalSeconds => $composableBuilder(
+    column: $table.intervalSeconds,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get transmissionCount => $composableBuilder(
+    column: $table.transmissionCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get expiresAt => $composableBuilder(
+    column: $table.expiresAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastTransmittedAt => $composableBuilder(
+    column: $table.lastTransmittedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get viaRf => $composableBuilder(
+    column: $table.viaRf,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get viaAprsIs => $composableBuilder(
+    column: $table.viaAprsIs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get enabled => $composableBuilder(
+    column: $table.enabled,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$OutgoingBulletinsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $OutgoingBulletinsTable> {
+  $$OutgoingBulletinsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get addressee => $composableBuilder(
+    column: $table.addressee,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get body => $composableBuilder(
+    column: $table.body,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get intervalSeconds => $composableBuilder(
+    column: $table.intervalSeconds,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get transmissionCount => $composableBuilder(
+    column: $table.transmissionCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get expiresAt => $composableBuilder(
+    column: $table.expiresAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastTransmittedAt => $composableBuilder(
+    column: $table.lastTransmittedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get viaRf => $composableBuilder(
+    column: $table.viaRf,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get viaAprsIs => $composableBuilder(
+    column: $table.viaAprsIs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get enabled => $composableBuilder(
+    column: $table.enabled,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$OutgoingBulletinsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $OutgoingBulletinsTable> {
+  $$OutgoingBulletinsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get addressee =>
+      $composableBuilder(column: $table.addressee, builder: (column) => column);
+
+  GeneratedColumn<String> get body =>
+      $composableBuilder(column: $table.body, builder: (column) => column);
+
+  GeneratedColumn<int> get intervalSeconds => $composableBuilder(
+    column: $table.intervalSeconds,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get transmissionCount => $composableBuilder(
+    column: $table.transmissionCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get expiresAt =>
+      $composableBuilder(column: $table.expiresAt, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get lastTransmittedAt => $composableBuilder(
+    column: $table.lastTransmittedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get viaRf =>
+      $composableBuilder(column: $table.viaRf, builder: (column) => column);
+
+  GeneratedColumn<bool> get viaAprsIs =>
+      $composableBuilder(column: $table.viaAprsIs, builder: (column) => column);
+
+  GeneratedColumn<bool> get enabled =>
+      $composableBuilder(column: $table.enabled, builder: (column) => column);
+}
+
+class $$OutgoingBulletinsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $OutgoingBulletinsTable,
+          OutgoingBulletinRow,
+          $$OutgoingBulletinsTableFilterComposer,
+          $$OutgoingBulletinsTableOrderingComposer,
+          $$OutgoingBulletinsTableAnnotationComposer,
+          $$OutgoingBulletinsTableCreateCompanionBuilder,
+          $$OutgoingBulletinsTableUpdateCompanionBuilder,
+          (
+            OutgoingBulletinRow,
+            BaseReferences<
+              _$MeridianDatabase,
+              $OutgoingBulletinsTable,
+              OutgoingBulletinRow
+            >,
+          ),
+          OutgoingBulletinRow,
+          PrefetchHooks Function()
+        > {
+  $$OutgoingBulletinsTableTableManager(
+    _$MeridianDatabase db,
+    $OutgoingBulletinsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$OutgoingBulletinsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$OutgoingBulletinsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$OutgoingBulletinsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> addressee = const Value.absent(),
+                Value<String> body = const Value.absent(),
+                Value<int> intervalSeconds = const Value.absent(),
+                Value<int> transmissionCount = const Value.absent(),
+                Value<int?> expiresAt = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<int?> lastTransmittedAt = const Value.absent(),
+                Value<bool> viaRf = const Value.absent(),
+                Value<bool> viaAprsIs = const Value.absent(),
+                Value<bool> enabled = const Value.absent(),
+              }) => OutgoingBulletinsCompanion(
+                id: id,
+                addressee: addressee,
+                body: body,
+                intervalSeconds: intervalSeconds,
+                transmissionCount: transmissionCount,
+                expiresAt: expiresAt,
+                createdAt: createdAt,
+                lastTransmittedAt: lastTransmittedAt,
+                viaRf: viaRf,
+                viaAprsIs: viaAprsIs,
+                enabled: enabled,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String addressee,
+                required String body,
+                required int intervalSeconds,
+                Value<int> transmissionCount = const Value.absent(),
+                Value<int?> expiresAt = const Value.absent(),
+                required int createdAt,
+                Value<int?> lastTransmittedAt = const Value.absent(),
+                Value<bool> viaRf = const Value.absent(),
+                Value<bool> viaAprsIs = const Value.absent(),
+                Value<bool> enabled = const Value.absent(),
+              }) => OutgoingBulletinsCompanion.insert(
+                id: id,
+                addressee: addressee,
+                body: body,
+                intervalSeconds: intervalSeconds,
+                transmissionCount: transmissionCount,
+                expiresAt: expiresAt,
+                createdAt: createdAt,
+                lastTransmittedAt: lastTransmittedAt,
+                viaRf: viaRf,
+                viaAprsIs: viaAprsIs,
+                enabled: enabled,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$OutgoingBulletinsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $OutgoingBulletinsTable,
+      OutgoingBulletinRow,
+      $$OutgoingBulletinsTableFilterComposer,
+      $$OutgoingBulletinsTableOrderingComposer,
+      $$OutgoingBulletinsTableAnnotationComposer,
+      $$OutgoingBulletinsTableCreateCompanionBuilder,
+      $$OutgoingBulletinsTableUpdateCompanionBuilder,
+      (
+        OutgoingBulletinRow,
+        BaseReferences<
+          _$MeridianDatabase,
+          $OutgoingBulletinsTable,
+          OutgoingBulletinRow
+        >,
+      ),
+      OutgoingBulletinRow,
+      PrefetchHooks Function()
+    >;
+
+class $MeridianDatabaseManager {
+  final _$MeridianDatabase _db;
+  $MeridianDatabaseManager(this._db);
+  $$StationsTableTableManager get stations =>
+      $$StationsTableTableManager(_db, _db.stations);
+  $$PositionHistoryTableTableManager get positionHistory =>
+      $$PositionHistoryTableTableManager(_db, _db.positionHistory);
+  $$PacketsTableTableManager get packets =>
+      $$PacketsTableTableManager(_db, _db.packets);
+  $$ConversationsTableTableManager get conversations =>
+      $$ConversationsTableTableManager(_db, _db.conversations);
+  $$MessageEntriesTableTableManager get messageEntries =>
+      $$MessageEntriesTableTableManager(_db, _db.messageEntries);
+  $$GroupMessageEntriesTableTableManager get groupMessageEntries =>
+      $$GroupMessageEntriesTableTableManager(_db, _db.groupMessageEntries);
+  $$BulletinsTableTableManager get bulletins =>
+      $$BulletinsTableTableManager(_db, _db.bulletins);
+  $$OutgoingBulletinsTableTableManager get outgoingBulletins =>
+      $$OutgoingBulletinsTableTableManager(_db, _db.outgoingBulletins);
+}

--- a/lib/database/tables/bulletins.dart
+++ b/lib/database/tables/bulletins.dart
@@ -1,0 +1,31 @@
+import 'package:drift/drift.dart';
+
+import '../../models/bulletin.dart';
+import '../converters/bulletin_transports_converter.dart';
+
+/// Incoming bulletins. Unique on `(source_callsign, addressee)` per ADR-057 —
+/// retransmissions update the row rather than appending.
+@DataClassName('BulletinRow')
+class Bulletins extends Table {
+  TextColumn get sourceCallsign => text().named('source_callsign')();
+  TextColumn get addressee => text()();
+  TextColumn get body => text()();
+  IntColumn get firstHeardAt => integer().named('first_heard_at')();
+  IntColumn get lastHeardAt => integer().named('last_heard_at')();
+  IntColumn get heardCount =>
+      integer().named('heard_count').withDefault(const Constant(1))();
+  TextColumn get category =>
+      text().map(const EnumNameConverter(BulletinCategory.values))();
+  TextColumn get lineNumber => text().named('line_number')();
+  TextColumn get groupName => text().named('group_name').nullable()();
+  TextColumn get transports => text()
+      .map(const BulletinTransportsConverter())
+      .withDefault(const Constant(''))();
+  RealColumn get receivedLat => real().named('received_lat').nullable()();
+  RealColumn get receivedLon => real().named('received_lon').nullable()();
+  BoolColumn get isRead =>
+      boolean().named('is_read').withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {sourceCallsign, addressee};
+}

--- a/lib/database/tables/conversations.dart
+++ b/lib/database/tables/conversations.dart
@@ -1,0 +1,14 @@
+import 'package:drift/drift.dart';
+
+/// One row per direct or group thread. Direct threads are keyed by base
+/// callsign (uppercased, no SSID); group threads are keyed `#GROUP:<NAME>`.
+@DataClassName('ConversationRow')
+class Conversations extends Table {
+  TextColumn get peerCallsign => text().named('peer_callsign')();
+  IntColumn get lastMessageAt => integer().named('last_message_at')();
+  IntColumn get unreadCount =>
+      integer().named('unread_count').withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {peerCallsign};
+}

--- a/lib/database/tables/group_message_entries.dart
+++ b/lib/database/tables/group_message_entries.dart
@@ -1,0 +1,15 @@
+import 'package:drift/drift.dart';
+
+/// Group-channel messages keyed by group name. Group subscriptions
+/// themselves remain in SharedPreferences (see ADR-062).
+@DataClassName('GroupMessageEntryRow')
+class GroupMessageEntries extends Table {
+  TextColumn get id => text()();
+  TextColumn get groupName => text().named('group_name')();
+  TextColumn get fromCallsign => text().named('from_callsign')();
+  TextColumn get body => text()();
+  IntColumn get timestamp => integer()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/database/tables/message_entries.dart
+++ b/lib/database/tables/message_entries.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart';
 
 import '../../models/message_category.dart';
-import '../../services/message_service.dart';
+import '../../models/message_status.dart';
 import 'conversations.dart';
 
 /// Direct and group messages.

--- a/lib/database/tables/message_entries.dart
+++ b/lib/database/tables/message_entries.dart
@@ -1,0 +1,35 @@
+import 'package:drift/drift.dart';
+
+import '../../models/message_category.dart';
+import '../../services/message_service.dart';
+import 'conversations.dart';
+
+/// Direct and group messages.
+///
+/// `id` uses the existing composite local-id format (`${peer}_${wireId}_${ms}`
+/// for outgoing direct, `group_${name}_${ms}` for group, `${source}:${wireId}`
+/// for incoming deduped) rather than a UUID — keeps the deduplication contract
+/// stable across the migration.
+@DataClassName('MessageEntryRow')
+class MessageEntries extends Table {
+  TextColumn get id => text()();
+  TextColumn get conversationPeer => text()
+      .named('conversation_peer')
+      .references(Conversations, #peerCallsign, onDelete: KeyAction.cascade)();
+  TextColumn get fromCallsign => text().named('from_callsign').nullable()();
+  TextColumn get addressee => text().nullable()();
+  TextColumn get body => text()();
+  IntColumn get timestamp => integer()();
+  BoolColumn get isOutgoing => boolean().named('is_outgoing')();
+  TextColumn get wireId => text().named('wire_id').nullable()();
+  TextColumn get status =>
+      text().map(const EnumNameConverter(MessageStatus.values))();
+  IntColumn get retryCount =>
+      integer().named('retry_count').withDefault(const Constant(0))();
+  TextColumn get category =>
+      text().map(const EnumNameConverter(MessageCategory.values))();
+  TextColumn get groupName => text().named('group_name').nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/database/tables/outgoing_bulletins.dart
+++ b/lib/database/tables/outgoing_bulletins.dart
@@ -1,0 +1,23 @@
+import 'package:drift/drift.dart';
+
+/// Operator-scheduled outgoing bulletins. `id` is an auto-incremented integer
+/// to preserve the existing int-id contract (see ADR-062 plan deviation
+/// note).
+@DataClassName('OutgoingBulletinRow')
+class OutgoingBulletins extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get addressee => text()();
+  TextColumn get body => text()();
+  IntColumn get intervalSeconds => integer().named('interval_seconds')();
+  IntColumn get transmissionCount =>
+      integer().named('transmission_count').withDefault(const Constant(0))();
+  IntColumn get expiresAt => integer().named('expires_at').nullable()();
+  IntColumn get createdAt => integer().named('created_at')();
+  IntColumn get lastTransmittedAt =>
+      integer().named('last_transmitted_at').nullable()();
+  BoolColumn get viaRf =>
+      boolean().named('via_rf').withDefault(const Constant(true))();
+  BoolColumn get viaAprsIs =>
+      boolean().named('via_aprs_is').withDefault(const Constant(true))();
+  BoolColumn get enabled => boolean().withDefault(const Constant(true))();
+}

--- a/lib/database/tables/packets.dart
+++ b/lib/database/tables/packets.dart
@@ -1,0 +1,33 @@
+import 'package:drift/drift.dart';
+
+import '../../core/packet/aprs_packet.dart';
+
+/// Enum mirroring the sealed [AprsPacket] hierarchy. Stored as text so that
+/// adding new packet types in the future is non-breaking.
+enum PacketTypeTag {
+  position,
+  weather,
+  message,
+  object,
+  item,
+  status,
+  micE,
+  unknown,
+}
+
+@DataClassName('PacketRow')
+class Packets extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get rawLine => text().named('raw_line')();
+  TextColumn get packetType => text()
+      .named('packet_type')
+      .map(const EnumNameConverter(PacketTypeTag.values))();
+  TextColumn get sourceCallsign => text().named('source_callsign')();
+  TextColumn get destination => text().nullable()();
+  IntColumn get receivedAt => integer().named('received_at')();
+  BoolColumn get isOutgoing =>
+      boolean().named('is_outgoing').withDefault(const Constant(false))();
+  TextColumn get sourceChannel => text()
+      .named('source_channel')
+      .map(const EnumNameConverter(PacketSource.values))();
+}

--- a/lib/database/tables/position_history.dart
+++ b/lib/database/tables/position_history.dart
@@ -1,0 +1,13 @@
+import 'package:drift/drift.dart';
+
+import 'stations.dart';
+
+@DataClassName('PositionHistoryRow')
+class PositionHistory extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get callsign =>
+      text().references(Stations, #callsign, onDelete: KeyAction.cascade)();
+  RealColumn get latitude => real()();
+  RealColumn get longitude => real()();
+  IntColumn get timestamp => integer()();
+}

--- a/lib/database/tables/stations.dart
+++ b/lib/database/tables/stations.dart
@@ -1,0 +1,26 @@
+import 'package:drift/drift.dart';
+
+import '../../core/packet/station.dart';
+
+@DataClassName('StationRow')
+class Stations extends Table {
+  TextColumn get callsign => text()();
+  TextColumn get symbolTable => text().named('symbol_table')();
+  TextColumn get symbolCode => text().named('symbol_code')();
+  TextColumn get comment => text()();
+  TextColumn get rawPacket => text().named('raw_packet')();
+  TextColumn get device => text().nullable()();
+  IntColumn get lastHeard => integer().named('last_heard')();
+  TextColumn get stationType => text()
+      .named('station_type')
+      .map(const EnumNameConverter(StationType.values))();
+  TextColumn get messageCapability => text()
+      .named('message_capability')
+      .map(const EnumNameConverter(MessageCapability.values))();
+  TextColumn get capabilities => text().nullable()();
+  RealColumn get lat => real()();
+  RealColumn get lon => real()();
+
+  @override
+  Set<Column> get primaryKey => {callsign};
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,12 @@ import 'core/packet/aprs_packet.dart' show PacketSource;
 import 'core/packet/device_resolver.dart';
 import 'core/transport/aprs_is_transport.dart';
 import 'core/transport/ble_diagnostics.dart';
+import 'database/daos/bulletin_dao.dart';
+import 'database/daos/message_dao.dart';
+import 'database/daos/packet_dao.dart';
+import 'database/daos/station_dao.dart';
+import 'database/database_provider.dart';
+import 'database/meridian_database.dart';
 import 'map/stadia_tile_provider.dart';
 import 'screens/map_screen.dart';
 import 'screens/onboarding/onboarding_screen.dart';
@@ -77,6 +83,12 @@ Future<void> main() async {
     // Initialise Android notification channel options for the background service.
     BackgroundServiceManager.initOptions();
   }
+
+  // Open the SQLite database (drift). On non-web platforms this spawns a
+  // dedicated drift isolate and registers its connect port via
+  // `IsolateNameServer` so the Android foreground-service isolate can share
+  // the same database connection. See ADR-062.
+  final database = await openMeridianDatabase();
 
   // Load theme preference and onboarding state before the first frame.
   final themeController = await ThemeController.create();
@@ -155,8 +167,11 @@ Future<void> main() async {
   // Build service layer
   // ---------------------------------------------------------------------------
 
-  final service = StationService();
-  await service.loadPersistedHistory(prefs);
+  final service = StationService(
+    stationDao: database.stationDao,
+    packetDao: database.packetDao,
+  );
+  await service.loadPersistedSettings(prefs);
   service.attach(registry);
 
   // Reconnect APRS-IS only if the user chose to connect last session.
@@ -197,6 +212,7 @@ Future<void> main() async {
 
   final bulletinService = BulletinService(
     subscriptions: bulletinSubscriptions,
+    bulletinDao: database.bulletinDao,
     prefs: prefs,
   );
   await bulletinService.load();
@@ -234,6 +250,7 @@ Future<void> main() async {
     service,
     groupSubscriptions: groupSubscriptions,
     bulletins: bulletinService,
+    messageDao: database.messageDao,
   );
   await messageService.loadHistory();
 
@@ -267,6 +284,7 @@ Future<void> main() async {
     tx: txService,
     onPacketLogged: (line) =>
         service.ingestLine(line, source: PacketSource.aprsIs),
+    onResumed: bulletinService.refreshOutgoing,
   );
 
   // ---------------------------------------------------------------------------
@@ -308,6 +326,11 @@ Future<void> main() async {
         ChangeNotifierProvider<AdvancedModeController>.value(
           value: advancedModeController,
         ),
+        Provider<MeridianDatabase>.value(value: database),
+        Provider<StationDao>.value(value: database.stationDao),
+        Provider<PacketDao>.value(value: database.packetDao),
+        Provider<MessageDao>.value(value: database.messageDao),
+        Provider<BulletinDao>.value(value: database.bulletinDao),
         ChangeNotifierProvider<StationService>.value(value: service),
         ChangeNotifierProvider<ConnectionRegistry>.value(value: registry),
         ChangeNotifierProvider<StationSettingsService>.value(

--- a/lib/models/message_status.dart
+++ b/lib/models/message_status.dart
@@ -1,0 +1,7 @@
+/// Delivery state of an outgoing message.
+///
+/// Lives in the model layer (not the service layer) so the persistence layer
+/// — `lib/database/` tables, DAOs, and the generated database — can reference
+/// it without importing `MessageService`. `MessageService` re-exports this
+/// enum for existing consumers.
+enum MessageStatus { pending, acked, retrying, failed, rejected, cancelled }

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -123,12 +123,14 @@ class BackgroundServiceManager extends ChangeNotifier
     required TxService tx,
     ForegroundServiceApi? taskApi,
     void Function(String line)? onPacketLogged,
+    Future<void> Function()? onResumed,
     Clock clock = DateTime.now,
   }) : _registry = registry,
        _beaconing = beaconing,
        _tx = tx,
        _taskApi = taskApi ?? const _DefaultForegroundServiceApi(),
        _onPacketLogged = onPacketLogged,
+       _onResumed = onResumed,
        _clock = clock {
     _registry.addListener(_onServiceStateChanged);
     _beaconing.addListener(_onServiceStateChanged);
@@ -154,6 +156,13 @@ class BackgroundServiceManager extends ChangeNotifier
   /// local packet log — same loopback semantics as
   /// [BeaconingService.onBeaconSent] for the foreground path.
   final void Function(String line)? _onPacketLogged;
+
+  /// Invoked on `AppLifecycleState.resumed` while the foreground service is
+  /// running. Wired to [BulletinService.refreshOutgoing] so the main isolate
+  /// picks up outgoing-bulletin transmission state the background isolate
+  /// wrote to the shared database while the app was backgrounded (ADR-062),
+  /// without waiting for the next scheduler tick.
+  final Future<void> Function()? _onResumed;
 
   static const _keyBgActivity = 'bg_activity_enabled';
 
@@ -393,6 +402,10 @@ class BackgroundServiceManager extends ChangeNotifier
 
       case AppLifecycleState.resumed:
         _isInBackground = false;
+
+        // Re-read outgoing-bulletin state the background isolate may have
+        // mutated in the shared DB while we were paused (ADR-062 / ADR-057).
+        _onResumed?.call(); // ignore: unawaited_futures
 
         // Reconcile BSM state against the OS first. If Android killed the
         // FGS overnight or the user swiped the notification away, _state

--- a/lib/services/bulletin_scheduler.dart
+++ b/lib/services/bulletin_scheduler.dart
@@ -98,6 +98,9 @@ class BulletinScheduler extends ChangeNotifier {
   /// isolate). Handles expiry first, then transmission.
   Future<void> tick() async {
     final now = _clock();
+    // Re-read outgoing bulletins from the shared DB so background-isolate
+    // transmission updates are observed on resume (ADR-057/061).
+    await _bulletins.refreshOutgoing();
     for (final ob in _bulletins.outgoingBulletins.toList()) {
       if (!ob.enabled) continue;
 

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -1,25 +1,44 @@
-/// Receive-side bulletin store.
+/// Receive-side bulletin store + outgoing-bulletin registry (ADR-062).
 ///
-/// Ingests classified bulletin packets from [MessageService] and upserts
-/// them into a `(sourceCallsign, addressee)`-keyed store. Retransmissions
-/// update the existing row: body replaces (marking unread if changed),
-/// `lastHeardAt` bumps, `heardCount` increments, `transports` union-merges.
+/// Ingests classified bulletin packets from [MessageService] and upserts them
+/// into a `(sourceCallsign, addressee)`-keyed store. Retransmissions update
+/// the existing row: body replaces (marking unread if changed), `lastHeardAt`
+/// bumps, `heardCount` increments, `transports` union-merges.
 ///
-/// For v0.17 PR 1 this service only applies the named-group subscription
-/// filter (unsubscribed `BLNxNAME` dropped). General `BLN0`–`BLN9` scope
-/// filtering (distance, station-location-null banner) lands in PR 5 along
-/// with the APRS-IS filter extension. See ADR-057, ADR-058.
+/// Persistence (ADR-062):
+///   - **Incoming** bulletins are an in-memory working set written through to
+///     drift (`bulletins` table, keyed by source|addressee). The model's `id`
+///     is a session-scoped navigation handle assigned in memory — it is NOT
+///     persisted (the table is keyed by source+addressee). The background
+///     isolate never ingests incoming bulletins, so no watch is needed here.
+///   - **Outgoing** bulletins use the drift autoincrement `id`. The in-memory
+///     `_outgoing` cache is updated by main-isolate write-through and re-read
+///     fresh from the shared DB by [refreshOutgoing] (called at the start of
+///     every [BulletinScheduler] tick). Because the background isolate writes
+///     transmission updates to the *same* `meridian.db`, the next main-isolate
+///     tick observes them without the operator triggering anything — this is
+///     the ADR-057/061 fix. The mechanism is polled (bounded by the 30 s tick),
+///     not a drift `watch()`: a continuous watch raced with write-through
+///     (a lagging emission carrying a pre-mutation snapshot could revert the
+///     cache), so it was deliberately dropped.
 library;
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math' as math;
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/packet/aprs_packet.dart';
 import '../core/util/clock.dart';
+import '../database/daos/bulletin_dao.dart';
+import '../database/meridian_database.dart'
+    show
+        BulletinRow,
+        BulletinsCompanion,
+        OutgoingBulletinRow,
+        OutgoingBulletinsCompanion;
 import '../models/bulletin.dart';
 import '../models/outgoing_bulletin.dart';
 import 'bulletin_subscription_service.dart';
@@ -33,34 +52,30 @@ enum BulletinIngestOutcome {
   updated,
 
   /// Dropped before upsert — named group not subscribed, or other future
-  /// scope filter (PR 5).
+  /// scope filter.
   dropped,
 }
 
 class BulletinService extends ChangeNotifier {
   BulletinService({
     required BulletinSubscriptionService subscriptions,
+    required BulletinDao bulletinDao,
     SharedPreferences? prefs,
     Clock clock = DateTime.now,
   }) : _subscriptions = subscriptions,
+       _bulletinDao = bulletinDao,
        _prefsOverride = prefs,
        _clock = clock;
 
   final BulletinSubscriptionService _subscriptions;
+  final BulletinDao _bulletinDao;
   final SharedPreferences? _prefsOverride;
   final Clock _clock;
 
-  static const _keyBulletins = 'bulletins_v1';
-  static const _keyNextId = 'bulletins_next_id_v1';
+  // Settings keys (stay in SharedPreferences — structured data is in drift).
   static const _keyShowBulletins = 'bulletins_show';
   static const _keyRadiusKm = 'bulletins_radius_km';
   static const _keyRetentionHours = 'bulletins_retention_hours';
-
-  /// SharedPreferences key holding the JSON-encoded list of
-  /// [OutgoingBulletin]s. Read directly by the background isolate's bulletin
-  /// timer (same pattern as beacon settings), so the key name is public.
-  static const keyOutgoingBulletins = 'outgoing_bulletins_v1';
-  static const _keyOutgoingNextId = 'outgoing_bulletins_next_id_v1';
 
   /// Allowed TX-interval options (seconds). `0` = one-shot.
   static const List<int> intervalOptionsSeconds = [
@@ -75,30 +90,25 @@ class BulletinService extends ChangeNotifier {
   /// Allowed expiry options (hours since creation).
   static const List<int> expiryOptionsHours = [2, 6, 12, 24, 48];
 
-  /// Allowed radius options (km). `0` is a sentinel for "Map area only" (no
-  /// client-side distance filter — the APRS-IS area filter handles it).
-  /// The `-1` sentinel means "Global" (no distance filter at all).
+  /// Allowed radius options (km). `0` = "Map area only"; `-1` = "Global".
   static const List<int> radiusOptionsKm = [0, 100, 500, 1000, -1];
 
-  /// Allowed retention options (hours). Default is 48h (APRSIS32 convention).
+  /// Allowed retention options (hours). Default 48h (APRSIS32 convention).
   static const List<int> retentionOptionsHours = [24, 48, 72];
 
-  // Keyed by "SOURCE|ADDRESSEE" for stable lookup.
+  // Incoming bulletins keyed by "SOURCE|ADDRESSEE". In-memory working set,
+  // written through to drift. `id` assigned in-memory (session-scoped).
   final Map<String, Bulletin> _bulletins = {};
   int _nextId = 1;
 
-  // Outgoing bulletins by id. Scheduler iterates this in-order per tick.
+  // Outgoing bulletins by drift id. Updated by main-isolate write-through and
+  // by [refreshOutgoing] (fresh DB read each scheduler tick).
   final Map<int, OutgoingBulletin> _outgoing = {};
-  int _outgoingNextId = 1;
 
   bool _showBulletins = true;
   int _radiusKm = 500;
   int _retentionHours = 48;
 
-  /// Operator's current position (optional). Pushed in by the owning app
-  /// layer when station settings or beacon location change. Used as the
-  /// origin for client-side distance filtering of general APRS-IS bulletins
-  /// (ADR-058).
   double? _operatorLat;
   double? _operatorLon;
 
@@ -108,20 +118,10 @@ class BulletinService extends ChangeNotifier {
     if (_operatorLat == lat && _operatorLon == lon) return;
     _operatorLat = lat;
     _operatorLon = lon;
-    // No notifyListeners — position does not affect rendered state, only
-    // future ingest decisions.
   }
 
-  /// Master toggle for bulletin display. When false, the Bulletins tab hides
-  /// all received rows (ingest keeps storing — ADR-054 capture-always parity).
   bool get showBulletins => _showBulletins;
-
-  /// Distance-filter radius in km for APRS-IS-received general bulletins.
-  /// `0` = "map area only" (area filter alone); `-1` = "global" (no filter).
-  /// Actual distance-filtering logic lands in PR 5 along with the filter
-  /// builder; this getter only stores the user preference for now.
   int get radiusKm => _radiusKm;
-
   int get retentionHours => _retentionHours;
 
   /// All stored bulletins, newest `lastHeardAt` first.
@@ -133,48 +133,35 @@ class BulletinService extends ChangeNotifier {
 
   int get unreadCount => _bulletins.values.where((b) => !b.isRead).length;
 
-  /// All outgoing bulletins in insertion order (oldest first). The scheduler
-  /// iterates this list on each tick; the "My bulletins" UI renders it.
-  List<OutgoingBulletin> get outgoingBulletins =>
-      List.unmodifiable(_outgoing.values);
+  /// All outgoing bulletins in insertion order (oldest first).
+  List<OutgoingBulletin> get outgoingBulletins {
+    final list = _outgoing.values.toList()
+      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return List.unmodifiable(list);
+  }
 
   OutgoingBulletin? outgoingById(int id) => _outgoing[id];
 
   Future<void> load() async {
     final prefs = await _prefs();
-    _nextId = prefs.getInt(_keyNextId) ?? 1;
-    _outgoingNextId = prefs.getInt(_keyOutgoingNextId) ?? 1;
     _showBulletins = prefs.getBool(_keyShowBulletins) ?? true;
     _radiusKm = prefs.getInt(_keyRadiusKm) ?? 500;
     _retentionHours = prefs.getInt(_keyRetentionHours) ?? 48;
-    final raw = prefs.getString(_keyBulletins);
-    if (raw != null) {
-      try {
-        final list = (jsonDecode(raw) as List<dynamic>)
-            .cast<Map<String, dynamic>>()
-            .map(Bulletin.fromJson);
-        _bulletins.clear();
-        for (final b in list) {
-          _bulletins[_key(b.sourceCallsign, b.addressee)] = b;
-        }
-      } catch (e) {
-        debugPrint('BulletinService: failed to decode bulletins: $e');
-      }
+
+    // Incoming — assign session-scoped ids as we hydrate.
+    _bulletins.clear();
+    _nextId = 1;
+    for (final row in await _bulletinDao.getAllIncoming()) {
+      final b = _rowToBulletin(row, _nextId++);
+      _bulletins[_key(b.sourceCallsign, b.addressee)] = b;
     }
-    final outgoingRaw = prefs.getString(keyOutgoingBulletins);
-    if (outgoingRaw != null) {
-      try {
-        final list = (jsonDecode(outgoingRaw) as List<dynamic>)
-            .cast<Map<String, dynamic>>()
-            .map(OutgoingBulletin.fromJson);
-        _outgoing.clear();
-        for (final ob in list) {
-          _outgoing[ob.id] = ob;
-        }
-      } catch (e) {
-        debugPrint('BulletinService: failed to decode outgoing: $e');
-      }
+
+    // Outgoing — explicit read (don't depend on the watch's first emission).
+    _outgoing.clear();
+    for (final row in await _bulletinDao.getAllOutgoing()) {
+      _outgoing[row.id] = _rowToOutgoing(row);
     }
+
     notifyListeners();
   }
 
@@ -200,12 +187,6 @@ class BulletinService extends ChangeNotifier {
     }
 
     // Client-side distance filter for general APRS-IS bulletins (ADR-058).
-    // Only applies when: category is general, transport is APRS-IS, the user
-    // has a non-sentinel radius configured, and both endpoints have known
-    // positions. If either position is unknown the bulletin is kept — the
-    // operator sees it and a banner (UI-only) prompts them to set their
-    // location. RF bulletins are never distance-filtered (short-range
-    // already). Named groups are never distance-filtered (explicit subscribe).
     if (info.category == BulletinCategory.general &&
         transport == PacketSource.aprsIs &&
         _radiusKm > 0 &&
@@ -226,9 +207,10 @@ class BulletinService extends ChangeNotifier {
     final key = _key(source, info.addressee);
     final existing = _bulletins[key];
     final BulletinIngestOutcome outcome;
+    final Bulletin stored;
 
     if (existing == null) {
-      _bulletins[key] = Bulletin(
+      stored = Bulletin(
         id: _nextId++,
         sourceCallsign: source,
         addressee: info.addressee,
@@ -251,18 +233,20 @@ class BulletinService extends ChangeNotifier {
         ...existing.transports,
         transport.asBulletinTransport,
       };
-      _bulletins[key] = existing.copyWith(
+      stored = existing.copyWith(
         body: bodyChanged ? body : existing.body,
         lastHeardAt: receivedAt,
         heardCount: existing.heardCount + 1,
         transports: mergedTransports,
-        // If the body has changed, re-mark as unread (new information).
         isRead: bodyChanged ? false : existing.isRead,
       );
       outcome = BulletinIngestOutcome.updated;
     }
 
-    _persist(); // ignore: unawaited_futures
+    _bulletins[key] = stored;
+    _bulletinDao.upsertIncoming(
+      _bulletinToCompanion(stored),
+    ); // ignore: unawaited_futures
     notifyListeners();
     return outcome;
   }
@@ -280,7 +264,10 @@ class BulletinService extends ChangeNotifier {
     final current = _bulletins[matchKey]!;
     if (current.isRead) return;
     _bulletins[matchKey] = current.copyWith(isRead: true);
-    await _persist();
+    await _bulletinDao.markIncomingRead(
+      current.sourceCallsign,
+      current.addressee,
+    );
     notifyListeners();
   }
 
@@ -319,15 +306,12 @@ class BulletinService extends ChangeNotifier {
   }
 
   // ---------------------------------------------------------------------------
-  // OutgoingBulletin CRUD (v0.17, ADR-057)
+  // OutgoingBulletin CRUD (ADR-057)
   // ---------------------------------------------------------------------------
 
   /// Create a new outgoing bulletin. Starts enabled with `lastTransmittedAt`
-  /// null, so the scheduler fires an initial pulse on its next tick.
-  ///
-  /// [intervalSeconds] must be one of [intervalOptionsSeconds] (0 = one-shot).
-  /// [expiresAt] defaults to `createdAt + 24h` when not supplied.
-  /// Throws [ArgumentError] on invalid addressee or interval.
+  /// null, so the scheduler fires an initial pulse on its next tick. The id is
+  /// assigned by drift (autoincrement).
   Future<OutgoingBulletin> createOutgoing({
     required String addressee,
     required String body,
@@ -352,26 +336,36 @@ class BulletinService extends ChangeNotifier {
       );
     }
     final now = _clock();
+    final resolvedExpiry = expiresAt ?? now.add(const Duration(hours: 24));
+    final id = await _bulletinDao.insertOutgoing(
+      OutgoingBulletinsCompanion.insert(
+        addressee: normalized,
+        body: body,
+        intervalSeconds: intervalSeconds,
+        createdAt: now.millisecondsSinceEpoch,
+        expiresAt: Value(resolvedExpiry.millisecondsSinceEpoch),
+        viaRf: Value(viaRf),
+        viaAprsIs: Value(viaAprsIs),
+      ),
+    );
     final ob = OutgoingBulletin(
-      id: _outgoingNextId++,
+      id: id,
       addressee: normalized,
       body: body,
       intervalSeconds: intervalSeconds,
-      expiresAt: expiresAt ?? now.add(const Duration(hours: 24)),
+      expiresAt: resolvedExpiry,
       createdAt: now,
       viaRf: viaRf,
       viaAprsIs: viaAprsIs,
       enabled: true,
     );
-    _outgoing[ob.id] = ob;
-    await _persist();
+    _outgoing[id] = ob;
     notifyListeners();
     return ob;
   }
 
-  /// Update the body and/or addressee of an outgoing bulletin. Per ADR-057
-  /// this resets `lastTransmittedAt` and `transmissionCount` so the scheduler
-  /// fires a fresh initial pulse on its next tick.
+  /// Update body/addressee. Resets `lastTransmittedAt` and `transmissionCount`
+  /// so the scheduler fires a fresh initial pulse (ADR-057).
   Future<void> updateOutgoingContent(
     int id, {
     String? addressee,
@@ -387,19 +381,22 @@ class BulletinService extends ChangeNotifier {
       }
       nextAddressee = normalized;
     }
+    await _bulletinDao.updateOutgoingContent(
+      id: id,
+      addressee: nextAddressee,
+      body: body,
+    );
     _outgoing[id] = current.copyWith(
       addressee: nextAddressee,
       body: body,
       clearLastTransmittedAt: true,
       transmissionCount: 0,
     );
-    await _persist();
     notifyListeners();
   }
 
   /// Update the schedule (interval, expiry, transport flags). Does NOT reset
-  /// `lastTransmittedAt` or `transmissionCount` — this is the explicit contract
-  /// per ADR-057 (changing when/where to retransmit ≠ re-sending the body).
+  /// `lastTransmittedAt`/`transmissionCount` (ADR-057).
   Future<void> updateOutgoingSchedule(
     int id, {
     int? intervalSeconds,
@@ -417,13 +414,19 @@ class BulletinService extends ChangeNotifier {
         'not a supported interval',
       );
     }
+    await _bulletinDao.updateOutgoingSchedule(
+      id: id,
+      intervalSeconds: intervalSeconds,
+      expiresAt: expiresAt,
+      viaRf: viaRf,
+      viaAprsIs: viaAprsIs,
+    );
     _outgoing[id] = current.copyWith(
       intervalSeconds: intervalSeconds,
       expiresAt: expiresAt,
       viaRf: viaRf,
       viaAprsIs: viaAprsIs,
     );
-    await _persist();
     notifyListeners();
   }
 
@@ -432,15 +435,16 @@ class BulletinService extends ChangeNotifier {
     final current = _outgoing[id];
     if (current == null) return;
     if (current.enabled == enabled) return;
+    await _bulletinDao.setOutgoingEnabled(id, enabled);
     _outgoing[id] = current.copyWith(enabled: enabled);
-    await _persist();
     notifyListeners();
   }
 
   /// Delete an outgoing bulletin permanently.
   Future<void> deleteOutgoing(int id) async {
-    if (_outgoing.remove(id) == null) return;
-    await _persist();
+    if (!_outgoing.containsKey(id)) return;
+    await _bulletinDao.deleteOutgoing(id);
+    _outgoing.remove(id);
     notifyListeners();
   }
 
@@ -449,18 +453,15 @@ class BulletinService extends ChangeNotifier {
   Future<void> recordOutgoingTransmission(int id, DateTime timestamp) async {
     final current = _outgoing[id];
     if (current == null) return;
+    await _bulletinDao.recordOutgoingTransmission(id, timestamp);
     _outgoing[id] = current.copyWith(
       lastTransmittedAt: timestamp,
       transmissionCount: current.transmissionCount + 1,
     );
-    await _persist();
     notifyListeners();
   }
 
-  /// Matches bulletin addressees per APRS spec §3.2.16 — `BLN` + a line
-  /// number (`0`–`9` or `A`–`Z`), optionally followed by a 1–5 char group
-  /// name. Total length capped at 9 by the wire format (matcher further
-  /// enforces this via padding/truncation in [AprsEncoder]).
+  /// Matches bulletin addressees per APRS spec §3.2.16.
   static final RegExp _bulletinAddresseePattern = RegExp(
     r'^BLN[0-9A-Z][A-Z0-9]{0,5}$',
   );
@@ -469,25 +470,93 @@ class BulletinService extends ChangeNotifier {
   // Retention sweeper
   // ---------------------------------------------------------------------------
 
-  /// Drop all bulletins whose `lastHeardAt` is older than [retention].
-  /// Call from a periodic sweeper (added in PR 5 along with the notification
-  /// pipeline).
+  /// Drop all incoming bulletins whose `lastHeardAt` is older than [retention].
   Future<void> pruneOlderThan(Duration retention) async {
     final cutoff = _clock().subtract(retention);
     final before = _bulletins.length;
     _bulletins.removeWhere((_, b) => b.lastHeardAt.isBefore(cutoff));
+    await _bulletinDao.pruneIncomingOlderThan(cutoff);
     if (_bulletins.length == before) return;
-    await _persist();
     notifyListeners();
   }
+
+  // ---------------------------------------------------------------------------
+  // Fresh re-read (absorbs background-isolate outgoing writes via shared DB)
+  // ---------------------------------------------------------------------------
+
+  /// Rebuild the outgoing cache from the shared database. Called at the start
+  /// of every [BulletinScheduler] tick so background-isolate transmission
+  /// updates surface in the main isolate without the operator triggering
+  /// anything (ADR-057/061). Also safe to call from a resume handler.
+  Future<void> refreshOutgoing() async {
+    final rows = await _bulletinDao.getAllOutgoing();
+    _outgoing
+      ..clear()
+      ..addEntries(rows.map((r) => MapEntry(r.id, _rowToOutgoing(r))));
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Row <-> model conversion
+  // ---------------------------------------------------------------------------
+
+  Bulletin _rowToBulletin(BulletinRow row, int id) => Bulletin(
+    id: id,
+    sourceCallsign: row.sourceCallsign,
+    addressee: row.addressee,
+    category: row.category,
+    lineNumber: row.lineNumber,
+    groupName: row.groupName,
+    body: row.body,
+    firstHeardAt: DateTime.fromMillisecondsSinceEpoch(row.firstHeardAt),
+    lastHeardAt: DateTime.fromMillisecondsSinceEpoch(row.lastHeardAt),
+    heardCount: row.heardCount,
+    transports: row.transports,
+    receivedLat: row.receivedLat,
+    receivedLon: row.receivedLon,
+    isRead: row.isRead,
+  );
+
+  BulletinsCompanion _bulletinToCompanion(Bulletin b) =>
+      BulletinsCompanion.insert(
+        sourceCallsign: b.sourceCallsign,
+        addressee: b.addressee,
+        body: b.body,
+        firstHeardAt: b.firstHeardAt.millisecondsSinceEpoch,
+        lastHeardAt: b.lastHeardAt.millisecondsSinceEpoch,
+        category: b.category,
+        lineNumber: b.lineNumber,
+        groupName: Value(b.groupName),
+        heardCount: Value(b.heardCount),
+        transports: Value(b.transports),
+        receivedLat: Value(b.receivedLat),
+        receivedLon: Value(b.receivedLon),
+        isRead: Value(b.isRead),
+      );
+
+  OutgoingBulletin _rowToOutgoing(OutgoingBulletinRow row) => OutgoingBulletin(
+    id: row.id,
+    addressee: row.addressee,
+    body: row.body,
+    intervalSeconds: row.intervalSeconds,
+    expiresAt: row.expiresAt != null
+        ? DateTime.fromMillisecondsSinceEpoch(row.expiresAt!)
+        : DateTime.fromMillisecondsSinceEpoch(
+            row.createdAt,
+          ).add(const Duration(hours: 24)),
+    createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+    lastTransmittedAt: row.lastTransmittedAt != null
+        ? DateTime.fromMillisecondsSinceEpoch(row.lastTransmittedAt!)
+        : null,
+    transmissionCount: row.transmissionCount,
+    viaRf: row.viaRf,
+    viaAprsIs: row.viaAprsIs,
+    enabled: row.enabled,
+  );
 
   String _key(String source, String addressee) =>
       '${source.toUpperCase()}|${addressee.toUpperCase()}';
 
-  /// Great-circle distance in kilometres between two lat/lon pairs. Flat-
-  /// earth approximation would have been enough at hundreds-of-km radii, but
-  /// haversine is <10 lines and avoids latitude-dependent error near the
-  /// poles or for very large radii.
   static double _haversineKm(
     double lat1,
     double lon1,
@@ -511,18 +580,4 @@ class BulletinService extends ChangeNotifier {
 
   Future<SharedPreferences> _prefs() async =>
       _prefsOverride ?? await SharedPreferences.getInstance();
-
-  Future<void> _persist() async {
-    final prefs = await _prefs();
-    await prefs.setString(
-      _keyBulletins,
-      jsonEncode(_bulletins.values.map((b) => b.toJson()).toList()),
-    );
-    await prefs.setInt(_keyNextId, _nextId);
-    await prefs.setString(
-      keyOutgoingBulletins,
-      jsonEncode(_outgoing.values.map((ob) => ob.toJson()).toList()),
-    );
-    await prefs.setInt(_keyOutgoingNextId, _outgoingNextId);
-  }
 }

--- a/lib/services/bulletin_service.dart
+++ b/lib/services/bulletin_service.dart
@@ -244,9 +244,18 @@ class BulletinService extends ChangeNotifier {
     }
 
     _bulletins[key] = stored;
-    _bulletinDao.upsertIncoming(
-      _bulletinToCompanion(stored),
-    ); // ignore: unawaited_futures
+    // Fire-and-forget so ingest stays synchronous for its callers. drift runs
+    // operations on its connection in submission order (FIFO), so sequential
+    // upserts for the same key can't reorder; we only need to keep a write
+    // failure from surfacing as an unhandled async error.
+    unawaited(
+      _bulletinDao
+          .upsertIncoming(_bulletinToCompanion(stored))
+          .catchError(
+            (Object e) =>
+                debugPrint('BulletinService: upsertIncoming failed: $e'),
+          ),
+    );
     notifyListeners();
     return outcome;
   }

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -1,8 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -13,9 +12,9 @@ import '../core/credentials/credential_key.dart';
 import '../core/credentials/secure_credential_store.dart';
 import '../core/packet/aprs_encoder.dart';
 import '../core/util/clock.dart';
-import '../models/outgoing_bulletin.dart';
+import '../database/database_provider.dart';
+import '../database/meridian_database.dart';
 import 'beaconing_service.dart' show BeaconMode;
-import 'bulletin_service.dart';
 import 'messaging_settings_service.dart';
 
 /// Entry point called by flutter_foreground_task when the foreground service
@@ -54,6 +53,13 @@ class MeridianConnectionTask extends TaskHandler {
   Timer? _beaconTimer;
   Timer? _bulletinTimer;
   int? _lastBeaconTs; // ms since epoch; null until first beacon this session
+
+  /// Client connection to the shared `meridian.db`, obtained from the main
+  /// isolate's `DriftIsolate` via `IsolateNameServer` (ADR-062). Lazily
+  /// established on first bulletin tick; null while the main isolate hasn't
+  /// registered its port yet (e.g. a startup race), in which case the tick is
+  /// skipped and retried next time.
+  MeridianDatabase? _bgDb;
 
   /// Master kill-switch for beaconing in this isolate. `true` between
   /// `start_beaconing` and `stop_beaconing` IPCs from the main isolate;
@@ -158,6 +164,23 @@ class MeridianConnectionTask extends TaskHandler {
     _bulletinTimer?.cancel();
     await _positionSub?.cancel();
     _positionSub = null;
+    await _bgDb?.close();
+    _bgDb = null;
+  }
+
+  /// Lazily connect to the shared drift database. Cached for the isolate's
+  /// lifetime. Returns null (and leaves the cache empty so the next tick
+  /// retries) when the main isolate's port isn't registered yet or the
+  /// connection throws.
+  Future<MeridianDatabase?> _ensureBgDatabase() async {
+    if (_bgDb != null) return _bgDb;
+    try {
+      _bgDb = await lookupBackgroundDatabasePort();
+    } catch (e) {
+      debugPrint('BG bulletin: drift connect failed: $e');
+      _bgDb = null;
+    }
+    return _bgDb;
   }
 
   // ---------------------------------------------------------------------------
@@ -545,19 +568,19 @@ class MeridianConnectionTask extends TaskHandler {
   }
 
   Future<void> _processOutgoingBulletins() async {
+    // Connect to the shared drift database. If the main isolate hasn't
+    // registered its port yet (startup race), skip this tick and retry.
+    final db = await _ensureBgDatabase();
+    if (db == null) return;
+
     final prefs = await SharedPreferences.getInstance();
     await prefs.reload();
 
-    final raw = prefs.getString(BulletinService.keyOutgoingBulletins);
-    if (raw == null || raw.isEmpty) return;
-
-    final List<OutgoingBulletin> outgoing;
+    final List<OutgoingBulletinRow> outgoing;
     try {
-      outgoing = (jsonDecode(raw) as List<dynamic>)
-          .cast<Map<String, dynamic>>()
-          .map(OutgoingBulletin.fromJson)
-          .toList();
-    } catch (_) {
+      outgoing = await db.bulletinDao.getAllOutgoing();
+    } catch (e) {
+      debugPrint('BG bulletin: read failed: $e');
       return;
     }
     if (outgoing.isEmpty) return;
@@ -588,24 +611,25 @@ class MeridianConnectionTask extends TaskHandler {
       return passcode!;
     }
 
-    var mutated = false;
     final now = _clock();
-    for (var i = 0; i < outgoing.length; i++) {
-      final ob = outgoing[i];
+    for (final ob in outgoing) {
       if (!ob.enabled) continue;
 
-      // Expiry → disable.
-      if (now.isAfter(ob.expiresAt)) {
-        outgoing[i] = ob.copyWith(enabled: false);
-        mutated = true;
+      // Expiry → disable (written straight through to the shared DB so the
+      // main isolate's BulletinService watch picks it up — ADR-057/061).
+      final expiresAt = ob.expiresAt;
+      if (expiresAt != null && now.millisecondsSinceEpoch > expiresAt) {
+        await db.bulletinDao.setOutgoingEnabled(ob.id, false);
         continue;
       }
 
-      if (ob.isOneShot && ob.transmissionCount > 0) continue;
+      final isOneShot = ob.intervalSeconds == 0;
+      if (isOneShot && ob.transmissionCount > 0) continue;
 
+      final lastTx = ob.lastTransmittedAt;
       final shouldTx =
-          ob.lastTransmittedAt == null ||
-          now.difference(ob.lastTransmittedAt!) >=
+          lastTx == null ||
+          now.difference(DateTime.fromMillisecondsSinceEpoch(lastTx)) >=
               Duration(seconds: ob.intervalSeconds);
       if (!shouldTx) continue;
 
@@ -642,11 +666,9 @@ class MeridianConnectionTask extends TaskHandler {
       }
 
       if (transmitted) {
-        outgoing[i] = ob.copyWith(
-          lastTransmittedAt: now,
-          transmissionCount: ob.transmissionCount + 1,
-        );
-        mutated = true;
+        // Write-through to the shared DB. The main-isolate BulletinService
+        // watch reflects the bump on resume without an explicit re-read.
+        await db.bulletinDao.recordOutgoingTransmission(ob.id, now);
 
         // Notify main isolate so the line is self-ingested into StationService —
         // mirrors the beacon_sent loopback so background-fired bulletins appear
@@ -656,13 +678,6 @@ class MeridianConnectionTask extends TaskHandler {
           'aprs_line': line,
         });
       }
-    }
-
-    if (mutated) {
-      await prefs.setString(
-        BulletinService.keyOutgoingBulletins,
-        jsonEncode(outgoing.map((ob) => ob.toJson()).toList()),
-      );
     }
   }
 }

--- a/lib/services/meridian_connection_task.dart
+++ b/lib/services/meridian_connection_task.dart
@@ -580,7 +580,10 @@ class MeridianConnectionTask extends TaskHandler {
     try {
       outgoing = await db.bulletinDao.getAllOutgoing();
     } catch (e) {
-      debugPrint('BG bulletin: read failed: $e');
+      // The cached client connection is likely stale (main isolate recycled
+      // its DriftIsolate). Drop it so _ensureBgDatabase() re-opens next tick.
+      debugPrint('BG bulletin: read failed, resetting DB handle: $e');
+      _bgDb = null;
       return;
     }
     if (outgoing.isEmpty) return;

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -26,14 +26,18 @@ import '../database/meridian_database.dart'
     show ConversationsCompanion, MessageEntriesCompanion, MessageEntryRow;
 import '../models/group_subscription.dart';
 import '../models/message_category.dart';
+import '../models/message_status.dart';
 import 'bulletin_service.dart';
 import 'group_subscription_service.dart';
 import 'station_service.dart';
 import 'station_settings_service.dart';
 import 'tx_service.dart';
 
-/// Delivery state of an outgoing message.
-enum MessageStatus { pending, acked, retrying, failed, rejected, cancelled }
+// Re-exported so existing consumers that import this service keep seeing
+// `MessageStatus`; the enum itself now lives in the model layer
+// (`models/message_status.dart`) so the persistence layer can reference it
+// without depending on this service.
+export '../models/message_status.dart';
 
 /// A single message in a conversation thread.
 class MessageEntry {

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -10,8 +10,8 @@
 library;
 
 import 'dart:async';
-import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -21,6 +21,9 @@ import '../core/callsign/message_classification.dart';
 import '../core/packet/aprs_encoder.dart';
 import '../core/packet/aprs_packet.dart';
 import '../core/util/clock.dart';
+import '../database/daos/message_dao.dart';
+import '../database/meridian_database.dart'
+    show ConversationsCompanion, MessageEntriesCompanion, MessageEntryRow;
 import '../models/group_subscription.dart';
 import '../models/message_category.dart';
 import 'bulletin_service.dart';
@@ -106,6 +109,15 @@ class Conversation {
   MessageEntry? get lastMessage => messages.isEmpty ? null : messages.last;
 }
 
+/// Persistence note (ADR-062): unlike [StationService], MessageService keeps
+/// [_conversations] as the authoritative in-memory working set and treats
+/// drift as a *write-through persistence layer* via targeted [MessageDao]
+/// calls. It deliberately does NOT subscribe to drift `watch()` streams —
+/// the retry scheduler holds direct references to [MessageEntry] objects and
+/// mutates them in place, so rebuilding entries from a watch emission would
+/// orphan those references and break ACK→timer cancellation. Messages are
+/// main-isolate-only writes, so the cross-isolate watch benefit does not
+/// apply here. Do not "add watch for consistency with StationService."
 class MessageService extends ChangeNotifier {
   MessageService(
     this._settings,
@@ -113,10 +125,12 @@ class MessageService extends ChangeNotifier {
     StationService stations, {
     required GroupSubscriptionService groupSubscriptions,
     required BulletinService bulletins,
+    required MessageDao messageDao,
     Clock clock = DateTime.now,
   }) : _stations = stations,
        _groupSubscriptions = groupSubscriptions,
        _bulletins = bulletins,
+       _messageDao = messageDao,
        _clock = clock {
     _incomingSub = stations.packetStream.listen(_onPacket);
   }
@@ -128,9 +142,9 @@ class MessageService extends ChangeNotifier {
   final StationService _stations;
   final GroupSubscriptionService _groupSubscriptions;
   final BulletinService _bulletins;
+  final MessageDao _messageDao;
 
   static const _keyCounter = 'message_id_counter';
-  static const _keyPeers = 'msg_peers';
   static const _keyMessageDays = 'history_message_days';
   static const _keyShowOtherSsids = 'msg_show_other_ssids';
   static const _retryDelays = [30, 60, 120, 240, 480]; // seconds (APRS spec)
@@ -140,8 +154,6 @@ class MessageService extends ChangeNotifier {
 
   int _messageHistoryDays = 90;
   bool _showOtherSsids = false;
-
-  static String _convKey(String peer) => 'msg_conv_$peer';
 
   // Active conversations keyed by peer callsign (uppercase, no padding).
   final _conversations = <String, Conversation>{};
@@ -252,9 +264,8 @@ class MessageService extends ChangeNotifier {
     _messageHistoryDays = days;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_keyMessageDays, days);
-    _pruneByAge(days);
+    await _pruneByAge(days);
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
   }
 
   Future<void> setShowOtherSsids(bool v) async {
@@ -265,7 +276,7 @@ class MessageService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Restore persisted conversations from [SharedPreferences].
+  /// Restore persisted conversations from the drift database (ADR-062).
   ///
   /// Call once after construction (before [runApp]). Messages that were
   /// [MessageStatus.pending] or [MessageStatus.retrying] when the app was last
@@ -276,23 +287,27 @@ class MessageService extends ChangeNotifier {
     _messageHistoryDays = prefs.getInt(_keyMessageDays) ?? 90;
     _showOtherSsids = prefs.getBool(_keyShowOtherSsids) ?? false;
 
-    final peersRaw = prefs.getString(_keyPeers);
-    if (peersRaw == null) return;
+    // Demote in-flight messages FIRST so the rows we read back are already
+    // consistent (no transient pending/retrying state in the in-memory map).
+    await _messageDao.demoteInFlightToFailed();
 
-    final peers = (jsonDecode(peersRaw) as List<dynamic>).cast<String>();
-    for (final peer in peers) {
-      final convRaw = prefs.getString(_convKey(peer));
-      if (convRaw == null) continue;
-      try {
-        final conv = _convFromJson(jsonDecode(convRaw) as Map<String, dynamic>);
-        _conversations[peer] = conv;
-      } catch (e) {
-        debugPrint('MessageService: failed to load conversation $peer: $e');
+    final convRows = await _messageDao.getAllConversations();
+    for (final row in convRows) {
+      final conv = Conversation(peerCallsign: row.peerCallsign)
+        ..unreadCount = row.unreadCount
+        ..lastActivity = DateTime.fromMillisecondsSinceEpoch(row.lastMessageAt);
+      _conversations[row.peerCallsign] = conv;
+    }
+
+    for (final conv in _conversations.values) {
+      final entryRows = await _messageDao.getEntriesForPeer(conv.peerCallsign);
+      for (final er in entryRows) {
+        conv.messages.add(_rowToEntry(er));
       }
     }
 
     // Drop messages that exceed the configured age limit.
-    _pruneByAge(_messageHistoryDays);
+    await _pruneByAge(_messageHistoryDays);
     notifyListeners();
   }
 
@@ -340,7 +355,7 @@ class MessageService extends ChangeNotifier {
     conv.messages.add(entry);
     conv.lastActivity = entry.timestamp;
     notifyListeners();
-    await _persist();
+    await _persistNewEntry(conv, entry);
   }
 
   /// Send a message to [toCallsign].
@@ -366,7 +381,7 @@ class MessageService extends ChangeNotifier {
     await _transmitMessage(peer, text, wireId);
     _scheduleRetry(entry, peer, attempt: 0);
     notifyListeners();
-    await _persist();
+    await _persistNewEntry(conv, entry);
   }
 
   /// Cancel a pending or retrying outgoing message.
@@ -385,11 +400,11 @@ class MessageService extends ChangeNotifier {
           (entry.status == MessageStatus.pending ||
               entry.status == MessageStatus.retrying)) {
         entry.status = MessageStatus.cancelled;
+        _persistStatus(entry); // ignore: unawaited_futures
         break;
       }
     }
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
   }
 
   /// Re-send a message that has reached [MessageStatus.failed].
@@ -405,11 +420,11 @@ class MessageService extends ChangeNotifier {
         entry.status = MessageStatus.pending;
         entry.retryCount = 0;
         notifyListeners();
+        await _persistStatus(entry);
         if (entry.wireId != null) {
           await _transmitMessage(peer, entry.text, entry.wireId!);
         }
         _scheduleRetry(entry, peer, attempt: 0);
-        await _persist();
         break;
       }
     }
@@ -417,12 +432,13 @@ class MessageService extends ChangeNotifier {
 
   /// Mark all messages in [peerCallsign]'s thread as read.
   void markRead(String peerCallsign) {
-    final conv = _conversations[peerCallsign.toUpperCase()];
+    final peer = peerCallsign.toUpperCase();
+    final conv = _conversations[peer];
     if (conv == null) return;
     if (conv.unreadCount == 0) return;
     conv.unreadCount = 0;
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
+    _messageDao.markRead(peer); // ignore: unawaited_futures
   }
 
   @override
@@ -547,7 +563,7 @@ class MessageService extends ChangeNotifier {
     }
 
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
+    _persistNewEntry(conv, entry); // ignore: unawaited_futures
   }
 
   void _handleGroup({
@@ -589,7 +605,7 @@ class MessageService extends ChangeNotifier {
     conv.unreadCount++;
 
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
+    _persistNewEntry(conv, entry); // ignore: unawaited_futures
   }
 
   /// Conversation-key prefix for group threads. Keeps group conversations in
@@ -620,6 +636,7 @@ class MessageService extends ChangeNotifier {
         _retryTimers[entry.localId]?.cancel();
         _retryTimers.remove(entry.localId);
         entry.status = MessageStatus.acked;
+        _persistStatus(entry); // ignore: unawaited_futures
         matched = true;
         break;
       }
@@ -631,7 +648,6 @@ class MessageService extends ChangeNotifier {
       );
     }
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
   }
 
   void _handleRej(String peer, String rejId) {
@@ -643,11 +659,11 @@ class MessageService extends ChangeNotifier {
         _retryTimers[entry.localId]?.cancel();
         _retryTimers.remove(entry.localId);
         entry.status = MessageStatus.rejected;
+        _persistStatus(entry); // ignore: unawaited_futures
         break;
       }
     }
     notifyListeners();
-    _persist(); // ignore: unawaited_futures
   }
 
   // ---------------------------------------------------------------------------
@@ -657,8 +673,8 @@ class MessageService extends ChangeNotifier {
   void _scheduleRetry(MessageEntry entry, String peer, {required int attempt}) {
     if (attempt >= _retryDelays.length) {
       entry.status = MessageStatus.failed;
+      _persistStatus(entry); // ignore: unawaited_futures
       notifyListeners();
-      _persist(); // ignore: unawaited_futures
       return;
     }
 
@@ -673,6 +689,7 @@ class MessageService extends ChangeNotifier {
 
       entry.status = MessageStatus.retrying;
       entry.retryCount = attempt + 1;
+      _persistStatus(entry); // ignore: unawaited_futures
       notifyListeners();
 
       if (entry.wireId != null) {
@@ -723,114 +740,78 @@ class MessageService extends ChangeNotifier {
   }
 
   // ---------------------------------------------------------------------------
-  // Internal — persistence
+  // Internal — drift persistence (write-through; see class-level note)
   // ---------------------------------------------------------------------------
 
-  /// Persist all conversations to [SharedPreferences]. Fire-and-forget; callers
-  /// do not need to await this.
-  Future<void> _persist() async {
-    final prefs = await SharedPreferences.getInstance();
-    final peers = _conversations.keys.toList();
-    await prefs.setString(_keyPeers, jsonEncode(peers));
-    for (final entry in _conversations.entries) {
-      await prefs.setString(
-        _convKey(entry.key),
-        jsonEncode(_convToJson(entry.value)),
+  /// Persist a newly-added entry plus its (possibly new) conversation row.
+  /// The conversation is upserted first to satisfy the `conversation_peer`
+  /// foreign key.
+  Future<void> _persistNewEntry(Conversation conv, MessageEntry entry) async {
+    await _messageDao.upsertConversation(_convToCompanion(conv));
+    await _messageDao.insertEntry(_entryToCompanion(entry, conv.peerCallsign));
+  }
+
+  /// Persist a status/retry transition for an existing entry.
+  Future<void> _persistStatus(MessageEntry entry) =>
+      _messageDao.updateEntryStatus(
+        localId: entry.localId,
+        status: entry.status,
+        retryCount: entry.retryCount,
       );
-    }
-  }
 
-  Map<String, dynamic> _convToJson(Conversation c) {
-    // Omit messages older than the configured age limit before serialising.
-    final msgs = _messageHistoryDays == forever
-        ? c.messages
-        : c.messages
-              .where((e) => _withinAge(e.timestamp, _messageHistoryDays))
-              .toList();
-    return {
-      'peer': c.peerCallsign,
-      'unreadCount': c.unreadCount,
-      'lastActivity': c.lastActivity.millisecondsSinceEpoch,
-      'messages': msgs.map(_entryToJson).toList(),
-    };
-  }
+  ConversationsCompanion _convToCompanion(Conversation c) =>
+      ConversationsCompanion.insert(
+        peerCallsign: c.peerCallsign,
+        lastMessageAt: c.lastActivity.millisecondsSinceEpoch,
+        unreadCount: Value(c.unreadCount),
+      );
 
-  Conversation _convFromJson(Map<String, dynamic> json) {
-    final conv = Conversation(peerCallsign: json['peer'] as String);
-    conv.unreadCount = (json['unreadCount'] as int?) ?? 0;
-    conv.lastActivity = DateTime.fromMillisecondsSinceEpoch(
-      json['lastActivity'] as int,
-    );
-    final msgs = (json['messages'] as List<dynamic>?) ?? [];
-    for (final m in msgs) {
-      conv.messages.add(_entryFromJson(m as Map<String, dynamic>));
-    }
-    return conv;
-  }
+  MessageEntriesCompanion _entryToCompanion(MessageEntry e, String peer) =>
+      MessageEntriesCompanion.insert(
+        id: e.localId,
+        conversationPeer: peer,
+        body: e.text,
+        timestamp: e.timestamp.millisecondsSinceEpoch,
+        isOutgoing: e.isOutgoing,
+        status: e.status,
+        category: e.category,
+        fromCallsign: Value(e.fromCallsign),
+        addressee: Value(e.addressee),
+        wireId: Value(e.wireId),
+        retryCount: Value(e.retryCount),
+        groupName: Value(e.groupName),
+      );
 
-  Map<String, dynamic> _entryToJson(MessageEntry e) => {
-    'localId': e.localId,
-    'wireId': e.wireId,
-    'text': e.text,
-    'timestamp': e.timestamp.millisecondsSinceEpoch,
-    'isOutgoing': e.isOutgoing,
-    'addressee': e.addressee,
-    'fromCallsign': e.fromCallsign,
-    'category': e.category.name,
-    'groupName': e.groupName,
-    'status': e.status.name,
-    'retryCount': e.retryCount,
-  };
+  MessageEntry _rowToEntry(MessageEntryRow row) => MessageEntry(
+    localId: row.id,
+    wireId: row.wireId,
+    text: row.body,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(row.timestamp),
+    isOutgoing: row.isOutgoing,
+    addressee: row.addressee,
+    fromCallsign: row.fromCallsign,
+    category: row.category,
+    groupName: row.groupName,
+    status: row.status,
+    retryCount: row.retryCount,
+  );
 
-  /// Remove messages older than [days] from all conversations, then drop
-  /// conversations that become empty as a result.
-  void _pruneByAge(int days) {
+  /// Remove messages older than [days] from the in-memory map and the drift
+  /// tables, then drop conversations that become empty as a result.
+  Future<void> _pruneByAge(int days) async {
     if (days == forever) return;
     _conversations.removeWhere((_, conv) {
       conv.messages.removeWhere((e) => !_withinAge(e.timestamp, days));
       return conv.messages.isEmpty;
     });
+    await _messageDao.pruneOlderThan(_clock().subtract(Duration(days: days)));
+    await _messageDao.pruneEmptyConversations();
   }
 
   /// Returns true if [dt] is within [days] days of now.
   bool _withinAge(DateTime dt, int days) {
     if (days == forever) return true;
     return _clock().difference(dt).inDays < days;
-  }
-
-  MessageEntry _entryFromJson(Map<String, dynamic> json) {
-    final statusName = (json['status'] as String?) ?? 'failed';
-    var status = MessageStatus.values.firstWhere(
-      (s) => s.name == statusName,
-      orElse: () => MessageStatus.failed,
-    );
-    // Timers can't be resumed after a restart — treat as failed so the user
-    // can explicitly resend if needed.
-    if (status == MessageStatus.pending || status == MessageStatus.retrying) {
-      status = MessageStatus.failed;
-    }
-    // Legacy-safe: entries saved before v0.17 lack `category`/`groupName`.
-    // They are all direct messages (cross-SSID handled via `addressee`).
-    final categoryName = json['category'] as String?;
-    final category = categoryName == null
-        ? MessageCategory.direct
-        : MessageCategory.values.firstWhere(
-            (c) => c.name == categoryName,
-            orElse: () => MessageCategory.direct,
-          );
-    return MessageEntry(
-      localId: json['localId'] as String,
-      wireId: json['wireId'] as String?,
-      text: json['text'] as String,
-      timestamp: DateTime.fromMillisecondsSinceEpoch(json['timestamp'] as int),
-      isOutgoing: (json['isOutgoing'] as bool?) ?? false,
-      addressee: json['addressee'] as String?,
-      fromCallsign: json['fromCallsign'] as String?,
-      category: category,
-      groupName: json['groupName'] as String?,
-      status: status,
-      retryCount: (json['retryCount'] as int?) ?? 0,
-    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:convert';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint;
 import 'package:latlong2/latlong.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -10,134 +10,148 @@ import '../core/packet/aprs_packet.dart';
 import '../core/packet/aprs_parser.dart';
 import '../core/packet/station.dart';
 import '../core/util/clock.dart';
+import '../database/daos/packet_dao.dart';
+import '../database/daos/station_dao.dart';
+import '../database/meridian_database.dart';
+import '../database/tables/packets.dart' show PacketTypeTag;
 
 /// Service that ingests APRS text lines, decodes them with [AprsParser], and
-/// exposes two streams:
+/// persists stations + packets to the drift database (ADR-062).
 ///
-///   - [packetStream] — every decoded [AprsPacket] (all types)
-///   - [stationUpdates] — a snapshot of the station map, updated each time a
-///     position packet is received
+/// Reads are served from in-memory caches kept in sync with the database via
+/// drift `watch()` subscriptions plus immediate write-through updates from
+/// main-isolate ingests. The synchronous [currentStations] and [recentPackets]
+/// getters are preserved for the existing UI layer.
 ///
-/// Lines are normally fed via [attach], which subscribes once to the
-/// multiplexed [ConnectionRegistry.lines] stream and routes each tagged line
-/// to the parser. Tests and one-off callers can also push lines synchronously
-/// via [ingestLine]. This service has no transport dependency; connection
-/// lifecycle is managed by the connection classes and [ConnectionRegistry].
-///
-/// [recentPackets] holds a rolling buffer of recent packets. The in-session
-/// buffer is capped at [_kMaxInMemoryPackets] for performance; time-based
-/// pruning ([packetHistoryDays] / [stationHistoryDays]) is applied at load
-/// and persist boundaries.
-///
-/// History is persisted across app restarts. Call [loadPersistedHistory] once
-/// after construction (before ingesting any lines) to restore the previous
-/// session.
+/// Settings (retention windows, display toggles, weather overlay) continue to
+/// live in `SharedPreferences` — only structured packet/station data has moved
+/// to SQLite. Call [loadPersistedSettings] once after construction (before
+/// [attach]) to restore those preferences.
 class StationService extends ChangeNotifier {
-  // Hard in-session cap — not user-configurable. Keeps RAM bounded during
-  // long APRS-IS sessions on busy frequencies. Time-based pruning reduces
-  // this further at the persistence boundary.
+  // Hard in-session cap on the cached packet snapshot. Keeps RAM bounded and
+  // matches the previous in-memory rolling-buffer behaviour. Time-based
+  // pruning of the underlying `packets` table is governed by
+  // [packetHistoryDays] via the 60-second prune timer.
   static const int _kMaxInMemoryPackets = 5000;
 
-  // SharedPreferences keys.
+  /// Maximum number of position-history entries kept per station. Enforced
+  /// inside the upsert transaction.
+  static const int _kMaxPositionHistory = 500;
+
+  /// Sentinel meaning "keep forever" (no age-based pruning).
+  static const int forever = 0;
+
+  // SharedPreferences keys — settings only. Structured data lives in drift.
   static const _keyPacketDays = 'history_packet_days';
   static const _keyStationDays = 'history_station_days';
-  static const _keyPacketLog = 'packet_log_v1';
-  static const _keyStationHistory = 'station_history_v1';
   static const _keyStationMaxAgeMinutes = 'station_max_age_minutes';
   static const _keyHiddenTypes = 'station_hidden_types';
   static const _keyShowWeatherOverlay = 'show_weather_overlay';
   static const _keyShowTracks = 'show_tracks';
   static const _keyUseImperialUnits = 'use_imperial_units';
-
-  // Weather overlay sub-settings
   static const _keyWeatherRadiusKm = 'weather_overlay_radius_km';
   static const _keyWeatherUseCelsius = 'weather_overlay_use_celsius';
   static const _keyWeatherMaxAgeMinutes = 'weather_overlay_max_age_minutes';
 
-  /// Maximum number of position history entries kept per station.
-  static const int _kMaxPositionHistory = 500;
+  StationService({
+    required StationDao stationDao,
+    required PacketDao packetDao,
+    Clock clock = DateTime.now,
+  }) : _stationDao = stationDao,
+       _packetDao = packetDao,
+       _clock = clock {
+    _stationsSub = _stationDao.watchAllStations().listen(
+      _onStationsRowsChanged,
+    );
+    _packetsSub = _packetDao
+        .watchRecent(limit: _kMaxInMemoryPackets)
+        .listen(_onPacketsRowsChanged);
+    // Prune timer is started in [attach] — unit and widget tests that build
+    // the service without wiring a registry don't need a 60 s timer hanging
+    // around the framework's pending-timer check.
+  }
 
-  /// Sentinel value meaning "keep forever" (no age-based pruning).
-  static const int forever = 0;
-
+  final StationDao _stationDao;
+  final PacketDao _packetDao;
+  final Clock _clock;
   final _parser = AprsParser();
 
-  // Station map — callsign → most-recently-heard Station.
-  final _stations = <String, Station>{};
+  // Snapshot caches served by sync getters.
+  Map<String, Station> _stationCache = {};
+  List<AprsPacket> _packetCache = [];
 
-  // Broadcast controllers.
-  final _stationController = StreamController<Map<String, Station>>.broadcast();
+  // Broadcast streams (separate from drift `watch()` so packetStream fires
+  // synchronously on parse — required by `MessageService._onPacket` and the
+  // existing UI listeners).
   final _packetController = StreamController<AprsPacket>.broadcast();
+  final _stationController = StreamController<Map<String, Station>>.broadcast();
 
-  // Rolling packet buffer (newest at index 0).
-  final _recentPackets = <AprsPacket>[];
+  // Active drift watch subscriptions.
+  StreamSubscription<List<StationRow>>? _stationsSub;
+  StreamSubscription<List<PacketRow>>? _packetsSub;
 
-  // History age limits (days; 0 = forever).
+  // Single in-flight ingest serialises the "read prev → merge → write" chain
+  // so two close-spaced position packets for the same callsign cannot race on
+  // their merged position-history.
+  Future<void> _ingestChain = Future.value();
+
+  // Periodic retention prune; falls back to a no-op while `_prefs` is null.
+  Timer? _pruneTimer;
+
+  // Active subscription to ConnectionRegistry.lines, set by [attach].
+  StreamSubscription<({String line, ConnectionType source})>? _registrySub;
+
+  SharedPreferences? _prefs;
+
+  // History age limits (days; [forever] = no limit).
   int _packetHistoryDays = 30;
   int _stationHistoryDays = 90;
 
-  // Map display filter: max age in minutes; null = no limit. Default: 60 min.
-  // This is a VIEW filter only — it does not delete station data. The station
-  // map is filtered in the UI layer (map_screen.dart) before building markers.
+  // Map display filter — view filter only, no data deletion.
   int? _stationMaxAgeMinutes = 60;
 
-  // Station type display filter — types in this set are hidden on the map.
-  // View filter only; no data is deleted.
+  // Display toggles — view filters only.
   Set<StationType> _hiddenTypes = {};
-
-  // Whether to render movement trail polylines on the map.
   bool _showTracks = true;
-
-  // Whether to display distances in imperial units (miles/feet) instead of
-  // metric (km/m).
   bool _useImperialUnits = false;
-
-  // Whether to show the weather overlay chip on the map.
   bool _showWeatherOverlay = false;
-
   int _weatherOverlayRadiusKm = 50;
   bool _weatherOverlayUseCelsius = false;
   int _weatherOverlayMaxAgeMinutes = 60;
 
-  // Persistence state.
-  SharedPreferences? _prefs;
-  Timer? _persistTimer;
-
-  // Active subscription to ConnectionRegistry.lines, set by [attach] and
-  // cancelled by [stop]. Null until [attach] is called.
-  StreamSubscription<({String line, ConnectionType source})>? _registrySub;
-
-  StationService({Clock clock = DateTime.now}) : _clock = clock;
-
-  final Clock _clock;
-
   // ---------------------------------------------------------------------------
-  // Backward-compat stubs (removed in Phase 6 when UI is updated)
+  // Backward-compat stubs (kept until v0.20 UI cleanup)
   // ---------------------------------------------------------------------------
 
   /// Always returns [ConnectionStatus.disconnected].
-  ///
-  /// APRS-IS connection status is now available via [ConnectionRegistry].
-  /// This getter is retained for UI compatibility until Phase 6.
+  /// APRS-IS connection state lives on [ConnectionRegistry] now.
   ConnectionStatus get currentConnectionStatus => ConnectionStatus.disconnected;
 
-  /// A stream that never emits.
-  ///
-  /// APRS-IS connection state is now available via [ConnectionRegistry].
-  /// This getter is retained for UI compatibility until Phase 6.
+  /// Always-empty stream — kept for UI compatibility.
   Stream<ConnectionStatus> get connectionState => const Stream.empty();
 
   /// No-op. Line ingestion is wired in main.dart via [ConnectionRegistry].
   Future<void> start() async {}
 
-  /// Closes stream controllers, cancels timers, and detaches from any
-  /// [ConnectionRegistry] previously wired via [attach].
+  /// Cancels watch subscriptions, prune timer, registry subscription, and
+  /// closes the broadcast controllers. Idempotent.
   Future<void> stop() async {
-    _persistTimer?.cancel();
+    _pruneTimer?.cancel();
+    _pruneTimer = null;
     await _registrySub?.cancel();
     _registrySub = null;
-    await _stationController.close();
-    await _packetController.close();
+    await _stationsSub?.cancel();
+    _stationsSub = null;
+    await _packetsSub?.cancel();
+    _packetsSub = null;
+    if (!_stationController.isClosed) await _stationController.close();
+    if (!_packetController.isClosed) await _packetController.close();
+  }
+
+  @override
+  void dispose() {
+    unawaited(stop());
+    super.dispose();
   }
 
   /// No-op. Use [ConnectionRegistry] to access [AprsIsConnection].
@@ -156,37 +170,38 @@ class StationService extends ChangeNotifier {
   void updateFilter(double lat, double lon, {int radiusKm = 150}) {}
 
   // ---------------------------------------------------------------------------
-  // Public API
+  // Public API — reads
   // ---------------------------------------------------------------------------
 
-  /// All decoded packets as they arrive.
+  /// All decoded packets as they arrive (sync emission on parse).
   Stream<AprsPacket> get packetStream => _packetController.stream;
 
-  /// Station map snapshots. Emitted whenever a position packet updates a
-  /// station.
+  /// Station map snapshots. Fires whenever a position-like packet updates a
+  /// station, or whenever the drift watch stream reports a change (e.g.
+  /// background-isolate write).
   Stream<Map<String, Station>> get stationUpdates => _stationController.stream;
 
-  /// Current station map (unmodifiable).
-  Map<String, Station> get currentStations => Map.unmodifiable(_stations);
+  /// Current station map (unmodifiable snapshot of the cache).
+  Map<String, Station> get currentStations => Map.unmodifiable(_stationCache);
 
   /// Rolling buffer of the most recently decoded packets, newest first.
-  List<AprsPacket> get recentPackets => List.unmodifiable(_recentPackets);
+  List<AprsPacket> get recentPackets => List.unmodifiable(_packetCache);
 
-  /// Max age of persisted packets in days. [forever] (0) means no age limit.
   int get packetHistoryDays => _packetHistoryDays;
-
-  /// Max age of persisted stations in days. [forever] (0) means no age limit.
   int get stationHistoryDays => _stationHistoryDays;
-
-  /// Max age for the map display filter in minutes. [null] means no limit.
-  ///
-  /// This is a view filter only — changing it never deletes station data.
-  /// The map screen filters [currentStations] by this value before building
-  /// markers and polylines. Station data is retained according to
-  /// [stationHistoryDays].
   int? get stationMaxAgeMinutes => _stationMaxAgeMinutes;
+  Set<StationType> get hiddenTypes => Set.unmodifiable(_hiddenTypes);
+  bool get showTracks => _showTracks;
+  bool get useImperialUnits => _useImperialUnits;
+  bool get showWeatherOverlay => _showWeatherOverlay;
+  int get weatherOverlayRadiusKm => _weatherOverlayRadiusKm;
+  bool get weatherOverlayUseCelsius => _weatherOverlayUseCelsius;
+  int get weatherOverlayMaxAgeMinutes => _weatherOverlayMaxAgeMinutes;
 
-  /// Update the map station age filter. Set to [null] to disable filtering.
+  // ---------------------------------------------------------------------------
+  // Public API — settings (mirror previous SharedPreferences semantics)
+  // ---------------------------------------------------------------------------
+
   Future<void> setStationMaxAgeMinutes(int? value) async {
     if (value == _stationMaxAgeMinutes) return;
     _stationMaxAgeMinutes = value;
@@ -198,13 +213,6 @@ class StationService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Station types currently hidden on the map (display filter, not deletion).
-  Set<StationType> get hiddenTypes => Set.unmodifiable(_hiddenTypes);
-
-  /// Whether to render track polylines on the map.
-  bool get showTracks => _showTracks;
-
-  /// Update the show-tracks toggle. Persists the selection.
   Future<void> setShowTracks(bool value) async {
     if (_showTracks == value) return;
     _showTracks = value;
@@ -212,11 +220,6 @@ class StationService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Whether distances are displayed in imperial units (mi/ft) rather than
-  /// metric (km/m).
-  bool get useImperialUnits => _useImperialUnits;
-
-  /// Toggle the distance unit preference. Persists the selection.
   Future<void> setUseImperialUnits(bool value) async {
     if (_useImperialUnits == value) return;
     _useImperialUnits = value;
@@ -224,14 +227,6 @@ class StationService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Whether to show the weather overlay chip on the map.
-  bool get showWeatherOverlay => _showWeatherOverlay;
-
-  int get weatherOverlayRadiusKm => _weatherOverlayRadiusKm;
-  bool get weatherOverlayUseCelsius => _weatherOverlayUseCelsius;
-  int get weatherOverlayMaxAgeMinutes => _weatherOverlayMaxAgeMinutes;
-
-  /// Update the weather overlay toggle. Persists the selection.
   Future<void> setShowWeatherOverlay(bool value) async {
     if (_showWeatherOverlay == value) return;
     _showWeatherOverlay = value;
@@ -260,7 +255,6 @@ class StationService extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Update which station types are hidden. Persists the selection.
   Future<void> setHiddenTypes(Set<StationType> types) async {
     _hiddenTypes = Set.of(types);
     await _prefs?.setStringList(
@@ -270,56 +264,55 @@ class StationService extends ChangeNotifier {
     notifyListeners();
   }
 
-  // ---------------------------------------------------------------------------
-  // Ingest
-  // ---------------------------------------------------------------------------
-
-  /// Subscribe to [registry]'s multiplexed [ConnectionRegistry.lines] stream
-  /// and route every tagged line into the parser. This is the single
-  /// production ingestion seam — [main.dart] calls it once at startup, after
-  /// [loadPersistedHistory].
-  ///
-  /// Calling [attach] more than once is a programming error; the second call
-  /// will throw in debug builds. Use [stop] to cancel the subscription.
-  void attach(ConnectionRegistry registry) {
-    assert(
-      _registrySub == null,
-      'StationService.attach called twice; a single subscription is expected.',
-    );
-    _registrySub = registry.lines.listen(
-      (event) =>
-          _handleLine(event.line, source: _packetSourceFor(event.source)),
-    );
+  /// Update the packet retention window. Immediately prunes the underlying
+  /// `packets` table when shortened.
+  Future<void> setPacketHistoryDays(int days) async {
+    if (_packetHistoryDays == days) return;
+    _packetHistoryDays = days;
+    await _prefs?.setInt(_keyPacketDays, days);
+    if (days != forever) {
+      await _packetDao.pruneOlderThan(_clock().subtract(Duration(days: days)));
+    }
+    notifyListeners();
   }
 
-  /// Ingest a pre-formatted APRS line from a connection.
-  ///
-  /// [source] identifies whether the line came from APRS-IS, a BLE TNC, or a
-  /// serial TNC. Defaults to [PacketSource.aprsIs]. Production ingestion goes
-  /// through [attach]; this method remains the synchronous direct-injection
-  /// seam used by tests and the background-isolate packet relay.
-  void ingestLine(String raw, {PacketSource source = PacketSource.aprsIs}) =>
-      _handleLine(raw, source: source);
+  /// Update the station retention window. Immediately prunes the underlying
+  /// `stations` table (CASCADE deletes their position history).
+  Future<void> setStationHistoryDays(int days) async {
+    if (_stationHistoryDays == days) return;
+    _stationHistoryDays = days;
+    await _prefs?.setInt(_keyStationDays, days);
+    if (days != forever) {
+      await _stationDao.pruneOlderThan(_clock().subtract(Duration(days: days)));
+    }
+    notifyListeners();
+  }
 
-  static PacketSource _packetSourceFor(ConnectionType type) => switch (type) {
-    ConnectionType.aprsIs => PacketSource.aprsIs,
-    ConnectionType.bleTnc => PacketSource.bleTnc,
-    ConnectionType.serialTnc => PacketSource.serialTnc,
-  };
+  /// Delete the entire packet log (drift) and the in-memory cache.
+  Future<void> clearPacketLog() async {
+    await _packetDao.clearAll();
+    _packetCache = const [];
+    notifyListeners();
+  }
 
-  /// Record a packet that *we* just transmitted, tagged with the transport
-  /// it went out on. Used by [TxService] to surface outgoing traffic in the
-  /// packet log alongside received packets.
-  void recordOutgoing(String raw, {required PacketSource source}) =>
-      _handleLine(raw, source: source, isOutgoing: true);
+  /// Delete every station and its position history (drift) and clear the
+  /// in-memory cache.
+  Future<void> clearStationHistory() async {
+    await _stationDao.clearAll();
+    _stationCache = const {};
+    _stationController.add(const {});
+    notifyListeners();
+  }
 
   // ---------------------------------------------------------------------------
-  // History persistence
+  // Settings load (no structured data — that comes from drift watch streams)
   // ---------------------------------------------------------------------------
 
-  /// Restore history and limit settings from [prefs]. Call once after
-  /// construction, before ingesting any lines.
-  Future<void> loadPersistedHistory(SharedPreferences prefs) async {
+  /// Restore retention windows and display toggles from [prefs]. Call once at
+  /// startup, before [attach]. Replaces the v0.18 `loadPersistedHistory` JSON
+  /// restore — structured data now lives in drift and hydrates via the
+  /// watch streams subscribed in the constructor.
+  Future<void> loadPersistedSettings(SharedPreferences prefs) async {
     _prefs = prefs;
 
     _packetHistoryDays = prefs.getInt(_keyPacketDays) ?? 30;
@@ -337,107 +330,72 @@ class StationService extends ChangeNotifier {
     _weatherOverlayRadiusKm = prefs.getInt(_keyWeatherRadiusKm) ?? 50;
     _weatherOverlayUseCelsius = prefs.getBool(_keyWeatherUseCelsius) ?? false;
     _weatherOverlayMaxAgeMinutes = prefs.getInt(_keyWeatherMaxAgeMinutes) ?? 60;
-
-    // Restore station map, skipping entries older than the configured limit.
-    final stationsRaw = prefs.getString(_keyStationHistory);
-    if (stationsRaw != null) {
-      try {
-        final list = jsonDecode(stationsRaw) as List<dynamic>;
-        for (final item in list) {
-          final s = _stationFromJson(item as Map<String, dynamic>);
-          if (_withinAge(s.lastHeard, _stationHistoryDays)) {
-            _stations[s.callsign] = s;
-          }
-        }
-      } catch (e) {
-        debugPrint('StationService: failed to load station history: $e');
-      }
-      _stationController.add(Map.unmodifiable(_stations));
-    }
-
-    // Restore packet log, skipping entries older than the configured limit.
-    final packetsRaw = prefs.getString(_keyPacketLog);
-    if (packetsRaw != null) {
-      try {
-        final list = jsonDecode(packetsRaw) as List<dynamic>;
-        for (final item in list) {
-          final map = item as Map<String, dynamic>;
-          final raw = map['raw'] as String;
-          // 'tnc' is a legacy alias kept for backward compat with persisted logs.
-          final srcStr = map['src'] as String?;
-          final src = switch (srcStr) {
-            'aprs_is' => PacketSource.aprsIs,
-            'tnc' => PacketSource.tnc,
-            'ble_tnc' => PacketSource.bleTnc,
-            'serial_tnc' => PacketSource.serialTnc,
-            _ => PacketSource.aprsIs,
-          };
-          final tsMs = map['ts'] as int?;
-          final receivedAt = tsMs != null
-              ? DateTime.fromMillisecondsSinceEpoch(tsMs, isUtc: true)
-              : _clock().toUtc();
-          final packet = _parser.parse(
-            raw,
-            transportSource: src,
-            receivedAt: receivedAt,
-          );
-          if (_withinAge(packet.receivedAt, _packetHistoryDays)) {
-            _recentPackets.add(packet);
-          }
-        }
-      } catch (e) {
-        debugPrint('StationService: failed to load packet log: $e');
-      }
-    }
-  }
-
-  /// Update the packet history age limit in days ([forever] = no limit).
-  Future<void> setPacketHistoryDays(int days) async {
-    if (_packetHistoryDays == days) return;
-    _packetHistoryDays = days;
-    await _prefs?.setInt(_keyPacketDays, days);
-    _recentPackets.removeWhere((p) => !_withinAge(p.receivedAt, days));
-    notifyListeners();
-    _schedulePersist();
-  }
-
-  /// Update the station history age limit in days ([forever] = no limit).
-  Future<void> setStationHistoryDays(int days) async {
-    if (_stationHistoryDays == days) return;
-    _stationHistoryDays = days;
-    await _prefs?.setInt(_keyStationDays, days);
-    _stations.removeWhere((_, s) => !_withinAge(s.lastHeard, days));
-    _stationController.add(Map.unmodifiable(_stations));
-    notifyListeners();
-    _schedulePersist();
-  }
-
-  /// Delete all persisted and in-memory packets.
-  Future<void> clearPacketLog() async {
-    _recentPackets.clear();
-    await _prefs?.remove(_keyPacketLog);
-    notifyListeners();
-  }
-
-  /// Delete all persisted and in-memory stations.
-  Future<void> clearStationHistory() async {
-    _stations.clear();
-    await _prefs?.remove(_keyStationHistory);
-    _stationController.add(Map.unmodifiable(_stations));
-    notifyListeners();
   }
 
   // ---------------------------------------------------------------------------
-  // Internal
+  // Ingest
   // ---------------------------------------------------------------------------
 
-  void _handleLine(
+  /// Subscribe to [registry]'s multiplexed lines stream. Single production
+  /// ingestion seam. Calling twice is a programming error.
+  void attach(ConnectionRegistry registry) {
+    assert(
+      _registrySub == null,
+      'StationService.attach called twice; a single subscription is expected.',
+    );
+    _registrySub = registry.lines.listen((event) {
+      // Fire-and-forget — `_handleLine` serialises internally so cache merges
+      // stay consistent regardless of how fast the registry pushes events.
+      unawaited(
+        _handleLine(event.line, source: _packetSourceFor(event.source)),
+      );
+    });
+    _pruneTimer ??= Timer.periodic(
+      const Duration(seconds: 60),
+      (_) => unawaited(_runPrune()),
+    );
+  }
+
+  /// Ingest a pre-formatted APRS line. Returns a future that completes once
+  /// the packet (and any station update) has been persisted to drift and the
+  /// snapshot caches reflect the new state. Tests should `await` this.
+  Future<void> ingestLine(
+    String raw, {
+    PacketSource source = PacketSource.aprsIs,
+  }) => _handleLine(raw, source: source);
+
+  /// Record a packet we transmitted, tagged with the transport it went out
+  /// on. Mirrors [ingestLine] but flags the row `is_outgoing = true`.
+  Future<void> recordOutgoing(String raw, {required PacketSource source}) =>
+      _handleLine(raw, source: source, isOutgoing: true);
+
+  static PacketSource _packetSourceFor(ConnectionType type) => switch (type) {
+    ConnectionType.aprsIs => PacketSource.aprsIs,
+    ConnectionType.bleTnc => PacketSource.bleTnc,
+    ConnectionType.serialTnc => PacketSource.serialTnc,
+  };
+
+  Future<void> _handleLine(
     String raw, {
     PacketSource source = PacketSource.aprsIs,
     bool isOutgoing = false,
   }) {
-    debugPrint(raw);
+    // Serialise on the per-service ingest chain so position-history merges
+    // observe a stable "previous station" snapshot.
+    final task = _ingestChain.then(
+      (_) => _processLine(raw, source: source, isOutgoing: isOutgoing),
+    );
+    _ingestChain = task.catchError((Object e, StackTrace st) {
+      debugPrint('StationService ingest error: $e\n$st');
+    });
+    return task;
+  }
 
+  Future<void> _processLine(
+    String raw, {
+    required PacketSource source,
+    required bool isOutgoing,
+  }) async {
     if (raw.isEmpty || raw.startsWith('#')) return;
 
     final packet = _parser.parse(
@@ -446,62 +404,98 @@ class StationService extends ChangeNotifier {
       receivedAt: _clock().toUtc(),
     )..isOutgoing = isOutgoing;
 
-    // Add to rolling in-session buffer, capped for performance.
-    _recentPackets.insert(0, packet);
-    if (_recentPackets.length > _kMaxInMemoryPackets) {
-      _recentPackets.removeLast();
-    }
-
+    // Synchronous emission — preserves `MessageService._onPacket` semantics.
     _packetController.add(packet);
 
+    // Insert packet row (always). Awaited so ingestLine callers see the new
+    // row in `recentPackets` after `await`.
+    await _packetDao.insertPacket(
+      PacketsCompanion.insert(
+        rawLine: raw,
+        packetType: _packetTypeTag(packet),
+        sourceCallsign: packet.source,
+        receivedAt: packet.receivedAt.millisecondsSinceEpoch,
+        sourceChannel: source,
+        destination: Value(packet.destination),
+        isOutgoing: Value(isOutgoing),
+      ),
+    );
+
+    // Eagerly update the packet cache so sync getters reflect the new packet
+    // before the watch stream re-emits.
+    _packetCache = [packet, ..._packetCache];
+    if (_packetCache.length > _kMaxInMemoryPackets) {
+      _packetCache = _packetCache.sublist(0, _kMaxInMemoryPackets);
+    }
+    notifyListeners();
+
+    // Position-like packets update the station map.
     if (packet is PositionPacket) {
-      debugPrint('PARSED: ${packet.source} @ ${packet.lat}, ${packet.lon}');
-      final station = _mergeStation(_stationFromPosition(packet));
-      _stations[station.callsign] = station;
-      _stationController.add(Map.unmodifiable(_stations));
+      await _upsertStation(_stationFromPosition(packet));
     } else if (packet is MicEPacket) {
-      debugPrint('MIC-E: ${packet.source} @ ${packet.lat}, ${packet.lon}');
-      final station = _mergeStation(_stationFromMicE(packet));
-      _stations[station.callsign] = station;
-      _stationController.add(Map.unmodifiable(_stations));
+      await _upsertStation(_stationFromMicE(packet));
     } else if (packet is ObjectPacket) {
-      if (!packet.isAlive) {
-        if (_stations.remove(packet.objectName) != null) {
-          _stationController.add(Map.unmodifiable(_stations));
-        }
+      if (packet.isAlive) {
+        await _upsertStation(_stationFromObject(packet));
       } else {
-        final station = _mergeStation(_stationFromObject(packet));
-        _stations[station.callsign] = station;
-        _stationController.add(Map.unmodifiable(_stations));
+        await _deleteStation(packet.objectName);
       }
     } else if (packet is ItemPacket) {
-      if (!packet.isAlive) {
-        if (_stations.remove(packet.itemName) != null) {
-          _stationController.add(Map.unmodifiable(_stations));
-        }
+      if (packet.isAlive) {
+        await _upsertStation(_stationFromItem(packet));
       } else {
-        final station = _mergeStation(_stationFromItem(packet));
-        _stations[station.callsign] = station;
-        _stationController.add(Map.unmodifiable(_stations));
+        await _deleteStation(packet.itemName);
       }
     } else if (packet is WeatherPacket) {
       if (packet.lat != null && packet.lon != null) {
-        final station = _mergeStation(_stationFromWeather(packet));
-        _stations[station.callsign] = station;
-        _stationController.add(Map.unmodifiable(_stations));
+        await _upsertStation(_stationFromWeather(packet));
       }
     } else if (packet is UnknownPacket) {
       debugPrint('SKIP: ${packet.reason} -- $raw');
     }
-
-    _schedulePersist();
   }
 
-  Station _mergeStation(Station incoming) {
-    final prev = _stations[incoming.callsign];
+  Future<void> _upsertStation(Station incoming) async {
+    final prevRow = await _stationDao.getStation(incoming.callsign);
+    final prev = prevRow == null
+        ? null
+        : _stationCache[incoming.callsign] ?? _rowToStation(prevRow, const []);
+
+    final merged = _merge(prev: prev, incoming: incoming);
+
+    PositionHistoryCompanion? prevPos;
+    if (prev != null) {
+      prevPos = PositionHistoryCompanion.insert(
+        callsign: prev.callsign,
+        latitude: prev.lat,
+        longitude: prev.lon,
+        timestamp: prev.lastHeard.millisecondsSinceEpoch,
+      );
+    }
+
+    await _stationDao.upsertWithPositionHistory(
+      station: _stationToCompanion(merged),
+      previousPosition: prevPos,
+      capHistoryAt: _kMaxPositionHistory,
+    );
+
+    _stationCache = Map<String, Station>.from(_stationCache)
+      ..[merged.callsign] = merged;
+    _stationController.add(Map.unmodifiable(_stationCache));
+    notifyListeners();
+  }
+
+  Future<void> _deleteStation(String callsign) async {
+    final removed = await _stationDao.deleteByCallsign(callsign);
+    if (removed == 0) return;
+    _stationCache = Map<String, Station>.from(_stationCache)..remove(callsign);
+    _stationController.add(Map.unmodifiable(_stationCache));
+    notifyListeners();
+  }
+
+  Station _merge({required Station? prev, required Station incoming}) {
     if (prev == null) return incoming;
 
-    // Append the previous position to the history track before overwriting it.
     final newEntry = TimestampedPosition(
       prev.lastHeard,
       LatLng(prev.lat, prev.lon),
@@ -523,14 +517,125 @@ class StationService extends ChangeNotifier {
       device: incoming.device ?? prev.device,
       positionHistory: history,
       type: incoming.type,
-      // Prefer a known capability over an unknown one. A later Position packet
-      // is authoritative, but we don't want a later Object/Item packet (which
-      // is always "unknown") to erase a prior known value.
       messageCapability: incoming.messageCapability != MessageCapability.unknown
           ? incoming.messageCapability
           : prev.messageCapability,
     );
   }
+
+  // ---------------------------------------------------------------------------
+  // Watch stream → cache reconciliation (covers cross-isolate writes)
+  // ---------------------------------------------------------------------------
+
+  Future<void> _onStationsRowsChanged(List<StationRow> rows) async {
+    final byCallsign = {for (final r in rows) r.callsign: r};
+    final allHistory = await _stationDao.getAllPositionHistory();
+    final historyByCallsign = <String, List<TimestampedPosition>>{};
+    for (final h in allHistory) {
+      historyByCallsign
+          .putIfAbsent(h.callsign, () => <TimestampedPosition>[])
+          .add(
+            TimestampedPosition(
+              DateTime.fromMillisecondsSinceEpoch(h.timestamp, isUtc: true),
+              LatLng(h.latitude, h.longitude),
+            ),
+          );
+    }
+
+    final next = <String, Station>{};
+    for (final entry in byCallsign.entries) {
+      next[entry.key] = _rowToStation(
+        entry.value,
+        historyByCallsign[entry.key] ?? const [],
+      );
+    }
+    _stationCache = next;
+    _stationController.add(Map.unmodifiable(_stationCache));
+    notifyListeners();
+  }
+
+  void _onPacketsRowsChanged(List<PacketRow> rows) {
+    _packetCache = rows.map(_rowToPacket).toList();
+    notifyListeners();
+  }
+
+  AprsPacket _rowToPacket(PacketRow row) {
+    final packet = _parser.parse(
+      row.rawLine,
+      transportSource: row.sourceChannel,
+      receivedAt: DateTime.fromMillisecondsSinceEpoch(
+        row.receivedAt,
+        isUtc: true,
+      ),
+    )..isOutgoing = row.isOutgoing;
+    return packet;
+  }
+
+  Station _rowToStation(StationRow row, List<TimestampedPosition> history) {
+    return Station(
+      callsign: row.callsign,
+      lat: row.lat,
+      lon: row.lon,
+      rawPacket: row.rawPacket,
+      lastHeard: DateTime.fromMillisecondsSinceEpoch(
+        row.lastHeard,
+        isUtc: true,
+      ),
+      symbolTable: row.symbolTable,
+      symbolCode: row.symbolCode,
+      comment: row.comment,
+      device: row.device,
+      positionHistory: history,
+      type: row.stationType,
+      messageCapability: row.messageCapability,
+    );
+  }
+
+  StationsCompanion _stationToCompanion(Station s) => StationsCompanion.insert(
+    callsign: s.callsign,
+    symbolTable: s.symbolTable,
+    symbolCode: s.symbolCode,
+    comment: s.comment,
+    rawPacket: s.rawPacket,
+    device: Value(s.device),
+    lastHeard: s.lastHeard.millisecondsSinceEpoch,
+    stationType: s.type,
+    messageCapability: s.messageCapability,
+    lat: s.lat,
+    lon: s.lon,
+  );
+
+  PacketTypeTag _packetTypeTag(AprsPacket p) {
+    if (p is PositionPacket) return PacketTypeTag.position;
+    if (p is WeatherPacket) return PacketTypeTag.weather;
+    if (p is MessagePacket) return PacketTypeTag.message;
+    if (p is ObjectPacket) return PacketTypeTag.object;
+    if (p is ItemPacket) return PacketTypeTag.item;
+    if (p is StatusPacket) return PacketTypeTag.status;
+    if (p is MicEPacket) return PacketTypeTag.micE;
+    return PacketTypeTag.unknown;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Periodic retention prune
+  // ---------------------------------------------------------------------------
+
+  Future<void> _runPrune() async {
+    if (_packetHistoryDays != forever) {
+      await _packetDao.pruneOlderThan(
+        _clock().subtract(Duration(days: _packetHistoryDays)),
+      );
+    }
+    if (_stationHistoryDays != forever) {
+      await _stationDao.pruneOlderThan(
+        _clock().subtract(Duration(days: _stationHistoryDays)),
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Station factories — unchanged from v0.18
+  // ---------------------------------------------------------------------------
 
   Station _stationFromPosition(PositionPacket p) => Station(
     callsign: p.source,
@@ -596,134 +701,7 @@ class StationService extends ChangeNotifier {
     lastHeard: p.receivedAt,
     symbolTable: p.symbolTable,
     symbolCode: p.symbolCode,
-    comment: p.rawLine, // store raw for fallback display
+    comment: p.rawLine,
     type: StationType.weather,
   );
-
-  // ---------------------------------------------------------------------------
-  // Persistence helpers
-  // ---------------------------------------------------------------------------
-
-  bool _withinAge(DateTime dt, int days) {
-    if (days == forever) return true;
-    return _clock().difference(dt).inDays < days;
-  }
-
-  void _schedulePersist() {
-    if (_prefs == null) return;
-    _persistTimer?.cancel();
-    _persistTimer = Timer(const Duration(seconds: 3), _persistNow);
-  }
-
-  void _persistNow() {
-    final prefs = _prefs;
-    if (prefs == null) return;
-
-    try {
-      final stationList = _stations.values
-          .where((s) => _withinAge(s.lastHeard, _stationHistoryDays))
-          .map(_stationToJson)
-          .toList();
-      prefs.setString(
-        _keyStationHistory,
-        jsonEncode(stationList),
-      ); // ignore: unawaited_futures
-    } catch (e) {
-      debugPrint('StationService: failed to persist stations: $e');
-    }
-
-    try {
-      final packetList = _recentPackets
-          .where((p) => _withinAge(p.receivedAt, _packetHistoryDays))
-          .map(
-            (p) => {
-              'raw': p.rawLine,
-              'src': switch (p.transportSource) {
-                PacketSource.aprsIs => 'aprs_is',
-                PacketSource.tnc => 'tnc',
-                PacketSource.bleTnc => 'ble_tnc',
-                PacketSource.serialTnc => 'serial_tnc',
-              },
-              'ts': p.receivedAt.millisecondsSinceEpoch,
-            },
-          )
-          .toList();
-      prefs.setString(
-        _keyPacketLog,
-        jsonEncode(packetList),
-      ); // ignore: unawaited_futures
-    } catch (e) {
-      debugPrint('StationService: failed to persist packet log: $e');
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Station JSON helpers
-  // ---------------------------------------------------------------------------
-
-  Map<String, dynamic> _stationToJson(Station s) => {
-    'callsign': s.callsign,
-    'lat': s.lat,
-    'lon': s.lon,
-    'symbolTable': s.symbolTable,
-    'symbolCode': s.symbolCode,
-    'comment': s.comment,
-    'lastHeard': s.lastHeard.millisecondsSinceEpoch,
-    'rawPacket': s.rawPacket,
-    'type': s.type.name,
-    'messageCapability': s.messageCapability.name,
-    if (s.device != null) 'device': s.device,
-    if (s.positionHistory.isNotEmpty)
-      'positionHistory': s.positionHistory
-          .map(
-            (p) => {
-              'ts': p.timestamp.millisecondsSinceEpoch,
-              'lat': p.position.latitude,
-              'lon': p.position.longitude,
-            },
-          )
-          .toList(),
-  };
-
-  Station _stationFromJson(Map<String, dynamic> json) {
-    final symbolTable = json['symbolTable'] as String;
-    final symbolCode = json['symbolCode'] as String;
-    final typeStr = json['type'] as String?;
-    final type = typeStr != null
-        ? StationType.values.where((t) => t.name == typeStr).firstOrNull ??
-              classifyStationType(symbolTable, symbolCode)
-        : classifyStationType(symbolTable, symbolCode);
-
-    final capStr = json['messageCapability'] as String?;
-    final messageCapability = capStr != null
-        ? MessageCapability.values.where((c) => c.name == capStr).firstOrNull ??
-              MessageCapability.unknown
-        : MessageCapability.unknown;
-
-    final historyRaw = json['positionHistory'] as List<dynamic>?;
-    final positionHistory =
-        historyRaw?.map((e) {
-          final m = e as Map<String, dynamic>;
-          return TimestampedPosition(
-            DateTime.fromMillisecondsSinceEpoch(m['ts'] as int, isUtc: true),
-            LatLng((m['lat'] as num).toDouble(), (m['lon'] as num).toDouble()),
-          );
-        }).toList() ??
-        const [];
-
-    return Station(
-      callsign: json['callsign'] as String,
-      lat: (json['lat'] as num).toDouble(),
-      lon: (json['lon'] as num).toDouble(),
-      symbolTable: symbolTable,
-      symbolCode: symbolCode,
-      comment: (json['comment'] as String?) ?? '',
-      lastHeard: DateTime.fromMillisecondsSinceEpoch(json['lastHeard'] as int),
-      rawPacket: (json['rawPacket'] as String?) ?? '',
-      device: json['device'] as String?,
-      type: type,
-      positionHistory: positionHistory,
-      messageCapability: messageCapability,
-    );
-  }
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -60,9 +60,14 @@ class StationService extends ChangeNotifier {
   }) : _stationDao = stationDao,
        _packetDao = packetDao,
        _clock = clock {
-    _stationsSub = _stationDao.watchAllStations().listen(
-      _onStationsRowsChanged,
-    );
+    // asyncMap serialises handling: _onStationsRowsChanged awaits a position-
+    // history read, so a plain listen() would let two close-spaced emissions
+    // overlap and a slow earlier handler could clobber _stationCache with stale
+    // data. asyncMap waits for each handler before delivering the next event.
+    _stationsSub = _stationDao
+        .watchAllStations()
+        .asyncMap(_onStationsRowsChanged)
+        .listen((_) {});
     _packetsSub = _packetDao
         .watchRecent(limit: _kMaxInMemoryPackets)
         .listen(_onPacketsRowsChanged);
@@ -87,7 +92,7 @@ class StationService extends ChangeNotifier {
   final _stationController = StreamController<Map<String, Station>>.broadcast();
 
   // Active drift watch subscriptions.
-  StreamSubscription<List<StationRow>>? _stationsSub;
+  StreamSubscription<void>? _stationsSub;
   StreamSubscription<List<PacketRow>>? _packetsSub;
 
   // Single in-flight ingest serialises the "read prev → merge → write" chain

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.6"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.0"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.12.6"
   characters:
     dependency: transitive
     description:
@@ -81,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -177,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -209,6 +273,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: "8033500116b24398fba0cca0369cc31678cd627c01e41753a61186911cea743e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.33.0"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: b3dd5b75e30522a91da8abda9f5bb17230cb038097f6d15fa75d42bb563428aa
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.33.0"
+  drift_flutter:
+    dependency: "direct main"
+    description:
+      name: drift_flutter
+      sha256: "887fdec622174dc7eaefd0048403e34ee07cc18626ac8a7544cc3b8a4a172166"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   dylib:
     dependency: transitive
     description:
@@ -549,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   hooks:
     dependency: transitive
     description:
@@ -1013,6 +1109,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   rxdart:
     dependency: transitive
     description:
@@ -1114,6 +1226,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1138,6 +1258,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  sqlite3_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlite3_flutter_libs
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0+eol"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: ecdc06d4a7d79dcbc928d99afd2f7f5b0f98a637c46f89be83d911617f759978
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.44.4"
   stack_trace:
     dependency: transitive
     description:
@@ -1154,6 +1306,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   local_notifier: ^0.1.6
   flutter_svg: ^2.2.4
   flutter_secure_storage: ^9.2.2
+  drift: ^2.33.0
+  drift_flutter: ^0.3.0
 
 dev_dependencies:
   flutter_test:
@@ -48,6 +50,8 @@ dev_dependencies:
   fake_async: ^1.3.2
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.0
+  drift_dev: ^2.33.0
+  build_runner: ^2.4.12
 
 flutter:
   uses-material-design: true

--- a/test/core/util/clock_injection_test.dart
+++ b/test/core/util/clock_injection_test.dart
@@ -13,6 +13,8 @@ import 'package:meridian_aprs/core/packet/aprs_packet.dart';
 import 'package:meridian_aprs/services/station_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../helpers/test_database.dart';
+
 class _MutableClock {
   _MutableClock(this._now);
   DateTime _now;
@@ -29,10 +31,18 @@ void main() {
       final clock = _MutableClock(DateTime.utc(2026, 1, 1, 12));
       SharedPreferences.setMockInitialValues({});
 
-      final service = StationService(clock: clock.call);
-      await service.loadPersistedHistory(await SharedPreferences.getInstance());
+      final db = buildTestDatabase();
+      addTearDown(db.close);
+      final service = StationService(
+        stationDao: db.stationDao,
+        packetDao: db.packetDao,
+        clock: clock.call,
+      );
+      await service.loadPersistedSettings(
+        await SharedPreferences.getInstance(),
+      );
 
-      service.ingestLine(
+      await service.ingestLine(
         'N0CALL>APRS:!4903.50N/07201.75W-clock-injection-test',
       );
 
@@ -41,11 +51,15 @@ void main() {
       expect(service.recentPackets.first, isA<PositionPacket>());
 
       // Advance 2 days, then narrow the retention window to 1 day.
-      // `_withinAge` uses _clock(); after the advance, the entry is stale.
+      // Drift prune uses _clock(); after the advance, the entry is stale.
       clock.advance(const Duration(days: 2));
       await service.setPacketHistoryDays(1);
 
+      // Allow the watch stream to re-emit after the prune delete.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
       expect(service.recentPackets, isEmpty);
+      await service.stop();
     },
   );
 }

--- a/test/database/bulletin_dao_test.dart
+++ b/test/database/bulletin_dao_test.dart
@@ -1,0 +1,163 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/database/meridian_database.dart';
+import 'package:meridian_aprs/models/bulletin.dart';
+
+import '../helpers/test_database.dart';
+
+void main() {
+  late MeridianDatabase db;
+
+  setUp(() => db = buildTestDatabase());
+  tearDown(() => db.close());
+
+  BulletinsCompanion incoming(
+    String source,
+    String addressee, {
+    String body = 'body',
+    int lastHeardAt = 1000,
+    Set<BulletinTransport> transports = const {BulletinTransport.aprsIs},
+  }) => BulletinsCompanion.insert(
+    sourceCallsign: source,
+    addressee: addressee,
+    body: body,
+    firstHeardAt: 1000,
+    lastHeardAt: lastHeardAt,
+    category: BulletinCategory.general,
+    lineNumber: '0',
+    transports: Value(transports),
+  );
+
+  test('upsertIncoming replaces on (source, addressee) conflict', () async {
+    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0', body: 'v1'));
+    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0', body: 'v2'));
+    final rows = await db.bulletinDao.getAllIncoming();
+    expect(rows, hasLength(1));
+    expect(rows.single.body, 'v2');
+  });
+
+  test('transports converter round-trips a set', () async {
+    await db.bulletinDao.upsertIncoming(
+      incoming(
+        'K5WX',
+        'BLN0',
+        transports: {BulletinTransport.rf, BulletinTransport.aprsIs},
+      ),
+    );
+    final row = (await db.bulletinDao.getAllIncoming()).single;
+    expect(row.transports, {BulletinTransport.rf, BulletinTransport.aprsIs});
+    expect(row.category, BulletinCategory.general);
+  });
+
+  test('getAllIncoming ordered by lastHeardAt descending', () async {
+    await db.bulletinDao.upsertIncoming(
+      incoming('A', 'BLN0', lastHeardAt: 100),
+    );
+    await db.bulletinDao.upsertIncoming(
+      incoming('B', 'BLN1', lastHeardAt: 300),
+    );
+    final rows = await db.bulletinDao.getAllIncoming();
+    expect(rows.map((r) => r.sourceCallsign), ['B', 'A']);
+  });
+
+  test('markIncomingRead + deleteIncoming target the right row', () async {
+    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0'));
+    await db.bulletinDao.markIncomingRead('K5WX', 'BLN0');
+    expect((await db.bulletinDao.getAllIncoming()).single.isRead, isTrue);
+
+    await db.bulletinDao.deleteIncoming('K5WX', 'BLN0');
+    expect(await db.bulletinDao.getAllIncoming(), isEmpty);
+  });
+
+  test('pruneIncomingOlderThan deletes before cutoff', () async {
+    await db.bulletinDao.upsertIncoming(
+      incoming('OLD', 'BLN0', lastHeardAt: 100),
+    );
+    await db.bulletinDao.upsertIncoming(
+      incoming('NEW', 'BLN1', lastHeardAt: 5000),
+    );
+    final removed = await db.bulletinDao.pruneIncomingOlderThan(
+      DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+    expect(removed, 1);
+    expect(
+      (await db.bulletinDao.getAllIncoming()).map((r) => r.sourceCallsign),
+      ['NEW'],
+    );
+  });
+
+  // --- Outgoing ------------------------------------------------------------
+
+  Future<int> insertOutgoing({
+    String addressee = 'BLN0',
+    int intervalSeconds = 1800,
+    int createdAt = 1000,
+  }) => db.bulletinDao.insertOutgoing(
+    OutgoingBulletinsCompanion.insert(
+      addressee: addressee,
+      body: 'b',
+      intervalSeconds: intervalSeconds,
+      createdAt: createdAt,
+    ),
+  );
+
+  test('insertOutgoing assigns autoincrement ids', () async {
+    final id1 = await insertOutgoing();
+    final id2 = await insertOutgoing();
+    expect(id2, greaterThan(id1));
+    expect((await db.bulletinDao.getAllOutgoing()).length, 2);
+  });
+
+  test('recordOutgoingTransmission bumps count + stamps timestamp', () async {
+    final id = await insertOutgoing();
+    final ts = DateTime.fromMillisecondsSinceEpoch(4242);
+    await db.bulletinDao.recordOutgoingTransmission(id, ts);
+    await db.bulletinDao.recordOutgoingTransmission(id, ts);
+    final row = (await db.bulletinDao.getAllOutgoing()).single;
+    expect(row.transmissionCount, 2);
+    expect(row.lastTransmittedAt, 4242);
+  });
+
+  test('updateOutgoingContent resets lastTransmittedAt + count', () async {
+    final id = await insertOutgoing();
+    await db.bulletinDao.recordOutgoingTransmission(
+      id,
+      DateTime.fromMillisecondsSinceEpoch(10),
+    );
+    await db.bulletinDao.updateOutgoingContent(id: id, body: 'new body');
+    final row = (await db.bulletinDao.getAllOutgoing()).single;
+    expect(row.body, 'new body');
+    expect(row.transmissionCount, 0);
+    expect(row.lastTransmittedAt, isNull);
+  });
+
+  test('updateOutgoingSchedule does NOT reset transmission state', () async {
+    final id = await insertOutgoing();
+    await db.bulletinDao.recordOutgoingTransmission(
+      id,
+      DateTime.fromMillisecondsSinceEpoch(10),
+    );
+    await db.bulletinDao.updateOutgoingSchedule(id: id, intervalSeconds: 3600);
+    final row = (await db.bulletinDao.getAllOutgoing()).single;
+    expect(row.intervalSeconds, 3600);
+    expect(row.transmissionCount, 1);
+    expect(row.lastTransmittedAt, 10);
+  });
+
+  test('setOutgoingEnabled + deleteOutgoing', () async {
+    final id = await insertOutgoing();
+    await db.bulletinDao.setOutgoingEnabled(id, false);
+    expect((await db.bulletinDao.getAllOutgoing()).single.enabled, isFalse);
+
+    await db.bulletinDao.deleteOutgoing(id);
+    expect(await db.bulletinDao.getAllOutgoing(), isEmpty);
+  });
+
+  test('getAllOutgoing ordered by createdAt ascending', () async {
+    await insertOutgoing(addressee: 'BLN1', createdAt: 300);
+    await insertOutgoing(addressee: 'BLN0', createdAt: 100);
+    final rows = await db.bulletinDao.getAllOutgoing();
+    expect(rows.map((r) => r.addressee), ['BLN0', 'BLN1']);
+  });
+}

--- a/test/database/message_dao_test.dart
+++ b/test/database/message_dao_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:meridian_aprs/database/meridian_database.dart';
 import 'package:meridian_aprs/models/message_category.dart';
-import 'package:meridian_aprs/services/message_service.dart' show MessageStatus;
+import 'package:meridian_aprs/models/message_status.dart';
 
 import '../helpers/test_database.dart';
 

--- a/test/database/message_dao_test.dart
+++ b/test/database/message_dao_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/database/meridian_database.dart';
+import 'package:meridian_aprs/models/message_category.dart';
+import 'package:meridian_aprs/services/message_service.dart' show MessageStatus;
+
+import '../helpers/test_database.dart';
+
+void main() {
+  late MeridianDatabase db;
+
+  setUp(() => db = buildTestDatabase());
+  tearDown(() => db.close());
+
+  Future<void> conv(String peer, {int lastMessageAt = 1000}) =>
+      db.messageDao.upsertConversation(
+        ConversationsCompanion.insert(
+          peerCallsign: peer,
+          lastMessageAt: lastMessageAt,
+        ),
+      );
+
+  Future<void> entry(
+    String id,
+    String peer, {
+    int timestamp = 1000,
+    bool outgoing = false,
+    MessageStatus status = MessageStatus.acked,
+    MessageCategory category = MessageCategory.direct,
+  }) => db.messageDao.insertEntry(
+    MessageEntriesCompanion.insert(
+      id: id,
+      conversationPeer: peer,
+      body: 'body',
+      timestamp: timestamp,
+      isOutgoing: outgoing,
+      status: status,
+      category: category,
+    ),
+  );
+
+  test('unread increment + markRead', () async {
+    await conv('KB1XYZ');
+    await db.messageDao.incrementUnread('KB1XYZ');
+    await db.messageDao.incrementUnread('KB1XYZ');
+    var rows = await db.messageDao.getAllConversations();
+    expect(rows.single.unreadCount, 2);
+
+    await db.messageDao.markRead('KB1XYZ');
+    rows = await db.messageDao.getAllConversations();
+    expect(rows.single.unreadCount, 0);
+  });
+
+  test('insertEntry is idempotent on id (insertOrReplace)', () async {
+    await conv('KB1XYZ');
+    await entry('id1', 'KB1XYZ', status: MessageStatus.pending);
+    await entry('id1', 'KB1XYZ', status: MessageStatus.acked);
+    final rows = await db.messageDao.getEntriesForPeer('KB1XYZ');
+    expect(rows, hasLength(1));
+    expect(rows.single.status, MessageStatus.acked);
+  });
+
+  test('updateEntryStatus changes status + retryCount', () async {
+    await conv('KB1XYZ');
+    await entry('id1', 'KB1XYZ', status: MessageStatus.pending);
+    await db.messageDao.updateEntryStatus(
+      localId: 'id1',
+      status: MessageStatus.retrying,
+      retryCount: 3,
+    );
+    final row = (await db.messageDao.getEntriesForPeer('KB1XYZ')).single;
+    expect(row.status, MessageStatus.retrying);
+    expect(row.retryCount, 3);
+  });
+
+  test('getEntriesForPeer ordered ascending by timestamp', () async {
+    await conv('KB1XYZ');
+    await entry('b', 'KB1XYZ', timestamp: 300);
+    await entry('a', 'KB1XYZ', timestamp: 100);
+    final rows = await db.messageDao.getEntriesForPeer('KB1XYZ');
+    expect(rows.map((r) => r.id), ['a', 'b']);
+  });
+
+  test('demoteInFlightToFailed only touches pending/retrying', () async {
+    await conv('KB1XYZ');
+    await entry('p', 'KB1XYZ', status: MessageStatus.pending);
+    await entry('r', 'KB1XYZ', status: MessageStatus.retrying);
+    await entry('a', 'KB1XYZ', status: MessageStatus.acked);
+    await entry('c', 'KB1XYZ', status: MessageStatus.cancelled);
+
+    final changed = await db.messageDao.demoteInFlightToFailed();
+    expect(changed, 2);
+
+    final byId = {
+      for (final r in await db.messageDao.getEntriesForPeer('KB1XYZ'))
+        r.id: r.status,
+    };
+    expect(byId['p'], MessageStatus.failed);
+    expect(byId['r'], MessageStatus.failed);
+    expect(byId['a'], MessageStatus.acked);
+    expect(byId['c'], MessageStatus.cancelled);
+  });
+
+  test('pruneOlderThan removes aged entries from both tables', () async {
+    await conv('KB1XYZ');
+    await entry('old', 'KB1XYZ', timestamp: 100);
+    await entry('new', 'KB1XYZ', timestamp: 5000);
+    await db.messageDao.insertGroupEntry(
+      GroupMessageEntriesCompanion.insert(
+        id: 'g_old',
+        groupName: 'WX',
+        fromCallsign: 'K1ABC',
+        body: 'b',
+        timestamp: 100,
+      ),
+    );
+
+    final removed = await db.messageDao.pruneOlderThan(
+      DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+    expect(removed, 2); // one direct + one group
+    expect((await db.messageDao.getEntriesForPeer('KB1XYZ')).map((r) => r.id), [
+      'new',
+    ]);
+    expect(await db.messageDao.watchGroupEntries('WX').first, isEmpty);
+  });
+
+  test('pruneEmptyConversations drops conversations with no entries', () async {
+    await conv('EMPTY');
+    await conv('HASMSG');
+    await entry('id1', 'HASMSG');
+
+    final removed = await db.messageDao.pruneEmptyConversations();
+    expect(removed, 1);
+    final peers = (await db.messageDao.getAllConversations()).map(
+      (c) => c.peerCallsign,
+    );
+    expect(peers, ['HASMSG']);
+  });
+
+  test('cascade delete: removing conversation drops its entries', () async {
+    await conv('KB1XYZ');
+    await entry('id1', 'KB1XYZ');
+    await db.messageDao.clearAll();
+    expect(await db.messageDao.getEntriesForPeer('KB1XYZ'), isEmpty);
+    expect(await db.messageDao.getAllConversations(), isEmpty);
+  });
+
+  test('group entries round-trip via group table', () async {
+    await db.messageDao.insertGroupEntry(
+      GroupMessageEntriesCompanion.insert(
+        id: 'g1',
+        groupName: 'WX',
+        fromCallsign: 'K1ABC',
+        body: 'storm',
+        timestamp: 10,
+      ),
+    );
+    final rows = await db.messageDao.watchGroupEntries('WX').first;
+    expect(rows.single.body, 'storm');
+  });
+}

--- a/test/database/packet_dao_test.dart
+++ b/test/database/packet_dao_test.dart
@@ -1,0 +1,65 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/core/packet/aprs_packet.dart' show PacketSource;
+import 'package:meridian_aprs/database/meridian_database.dart';
+import 'package:meridian_aprs/database/tables/packets.dart';
+
+import '../helpers/test_database.dart';
+
+void main() {
+  late MeridianDatabase db;
+
+  setUp(() => db = buildTestDatabase());
+  tearDown(() => db.close());
+
+  PacketsCompanion packet(
+    String source, {
+    int receivedAt = 1000,
+    bool outgoing = false,
+    PacketSource channel = PacketSource.aprsIs,
+  }) => PacketsCompanion.insert(
+    rawLine: '$source>APRS:!',
+    packetType: PacketTypeTag.position,
+    sourceCallsign: source,
+    receivedAt: receivedAt,
+    sourceChannel: channel,
+    isOutgoing: Value(outgoing),
+  );
+
+  test('watchRecent returns newest-first and honours limit', () async {
+    await db.packetDao.insertPacket(packet('A', receivedAt: 100));
+    await db.packetDao.insertPacket(packet('B', receivedAt: 300));
+    await db.packetDao.insertPacket(packet('C', receivedAt: 200));
+
+    final rows = await db.packetDao.watchRecent(limit: 2).first;
+    expect(rows.map((r) => r.sourceCallsign), ['B', 'C']);
+  });
+
+  test('isOutgoing + sourceChannel round-trip', () async {
+    await db.packetDao.insertPacket(
+      packet('A', outgoing: true, channel: PacketSource.serialTnc),
+    );
+    final row = (await db.packetDao.watchRecent().first).single;
+    expect(row.isOutgoing, isTrue);
+    expect(row.sourceChannel, PacketSource.serialTnc);
+  });
+
+  test('pruneOlderThan deletes packets before cutoff', () async {
+    await db.packetDao.insertPacket(packet('OLD', receivedAt: 100));
+    await db.packetDao.insertPacket(packet('NEW', receivedAt: 5000));
+
+    final removed = await db.packetDao.pruneOlderThan(
+      DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+    expect(removed, 1);
+    final rows = await db.packetDao.watchRecent().first;
+    expect(rows.map((r) => r.sourceCallsign), ['NEW']);
+  });
+
+  test('clearAll empties the table', () async {
+    await db.packetDao.insertPacket(packet('A'));
+    await db.packetDao.clearAll();
+    expect(await db.packetDao.watchRecent().first, isEmpty);
+  });
+}

--- a/test/database/station_dao_test.dart
+++ b/test/database/station_dao_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/core/packet/station.dart';
+import 'package:meridian_aprs/database/meridian_database.dart';
+
+import '../helpers/test_database.dart';
+
+void main() {
+  late MeridianDatabase db;
+
+  setUp(() => db = buildTestDatabase());
+  tearDown(() => db.close());
+
+  StationsCompanion station(
+    String callsign, {
+    int lastHeard = 1000,
+    double lat = 1.0,
+    double lon = 2.0,
+    StationType type = StationType.fixed,
+  }) => StationsCompanion.insert(
+    callsign: callsign,
+    symbolTable: '/',
+    symbolCode: '>',
+    comment: '',
+    rawPacket: '$callsign>APRS:!',
+    lastHeard: lastHeard,
+    stationType: type,
+    messageCapability: MessageCapability.unknown,
+    lat: lat,
+    lon: lon,
+  );
+
+  test('upsertStation inserts then updates on conflict', () async {
+    await db.stationDao.upsertStation(station('W1AW', lat: 1));
+    await db.stationDao.upsertStation(station('W1AW', lat: 9));
+
+    final all = await db.stationDao.getAllStations();
+    expect(all, hasLength(1));
+    expect(all.single.lat, 9);
+  });
+
+  test('enum columns round-trip', () async {
+    await db.stationDao.upsertStation(
+      station('W1AW', type: StationType.weather),
+    );
+    final row = await db.stationDao.getStation('W1AW');
+    expect(row!.stationType, StationType.weather);
+    expect(row.messageCapability, MessageCapability.unknown);
+  });
+
+  test('getPositionHistory returns entries oldest-first', () async {
+    await db.stationDao.upsertStation(station('W1AW'));
+    await db.stationDao.appendPositionHistory(
+      PositionHistoryCompanion.insert(
+        callsign: 'W1AW',
+        latitude: 1,
+        longitude: 1,
+        timestamp: 300,
+      ),
+    );
+    await db.stationDao.appendPositionHistory(
+      PositionHistoryCompanion.insert(
+        callsign: 'W1AW',
+        latitude: 2,
+        longitude: 2,
+        timestamp: 100,
+      ),
+    );
+    final history = await db.stationDao.getPositionHistory('W1AW');
+    expect(history.map((h) => h.timestamp), [100, 300]);
+  });
+
+  test(
+    'upsertWithPositionHistory appends previous + caps per station',
+    () async {
+      await db.stationDao.upsertStation(station('W1AW'));
+      // Append 5 history rows then upsert with cap of 3.
+      for (var i = 0; i < 5; i++) {
+        await db.stationDao.appendPositionHistory(
+          PositionHistoryCompanion.insert(
+            callsign: 'W1AW',
+            latitude: i.toDouble(),
+            longitude: 0,
+            timestamp: i,
+          ),
+        );
+      }
+      await db.stationDao.upsertWithPositionHistory(
+        station: station('W1AW', lat: 50),
+        previousPosition: PositionHistoryCompanion.insert(
+          callsign: 'W1AW',
+          latitude: 99,
+          longitude: 0,
+          timestamp: 99,
+        ),
+        capHistoryAt: 3,
+      );
+
+      final history = await db.stationDao.getPositionHistory('W1AW');
+      expect(history, hasLength(3));
+      // Newest three by timestamp survive: 3, 4, 99.
+      expect(history.map((h) => h.timestamp), [3, 4, 99]);
+    },
+  );
+
+  test('deleteByCallsign cascades position history', () async {
+    await db.stationDao.upsertStation(station('W1AW'));
+    await db.stationDao.appendPositionHistory(
+      PositionHistoryCompanion.insert(
+        callsign: 'W1AW',
+        latitude: 1,
+        longitude: 1,
+        timestamp: 1,
+      ),
+    );
+    await db.stationDao.deleteByCallsign('W1AW');
+
+    expect(await db.stationDao.getStation('W1AW'), isNull);
+    expect(await db.stationDao.getPositionHistory('W1AW'), isEmpty);
+  });
+
+  test('pruneOlderThan removes stations before cutoff and cascades', () async {
+    await db.stationDao.upsertStation(station('OLD', lastHeard: 100));
+    await db.stationDao.appendPositionHistory(
+      PositionHistoryCompanion.insert(
+        callsign: 'OLD',
+        latitude: 1,
+        longitude: 1,
+        timestamp: 100,
+      ),
+    );
+    await db.stationDao.upsertStation(station('NEW', lastHeard: 5000));
+
+    final removed = await db.stationDao.pruneOlderThan(
+      DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+    expect(removed, 1);
+    expect(await db.stationDao.getStation('OLD'), isNull);
+    expect(await db.stationDao.getPositionHistory('OLD'), isEmpty);
+    expect(await db.stationDao.getStation('NEW'), isNotNull);
+  });
+
+  test('watchAllStations emits on insert', () async {
+    final first = db.stationDao.watchAllStations().firstWhere(
+      (rows) => rows.isNotEmpty,
+    );
+    await db.stationDao.upsertStation(station('W1AW'));
+    expect(await first, hasLength(1));
+  });
+
+  test('clearAll empties both tables', () async {
+    await db.stationDao.upsertStation(station('W1AW'));
+    await db.stationDao.appendPositionHistory(
+      PositionHistoryCompanion.insert(
+        callsign: 'W1AW',
+        latitude: 1,
+        longitude: 1,
+        timestamp: 1,
+      ),
+    );
+    await db.stationDao.clearAll();
+    expect(await db.stationDao.getAllStations(), isEmpty);
+    expect(await db.stationDao.getAllPositionHistory(), isEmpty);
+  });
+}

--- a/test/helpers/test_database.dart
+++ b/test/helpers/test_database.dart
@@ -1,0 +1,18 @@
+import 'package:drift/drift.dart' show driftRuntimeOptions;
+import 'package:drift/native.dart';
+import 'package:meridian_aprs/database/meridian_database.dart';
+
+bool _suppressedWarnings = false;
+
+/// Build an in-memory `MeridianDatabase` for use in unit and widget tests.
+///
+/// Tests routinely construct multiple databases (per-test setUp, or one for
+/// the SUT plus a second for a regression fixture). drift warns about this
+/// by default — silence the warning once.
+MeridianDatabase buildTestDatabase() {
+  if (!_suppressedWarnings) {
+    driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+    _suppressedWarnings = true;
+  }
+  return MeridianDatabase(NativeDatabase.memory());
+}

--- a/test/integration/bulletin_cross_isolate_test.dart
+++ b/test/integration/bulletin_cross_isolate_test.dart
@@ -39,9 +39,13 @@ void main() {
         await driftIsolate.shutdownAll();
         IsolateNameServer.removePortNameMapping(_portName);
       });
-      IsolateNameServer.registerPortWithName(
-        driftIsolate.connectPort,
-        _portName,
+      expect(
+        IsolateNameServer.registerPortWithName(
+          driftIsolate.connectPort,
+          _portName,
+        ),
+        isTrue,
+        reason: 'failed to register drift connect port',
       );
 
       final mainDb = MeridianDatabase.connect(await driftIsolate.connect());
@@ -67,6 +71,7 @@ void main() {
 
       // Worker isolate (acting as the background service) bumps it.
       final workerDone = ReceivePort();
+      addTearDown(workerDone.close);
       await Isolate.spawn(_workerEntry, [workerDone.sendPort, ob.id]);
       final ack = await workerDone.first.timeout(const Duration(seconds: 5));
       expect(

--- a/test/integration/bulletin_cross_isolate_test.dart
+++ b/test/integration/bulletin_cross_isolate_test.dart
@@ -1,0 +1,108 @@
+/// Cross-isolate outgoing-bulletin propagation test for ADR-057/061 (ADR-062).
+///
+/// Proves the foreground/background state-drift fix end-to-end without an
+/// Android foreground service: an outgoing bulletin is created on the "main"
+/// connection, a worker isolate (standing in for the background isolate)
+/// connects to the *same* `meridian.db` via the shared `DriftIsolate` port and
+/// bumps the bulletin's transmission count, and the main-side
+/// [BulletinService] reflects the bump after [BulletinService.refreshOutgoing]
+/// — the same re-read the [BulletinScheduler] performs each tick.
+library;
+
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/isolate.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/database/meridian_database.dart';
+import 'package:meridian_aprs/services/bulletin_service.dart';
+import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _portName = 'meridian_drift_bulletin_test';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'background-isolate transmission bump is visible after refreshOutgoing',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      IsolateNameServer.removePortNameMapping(_portName);
+
+      final driftIsolate = await DriftIsolate.spawn(
+        () => DatabaseConnection(NativeDatabase.memory()),
+      );
+      addTearDown(() async {
+        await driftIsolate.shutdownAll();
+        IsolateNameServer.removePortNameMapping(_portName);
+      });
+      IsolateNameServer.registerPortWithName(
+        driftIsolate.connectPort,
+        _portName,
+      );
+
+      final mainDb = MeridianDatabase.connect(await driftIsolate.connect());
+      addTearDown(mainDb.close);
+
+      final prefs = await SharedPreferences.getInstance();
+      final subs = BulletinSubscriptionService(prefs: prefs);
+      await subs.load();
+      final service = BulletinService(
+        subscriptions: subs,
+        bulletinDao: mainDb.bulletinDao,
+        prefs: prefs,
+      );
+      await service.load();
+
+      // Main isolate creates an outgoing bulletin.
+      final ob = await service.createOutgoing(
+        addressee: 'BLN0',
+        body: 'cross-isolate',
+        intervalSeconds: 1800,
+      );
+      expect(service.outgoingById(ob.id)!.transmissionCount, 0);
+
+      // Worker isolate (acting as the background service) bumps it.
+      final workerDone = ReceivePort();
+      await Isolate.spawn(_workerEntry, [workerDone.sendPort, ob.id]);
+      final ack = await workerDone.first.timeout(const Duration(seconds: 5));
+      expect(
+        ack,
+        isTrue,
+        reason: 'worker isolate failed to record transmission',
+      );
+
+      // Before re-read, the main cache is still stale (polled, not pushed).
+      expect(service.outgoingById(ob.id)!.transmissionCount, 0);
+
+      // The scheduler's per-tick re-read picks up the background write.
+      await service.refreshOutgoing();
+      expect(service.outgoingById(ob.id)!.transmissionCount, 1);
+      expect(service.outgoingById(ob.id)!.lastTransmittedAt, isNotNull);
+    },
+  );
+}
+
+/// Background-isolate entrypoint: connects to the shared drift port and records
+/// one transmission against the given outgoing-bulletin id.
+void _workerEntry(List<Object> args) async {
+  final done = args[0] as SendPort;
+  final id = args[1] as int;
+  try {
+    final port = IsolateNameServer.lookupPortByName(_portName);
+    if (port == null) {
+      done.send(false);
+      return;
+    }
+    final isolate = DriftIsolate.fromConnectPort(port);
+    final db = MeridianDatabase.connect(await isolate.connect());
+    await db.bulletinDao.recordOutgoingTransmission(id, DateTime.now());
+    await db.close();
+    done.send(true);
+  } catch (_) {
+    done.send(false);
+  }
+}

--- a/test/integration/drift_isolate_test.dart
+++ b/test/integration/drift_isolate_test.dart
@@ -38,9 +38,13 @@ void main() {
         IsolateNameServer.removePortNameMapping(_portName);
       });
 
-      IsolateNameServer.registerPortWithName(
-        driftIsolate.connectPort,
-        _portName,
+      expect(
+        IsolateNameServer.registerPortWithName(
+          driftIsolate.connectPort,
+          _portName,
+        ),
+        isTrue,
+        reason: 'failed to register drift connect port',
       );
 
       final mainDb = MeridianDatabase.connect(await driftIsolate.connect());
@@ -58,6 +62,7 @@ void main() {
       addTearDown(sub.cancel);
 
       final workerDone = ReceivePort();
+      addTearDown(workerDone.close);
       await Isolate.spawn(_workerEntry, workerDone.sendPort);
 
       // Worker signals when its insert has been awaited.

--- a/test/integration/drift_isolate_test.dart
+++ b/test/integration/drift_isolate_test.dart
@@ -1,0 +1,101 @@
+/// Cross-isolate stream propagation test for ADR-062.
+///
+/// Spawns a dedicated drift isolate (owning an in-memory SQLite database),
+/// registers its connect port via `IsolateNameServer`, then spawns a *worker*
+/// isolate that looks up the port and inserts a packet row. The main isolate
+/// subscribes to `PacketDao.watchRecent()` and asserts the worker's insert
+/// arrives on the stream without any explicit re-read trigger — proving that
+/// the foreground/background-isolate state-drift problem documented in
+/// ADR-057 and ADR-061 is resolved by the shared `DriftIsolate` topology.
+library;
+
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:drift/drift.dart';
+import 'package:drift/isolate.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/packet/aprs_packet.dart' show PacketSource;
+import 'package:meridian_aprs/database/meridian_database.dart';
+import 'package:meridian_aprs/database/tables/packets.dart';
+
+const _portName = 'meridian_drift_port_test';
+
+void main() {
+  test(
+    'background-isolate write is visible on main-isolate watch() stream',
+    () async {
+      IsolateNameServer.removePortNameMapping(_portName);
+
+      final driftIsolate = await DriftIsolate.spawn(
+        () => DatabaseConnection(NativeDatabase.memory()),
+      );
+
+      addTearDown(() async {
+        await driftIsolate.shutdownAll();
+        IsolateNameServer.removePortNameMapping(_portName);
+      });
+
+      IsolateNameServer.registerPortWithName(
+        driftIsolate.connectPort,
+        _portName,
+      );
+
+      final mainDb = MeridianDatabase.connect(await driftIsolate.connect());
+      addTearDown(mainDb.close);
+
+      // Force schema creation (no rows; drift opens lazily on first query).
+      await mainDb.packetDao.watchRecent(limit: 1).first;
+
+      final received = Completer<List<PacketRow>>();
+      final sub = mainDb.packetDao.watchRecent(limit: 10).listen((rows) {
+        if (rows.isNotEmpty && !received.isCompleted) {
+          received.complete(rows);
+        }
+      });
+      addTearDown(sub.cancel);
+
+      final workerDone = ReceivePort();
+      await Isolate.spawn(_workerEntry, workerDone.sendPort);
+
+      // Worker signals when its insert has been awaited.
+      final ack = await workerDone.first.timeout(const Duration(seconds: 5));
+      expect(ack, isTrue, reason: 'worker isolate failed to insert');
+
+      final rows = await received.future.timeout(const Duration(seconds: 5));
+      expect(rows, hasLength(1));
+      expect(rows.single.rawLine, 'CROSS-ISOLATE>APMDN0:test');
+      expect(rows.single.sourceCallsign, 'CROSS-ISOLATE');
+      expect(rows.single.sourceChannel, PacketSource.aprsIs);
+    },
+  );
+}
+
+/// Background-isolate entrypoint: connects to the shared drift port and
+/// performs a single insert.
+void _workerEntry(SendPort done) async {
+  try {
+    final port = IsolateNameServer.lookupPortByName(_portName);
+    if (port == null) {
+      done.send(false);
+      return;
+    }
+    final isolate = DriftIsolate.fromConnectPort(port);
+    final db = MeridianDatabase.connect(await isolate.connect());
+    await db.packetDao.insertPacket(
+      PacketsCompanion.insert(
+        rawLine: 'CROSS-ISOLATE>APMDN0:test',
+        packetType: PacketTypeTag.unknown,
+        sourceCallsign: 'CROSS-ISOLATE',
+        receivedAt: DateTime.now().millisecondsSinceEpoch,
+        sourceChannel: PacketSource.aprsIs,
+      ),
+    );
+    await db.close();
+    done.send(true);
+  } catch (_) {
+    done.send(false);
+  }
+}

--- a/test/services/bulletin_scheduler_test.dart
+++ b/test/services/bulletin_scheduler_test.dart
@@ -16,6 +16,7 @@ import 'package:meridian_aprs/services/station_settings_service.dart';
 import 'package:meridian_aprs/services/tx_service.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Recording TxService — captures sendBulletin calls for assertion.
@@ -79,7 +80,13 @@ class _Fixture {
     final registry = ConnectionRegistry();
     final subs = BulletinSubscriptionService(prefs: prefs);
     await subs.load();
-    final bulletins = BulletinService(subscriptions: subs, prefs: prefs);
+    final db = buildTestDatabase();
+    addTearDown(db.close);
+    final bulletins = BulletinService(
+      subscriptions: subs,
+      bulletinDao: db.bulletinDao,
+      prefs: prefs,
+    );
     await bulletins.load();
     final messaging = MessagingSettingsService(prefs: prefs);
     await messaging.load();

--- a/test/services/bulletin_service_test.dart
+++ b/test/services/bulletin_service_test.dart
@@ -6,6 +6,8 @@ import 'package:meridian_aprs/models/bulletin.dart';
 import 'package:meridian_aprs/services/bulletin_service.dart';
 import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
 
+import '../helpers/test_database.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -19,7 +21,13 @@ void main() {
     for (final g in subscribedGroups) {
       await subs.add(groupName: g, notify: false);
     }
-    final bulletins = BulletinService(subscriptions: subs, prefs: prefs);
+    final db = buildTestDatabase();
+    addTearDown(db.close);
+    final bulletins = BulletinService(
+      subscriptions: subs,
+      bulletinDao: db.bulletinDao,
+      prefs: prefs,
+    );
     await bulletins.load();
     return (bulletins, subs);
   }
@@ -185,13 +193,23 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final subs = BulletinSubscriptionService(prefs: prefs);
       await subs.load();
-      final first = BulletinService(subscriptions: subs, prefs: prefs);
+      final db = buildTestDatabase();
+      addTearDown(db.close);
+      final first = BulletinService(
+        subscriptions: subs,
+        bulletinDao: db.bulletinDao,
+        prefs: prefs,
+      );
       await first.load();
       await first.setShowBulletins(false);
       await first.setRadiusKm(1000);
       await first.setRetentionHours(72);
 
-      final reloaded = BulletinService(subscriptions: subs, prefs: prefs);
+      final reloaded = BulletinService(
+        subscriptions: subs,
+        bulletinDao: db.bulletinDao,
+        prefs: prefs,
+      );
       await reloaded.load();
       expect(reloaded.showBulletins, isFalse);
       expect(reloaded.radiusKm, 1000);
@@ -200,12 +218,18 @@ void main() {
   });
 
   group('persistence + retention', () {
-    test('bulletins round-trip through SharedPreferences', () async {
+    test('incoming bulletins round-trip through drift', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
       final subs = BulletinSubscriptionService(prefs: prefs);
       await subs.load();
-      final first = BulletinService(subscriptions: subs, prefs: prefs);
+      final db = buildTestDatabase();
+      addTearDown(db.close);
+      final first = BulletinService(
+        subscriptions: subs,
+        bulletinDao: db.bulletinDao,
+        prefs: prefs,
+      );
       await first.load();
 
       first.ingest(
@@ -215,10 +239,14 @@ void main() {
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
       );
-      // Let persistence flush.
-      await Future<void>.delayed(Duration.zero);
+      // Let the write-through upsert flush to drift.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      final reloaded = BulletinService(subscriptions: subs, prefs: prefs);
+      final reloaded = BulletinService(
+        subscriptions: subs,
+        bulletinDao: db.bulletinDao,
+        prefs: prefs,
+      );
       await reloaded.load();
       expect(reloaded.bulletins, hasLength(1));
       expect(reloaded.bulletins.first.body, 'Alert');

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -21,6 +21,7 @@ import 'package:meridian_aprs/services/station_settings_service.dart';
 import 'package:meridian_aprs/services/tx_service.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Fixture
@@ -57,7 +58,11 @@ class _Fixture {
       prefs,
       store: FakeSecureCredentialStore(),
     );
-    final stationService = StationService();
+    final db = buildTestDatabase();
+    final stationService = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
     final registry = ConnectionRegistry();
     final sentLines = <String>[];
     final txService = _RecordingTxService(registry, settings, sentLines);
@@ -70,6 +75,7 @@ class _Fixture {
 
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -80,6 +86,7 @@ class _Fixture {
       stationService,
       groupSubscriptions: groupSubs,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
 
     return _Fixture._(

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -89,6 +89,12 @@ class _Fixture {
       messageDao: db.messageDao,
     );
 
+    addTearDown(() async {
+      service.dispose(); // cancels retry timers
+      await stationService.stop();
+      await db.close();
+    });
+
     return _Fixture._(
       service: service,
       stationService: stationService,

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -83,6 +83,11 @@ class _Fixture {
       bulletins: bulletins,
       messageDao: db.messageDao,
     );
+    addTearDown(() async {
+      messageService.dispose(); // cancels retry timers
+      await stationService.stop();
+      await db.close();
+    });
     return _Fixture._(
       service: messageService,
       stationService: stationService,

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -1,9 +1,10 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/database/meridian_database.dart'
+    show ConversationsCompanion, MessageEntriesCompanion;
+import 'package:meridian_aprs/models/message_category.dart';
 import 'package:meridian_aprs/services/bulletin_service.dart';
 import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
 import 'package:meridian_aprs/services/group_subscription_service.dart';
@@ -13,6 +14,7 @@ import 'package:meridian_aprs/services/station_settings_service.dart';
 import 'package:meridian_aprs/services/tx_service.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Test fixture
@@ -55,7 +57,11 @@ class _Fixture {
       prefs,
       store: FakeSecureCredentialStore(),
     );
-    final stationService = StationService();
+    final db = buildTestDatabase();
+    final stationService = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
     final registry = ConnectionRegistry();
     final sentLines = <String>[];
     final txService = _RecordingTxService(registry, settings, sentLines);
@@ -65,6 +71,7 @@ class _Fixture {
     await bulletinSubs.load();
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -74,6 +81,7 @@ class _Fixture {
       stationService,
       groupSubscriptions: groupSubs,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
     return _Fixture._(
       service: messageService,
@@ -440,44 +448,48 @@ void main() {
     );
   });
 
-  // --- Legacy addressee=null deserialization ------------------------------
+  // --- Null-addressee entry round-trips from drift ------------------------
 
-  group('legacy serialization', () {
+  group('drift persistence', () {
     test(
-      'entry without addressee key deserializes with null, isCrossSsid false',
+      'entry with null addressee loads back with null, isCrossSsid false',
       () async {
-        // Seed SharedPreferences with a persisted conversation whose message
-        // has no 'addressee' key (simulating data written before this feature).
-        final legacyEntry = {
-          'localId': 'KB1XYZ:Hello',
-          'wireId': null,
-          'text': 'Hello',
-          'timestamp': DateTime.now().millisecondsSinceEpoch,
-          'isOutgoing': false,
-          'status': 'acked',
-          'retryCount': 0,
-          // No 'addressee' key.
-        };
-        final legacyConv = {
-          'peer': 'KB1XYZ',
-          'unreadCount': 0,
-          'lastActivity': DateTime.now().millisecondsSinceEpoch,
-          'messages': [legacyEntry],
-        };
-
         SharedPreferences.setMockInitialValues({
           'user_callsign': 'W1AW',
           'user_ssid': 9,
           'message_id_counter': 0,
-          'msg_peers': jsonEncode(['KB1XYZ']),
-          'msg_conv_KB1XYZ': jsonEncode(legacyConv),
         });
         final prefs = await SharedPreferences.getInstance();
         final settings = StationSettingsService(
           prefs,
           store: FakeSecureCredentialStore(),
         );
-        final stationService = StationService();
+        final db = buildTestDatabase();
+
+        // Seed the database directly with a conversation + entry whose
+        // addressee is null (mirrors data captured before cross-SSID support).
+        await db.messageDao.upsertConversation(
+          ConversationsCompanion.insert(
+            peerCallsign: 'KB1XYZ',
+            lastMessageAt: DateTime.now().millisecondsSinceEpoch,
+          ),
+        );
+        await db.messageDao.insertEntry(
+          MessageEntriesCompanion.insert(
+            id: 'KB1XYZ:Hello',
+            conversationPeer: 'KB1XYZ',
+            body: 'Hello',
+            timestamp: DateTime.now().millisecondsSinceEpoch,
+            isOutgoing: false,
+            status: MessageStatus.acked,
+            category: MessageCategory.direct,
+          ),
+        );
+
+        final stationService = StationService(
+          stationDao: db.stationDao,
+          packetDao: db.packetDao,
+        );
         final registry = ConnectionRegistry();
         final sentLines = <String>[];
         final txService = _RecordingTxService(registry, settings, sentLines);
@@ -487,6 +499,7 @@ void main() {
         await bulletinSubs.load();
         final bulletins = BulletinService(
           subscriptions: bulletinSubs,
+          bulletinDao: db.bulletinDao,
           prefs: prefs,
         );
         await bulletins.load();
@@ -496,6 +509,7 @@ void main() {
           stationService,
           groupSubscriptions: groupSubs,
           bulletins: bulletins,
+          messageDao: db.messageDao,
         );
         await service.loadHistory();
 
@@ -504,6 +518,168 @@ void main() {
         final entry = conv!.messages.first;
         expect(entry.addressee, isNull);
         expect(entry.isCrossSsid(service.myFullAddress), isFalse);
+        await stationService.stop();
+        await db.close();
+      },
+    );
+
+    test('a sent message survives a service restart on the same DB', () async {
+      SharedPreferences.setMockInitialValues({
+        'user_callsign': 'W1AW',
+        'user_ssid': 9,
+        'message_id_counter': 0,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final settings = StationSettingsService(
+        prefs,
+        store: FakeSecureCredentialStore(),
+      );
+      final db = buildTestDatabase();
+      final registry = ConnectionRegistry();
+      final groupSubs = GroupSubscriptionService(prefs: prefs);
+      await groupSubs.load();
+      final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+      await bulletinSubs.load();
+      final bulletins = BulletinService(
+        subscriptions: bulletinSubs,
+        bulletinDao: db.bulletinDao,
+        prefs: prefs,
+      );
+      await bulletins.load();
+
+      MessageService buildService(StationService stations) => MessageService(
+        settings,
+        _RecordingTxService(registry, settings, <String>[]),
+        stations,
+        groupSubscriptions: groupSubs,
+        bulletins: bulletins,
+        messageDao: db.messageDao,
+      );
+
+      final stations1 = StationService(
+        stationDao: db.stationDao,
+        packetDao: db.packetDao,
+      );
+      final svc1 = buildService(stations1);
+      await svc1.sendMessage('KB1XYZ', 'persisted hello');
+      expect(svc1.conversationWith('KB1XYZ')?.messages, hasLength(1));
+      svc1.dispose();
+      await stations1.stop();
+
+      // New service instance against the same database.
+      final stations2 = StationService(
+        stationDao: db.stationDao,
+        packetDao: db.packetDao,
+      );
+      final svc2 = buildService(stations2);
+      await svc2.loadHistory();
+
+      final conv = svc2.conversationWith('KB1XYZ');
+      expect(conv, isNotNull);
+      expect(conv!.messages.single.text, 'persisted hello');
+      // In-flight (pending) outgoing send was demoted to failed on reload.
+      expect(conv.messages.single.status, MessageStatus.failed);
+
+      svc2.dispose();
+      await stations2.stop();
+      await db.close();
+    });
+
+    test(
+      'setMessageHistoryDays prunes aged direct + group entries from drift',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'user_callsign': 'W1AW',
+          'user_ssid': 9,
+          'message_id_counter': 0,
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final settings = StationSettingsService(
+          prefs,
+          store: FakeSecureCredentialStore(),
+        );
+        final db = buildTestDatabase();
+
+        final now = DateTime.now();
+        final oldTs = now.subtract(const Duration(days: 60));
+        final freshTs = now.subtract(const Duration(days: 2));
+
+        // Seed: an old direct thread, an old group thread, a fresh direct
+        // thread. Default retention (90 d) keeps all on load; 30 d prunes the
+        // two 60-day-old threads and drops their now-empty conversation rows.
+        Future<void> seed(
+          String peer,
+          String id,
+          DateTime ts,
+          MessageCategory category,
+        ) async {
+          await db.messageDao.upsertConversation(
+            ConversationsCompanion.insert(
+              peerCallsign: peer,
+              lastMessageAt: ts.millisecondsSinceEpoch,
+            ),
+          );
+          await db.messageDao.insertEntry(
+            MessageEntriesCompanion.insert(
+              id: id,
+              conversationPeer: peer,
+              body: 'body',
+              timestamp: ts.millisecondsSinceEpoch,
+              isOutgoing: false,
+              status: MessageStatus.acked,
+              category: category,
+            ),
+          );
+        }
+
+        await seed('KB1XYZ', 'KB1XYZ:old', oldTs, MessageCategory.direct);
+        await seed('#GROUP:WX', 'group_WX_old', oldTs, MessageCategory.group);
+        await seed('W2ABC', 'W2ABC:fresh', freshTs, MessageCategory.direct);
+
+        final stations = StationService(
+          stationDao: db.stationDao,
+          packetDao: db.packetDao,
+        );
+        final registry = ConnectionRegistry();
+        final groupSubs = GroupSubscriptionService(prefs: prefs);
+        await groupSubs.load();
+        final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
+        await bulletinSubs.load();
+        final bulletins = BulletinService(
+          subscriptions: bulletinSubs,
+          bulletinDao: db.bulletinDao,
+          prefs: prefs,
+        );
+        await bulletins.load();
+        final service = MessageService(
+          settings,
+          _RecordingTxService(registry, settings, <String>[]),
+          stations,
+          groupSubscriptions: groupSubs,
+          bulletins: bulletins,
+          messageDao: db.messageDao,
+        );
+        await service.loadHistory();
+
+        // Default retention keeps everything.
+        expect(service.conversationWith('KB1XYZ'), isNotNull);
+        expect(service.conversationWith('#GROUP:WX'), isNotNull);
+        expect(service.conversationWith('W2ABC'), isNotNull);
+
+        await service.setMessageHistoryDays(30);
+
+        // Aged direct + group threads gone (in memory and in drift); fresh kept.
+        expect(service.conversationWith('KB1XYZ'), isNull);
+        expect(service.conversationWith('#GROUP:WX'), isNull);
+        expect(service.conversationWith('W2ABC'), isNotNull);
+
+        // Empty conversation rows were swept from drift.
+        final convRows = await db.messageDao.getAllConversations();
+        expect(convRows.map((c) => c.peerCallsign), ['W2ABC']);
+
+        service.dispose();
+        await stations.stop();
+        await db.close();
       },
     );
   });

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -17,6 +17,7 @@ import 'package:meridian_aprs/services/tx_service.dart';
 import 'package:meridian_aprs/ui/widgets/in_app_banner_overlay.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -54,7 +55,11 @@ class _Fixture {
       prefs,
       store: FakeSecureCredentialStore(),
     );
-    final stationService = StationService();
+    final db = buildTestDatabase();
+    final stationService = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
     final registry = ConnectionRegistry();
     final txService = _SilentTxService(registry, settings);
     final groupSubs = GroupSubscriptionService(prefs: prefs);
@@ -63,6 +68,7 @@ class _Fixture {
     await bulletinSubs.load();
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -72,6 +78,7 @@ class _Fixture {
       stationService,
       groupSubscriptions: groupSubs,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
     final bannerController = InAppBannerController();
 

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:meridian_aprs/core/connection/connection_registry.dart';
+import 'package:meridian_aprs/database/meridian_database.dart';
 import 'package:meridian_aprs/models/notification_preferences.dart';
 import 'package:meridian_aprs/services/bulletin_service.dart';
 import 'package:meridian_aprs/services/bulletin_subscription_service.dart';
@@ -31,12 +32,14 @@ class _Fixture {
     required this.notificationService,
     required this.bannerController,
     required this.stationService,
+    required this.db,
   });
 
   final MessageService messageService;
   final NotificationService notificationService;
   final InAppBannerController bannerController;
   final StationService stationService;
+  final MeridianDatabase db;
 
   static Future<_Fixture> create({
     String callsign = 'W1AW',
@@ -104,15 +107,18 @@ class _Fixture {
       notificationService: notificationService,
       bannerController: bannerController,
       stationService: stationService,
+      db: db,
     );
   }
 
-  void dispose() {
+  Future<void> dispose() async {
     messageService.removeListener(
       notificationService.handleMessageServiceChange,
     );
     notificationService.dispose();
     messageService.dispose();
+    await stationService.stop();
+    await db.close();
   }
 
   void injectInbound(String from, String text, {String msgId = '042'}) {

--- a/test/services/send_group_message_test.dart
+++ b/test/services/send_group_message_test.dart
@@ -18,6 +18,7 @@ import 'package:meridian_aprs/services/station_settings_service.dart';
 import 'package:meridian_aprs/services/tx_service.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 class _SendCapture {
   _SendCapture(this.line, this.digipeaterPath, this.forceVia);
@@ -55,20 +56,26 @@ Future<MessageService> _buildService({
   );
   final registry = ConnectionRegistry();
   final tx = _CapturingTxService(registry, settings, sends);
+  final db = buildTestDatabase();
 
   final groups = GroupSubscriptionService(prefs: prefs);
   await groups.load();
   final bulletinSubs = BulletinSubscriptionService(prefs: prefs);
   await bulletinSubs.load();
-  final bulletins = BulletinService(subscriptions: bulletinSubs, prefs: prefs);
+  final bulletins = BulletinService(
+    subscriptions: bulletinSubs,
+    bulletinDao: db.bulletinDao,
+    prefs: prefs,
+  );
   await bulletins.load();
 
   return MessageService(
     settings,
     tx,
-    StationService(),
+    StationService(stationDao: db.stationDao, packetDao: db.packetDao),
     groupSubscriptions: groups,
     bulletins: bulletins,
+    messageDao: db.messageDao,
   );
 }
 

--- a/test/services/send_group_message_test.dart
+++ b/test/services/send_group_message_test.dart
@@ -69,10 +69,19 @@ Future<MessageService> _buildService({
   );
   await bulletins.load();
 
+  final stationService = StationService(
+    stationDao: db.stationDao,
+    packetDao: db.packetDao,
+  );
+  addTearDown(() async {
+    await stationService.stop();
+    await db.close();
+  });
+
   return MessageService(
     settings,
     tx,
-    StationService(stationDao: db.stationDao, packetDao: db.packetDao),
+    stationService,
     groupSubscriptions: groups,
     bulletins: bulletins,
     messageDao: db.messageDao,

--- a/test/services/station_service_test.dart
+++ b/test/services/station_service_test.dart
@@ -4,20 +4,28 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:meridian_aprs/core/connection/connection_registry.dart';
 import 'package:meridian_aprs/core/packet/aprs_packet.dart';
 import 'package:meridian_aprs/core/packet/station.dart';
+import 'package:meridian_aprs/database/meridian_database.dart';
 import 'package:meridian_aprs/services/station_service.dart';
 
 import '../helpers/fake_meridian_connection.dart';
+import '../helpers/test_database.dart';
 
 void main() {
+  late MeridianDatabase db;
   late StationService service;
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
-    service = StationService();
+    db = buildTestDatabase();
+    service = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
   });
 
   tearDown(() async {
     await service.stop();
+    await db.close();
   });
 
   // ---------------------------------------------------------------------------
@@ -29,8 +37,9 @@ void main() {
       final packets = <AprsPacket>[];
       service.packetStream.listen(packets.add);
 
-      service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Comment');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Comment',
+      );
 
       expect(packets, hasLength(1));
       expect(packets.first.rawLine, contains('W1AW'));
@@ -40,8 +49,7 @@ void main() {
       final packets = <AprsPacket>[];
       service.packetStream.listen(packets.add);
 
-      service.ingestLine('# logresp W1AW unverified');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('# logresp W1AW unverified');
 
       expect(packets, isEmpty);
     });
@@ -50,8 +58,7 @@ void main() {
       final packets = <AprsPacket>[];
       service.packetStream.listen(packets.add);
 
-      service.ingestLine('');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('');
 
       expect(packets, isEmpty);
     });
@@ -62,18 +69,18 @@ void main() {
         final stationMaps = <Map<String, dynamic>>[];
         service.stationUpdates.listen((m) => stationMaps.add(m));
 
-        service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Comment');
-        await Future<void>.delayed(Duration.zero);
+        await service.ingestLine(
+          'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Comment',
+        );
 
-        expect(stationMaps, hasLength(1));
+        expect(stationMaps, isNotEmpty);
         expect(service.currentStations, contains('W1AW'));
       },
     );
 
     test('adds to recentPackets with newest first', () async {
-      service.ingestLine('W1AW>APMDN0:!4903.50N/07201.75W>A');
-      service.ingestLine('W2XY>APMDN0:!3234.00N/08901.00W>B');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1AW>APMDN0:!4903.50N/07201.75W>A');
+      await service.ingestLine('W2XY>APMDN0:!3234.00N/08901.00W>B');
 
       expect(service.recentPackets, hasLength(2));
       expect(service.recentPackets.first.rawLine, contains('W2XY'));
@@ -83,11 +90,10 @@ void main() {
       final packets = <AprsPacket>[];
       service.packetStream.listen(packets.add);
 
-      service.ingestLine(
+      await service.ingestLine(
         'W1AW>APMDN0:!4903.50N/07201.75W>TNC test',
         source: PacketSource.tnc,
       );
-      await Future<void>.delayed(Duration.zero);
 
       expect(packets.first.transportSource, PacketSource.tnc);
     });
@@ -99,22 +105,19 @@ void main() {
 
   group('StationType classification', () {
     test('position packet with car symbol is classified as mobile', () async {
-      service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Car');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>Car');
       expect(service.currentStations['W1AW']?.type, StationType.mobile);
     });
 
     test('position packet with house symbol is classified as fixed', () async {
-      // Primary table '-' is a house/home
-      service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W-Fixed');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W-Fixed');
       expect(service.currentStations['W1AW']?.type, StationType.fixed);
     });
 
     test('position packet with wx symbol is classified as weather', () async {
-      // Primary table '_' is a weather station
-      service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W_Weather');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W_Weather',
+      );
       expect(service.currentStations['W1AW']?.type, StationType.weather);
     });
   });
@@ -125,8 +128,7 @@ void main() {
 
   group('MessageCapability', () {
     test('position with `!` DTI is unsupported', () async {
-      service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>NoMsg');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>NoMsg');
       expect(
         service.currentStations['W1AW']?.messageCapability,
         MessageCapability.unsupported,
@@ -134,8 +136,9 @@ void main() {
     });
 
     test('position with `=` DTI is supported', () async {
-      service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>WithMsg');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>WithMsg',
+      );
       expect(
         service.currentStations['W1AW']?.messageCapability,
         MessageCapability.supported,
@@ -143,39 +146,33 @@ void main() {
     });
 
     test('object packet defaults to unknown', () async {
-      service.ingestLine('W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
       expect(
         service.currentStations['HOSPITAL']?.messageCapability,
         MessageCapability.unknown,
       );
     });
 
-    test(
-      'merge keeps known supported value when later object packet would be unknown',
-      () async {
-        // Position-supported first, then a later object reusing same callsign
-        // shouldn't clobber a known capability with unknown — but objects are
-        // keyed differently anyway. Use a position->position transition where
-        // a later identical position keeps the supported flag.
-        service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>First');
-        await Future<void>.delayed(Duration.zero);
-        service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>Second');
-        await Future<void>.delayed(Duration.zero);
-        expect(
-          service.currentStations['W1AW']?.messageCapability,
-          MessageCapability.supported,
-        );
-      },
-    );
+    test('two consecutive supported positions retain supported', () async {
+      await service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>First');
+      await service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>Second');
+      expect(
+        service.currentStations['W1AW']?.messageCapability,
+        MessageCapability.supported,
+      );
+    });
 
     test(
       'later position packet overrides prior capability (unsupported→supported)',
       () async {
-        service.ingestLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>NoMsg');
-        await Future<void>.delayed(Duration.zero);
-        service.ingestLine('W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>WithMsg');
-        await Future<void>.delayed(Duration.zero);
+        await service.ingestLine(
+          'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>NoMsg',
+        );
+        await service.ingestLine(
+          'W1AW>APMDN0,TCPIP*:=4903.50N/07201.75W>WithMsg',
+        );
         expect(
           service.currentStations['W1AW']?.messageCapability,
           MessageCapability.supported,
@@ -190,22 +187,23 @@ void main() {
 
   group('ObjectPacket handling', () {
     test('alive object adds a station keyed by object name', () async {
-      service.ingestLine('W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
 
       expect(service.currentStations, contains('HOSPITAL'));
       expect(service.currentStations['HOSPITAL']?.type, StationType.object);
     });
 
     test('killed object removes the station', () async {
-      // Add the object first
-      service.ingestLine('W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1ABC>APRS:;HOSPITAL *092345z4903.50N/07201.75W/',
+      );
       expect(service.currentStations, contains('HOSPITAL'));
 
-      // Then kill it
-      service.ingestLine('W1ABC>APRS:;HOSPITAL _092345z4903.50N/07201.75W/');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine(
+        'W1ABC>APRS:;HOSPITAL _092345z4903.50N/07201.75W/',
+      );
 
       expect(service.currentStations, isNot(contains('HOSPITAL')));
     });
@@ -213,20 +211,17 @@ void main() {
 
   group('ItemPacket handling', () {
     test('alive item adds a station keyed by item name', () async {
-      service.ingestLine('W1ABC>APRS:)RELAY !4903.50N/07201.75W-');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1ABC>APRS:)RELAY !4903.50N/07201.75W-');
 
       expect(service.currentStations, contains('RELAY'));
       expect(service.currentStations['RELAY']?.type, StationType.object);
     });
 
     test('killed item removes the station', () async {
-      service.ingestLine('W1ABC>APRS:)RELAY !4903.50N/07201.75W-');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1ABC>APRS:)RELAY !4903.50N/07201.75W-');
       expect(service.currentStations, contains('RELAY'));
 
-      service.ingestLine('W1ABC>APRS:)RELAY _4903.50N/07201.75W-');
-      await Future<void>.delayed(Duration.zero);
+      await service.ingestLine('W1ABC>APRS:)RELAY _4903.50N/07201.75W-');
 
       expect(service.currentStations, isNot(contains('RELAY')));
     });
@@ -252,36 +247,79 @@ void main() {
     test('setHiddenTypes persists to SharedPreferences', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      final svc = StationService();
-      await svc.loadPersistedHistory(prefs);
+      final localDb = buildTestDatabase();
+      final svc = StationService(
+        stationDao: localDb.stationDao,
+        packetDao: localDb.packetDao,
+      );
+      await svc.loadPersistedSettings(prefs);
 
       await svc.setHiddenTypes({StationType.fixed});
 
       final stored = prefs.getStringList('station_hidden_types');
       expect(stored, contains('fixed'));
       await svc.stop();
+      await localDb.close();
     });
 
-    test('loadPersistedHistory restores hiddenTypes', () async {
+    test('loadPersistedSettings restores hiddenTypes', () async {
       SharedPreferences.setMockInitialValues({
         'station_hidden_types': ['weather', 'mobile'],
-        'station_history_v1': '[]',
       });
       final prefs = await SharedPreferences.getInstance();
-      final svc = StationService();
-      await svc.loadPersistedHistory(prefs);
+      final localDb = buildTestDatabase();
+      final svc = StationService(
+        stationDao: localDb.stationDao,
+        packetDao: localDb.packetDao,
+      );
+      await svc.loadPersistedSettings(prefs);
 
       expect(
         svc.hiddenTypes,
         containsAll([StationType.weather, StationType.mobile]),
       );
       await svc.stop();
+      await localDb.close();
     });
 
     test('hiddenTypes getter returns unmodifiable set', () async {
       await service.setHiddenTypes({StationType.fixed});
       final types = service.hiddenTypes;
       expect(() => types.add(StationType.other), throwsUnsupportedError);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Drift persistence (ADR-062) — what was previously the
+  // `loadPersistedHistory` group is replaced by these tests.
+  // ---------------------------------------------------------------------------
+
+  group('drift persistence', () {
+    test('ingested packets survive service restart with the same DB', () async {
+      await service.ingestLine('W1AW>APMDN0:!4903.50N/07201.75W>Hello');
+      await service.stop();
+
+      final svc2 = StationService(
+        stationDao: db.stationDao,
+        packetDao: db.packetDao,
+      );
+      // The watch-stream cache hydrates on first emission; await one stream
+      // tick so the snapshot is populated before reading.
+      await svc2.stationUpdates.first;
+
+      expect(svc2.currentStations, contains('W1AW'));
+      await svc2.stop();
+    });
+
+    test('clearPacketLog wipes underlying drift rows', () async {
+      await service.ingestLine('W1AW>APMDN0:!4903.50N/07201.75W>Hello');
+      expect(service.recentPackets, hasLength(1));
+
+      await service.clearPacketLog();
+
+      expect(service.recentPackets, isEmpty);
+      final rows = await db.packetDao.watchRecent(limit: 10).first;
+      expect(rows, isEmpty);
     });
   });
 
@@ -307,41 +345,6 @@ void main() {
 
     test('disconnectAprsIs() is a no-op', () async {
       await expectLater(service.disconnectAprsIs(), completes);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // history persistence
-  // ---------------------------------------------------------------------------
-
-  group('loadPersistedHistory', () {
-    test('restores packets from shared preferences', () async {
-      final now = DateTime.now().millisecondsSinceEpoch;
-      SharedPreferences.setMockInitialValues({
-        'packet_log_v1':
-            '[{"raw":"W1AW>APMDN0:>Test","src":"aprs_is","ts":$now}]',
-        'station_history_v1': '[]',
-      });
-      final prefs = await SharedPreferences.getInstance();
-      final svc = StationService();
-      await svc.loadPersistedHistory(prefs);
-
-      expect(svc.recentPackets, hasLength(1));
-      await svc.stop();
-    });
-
-    test('maps legacy "tnc" source to PacketSource.tnc', () async {
-      final now = DateTime.now().millisecondsSinceEpoch;
-      SharedPreferences.setMockInitialValues({
-        'packet_log_v1': '[{"raw":"W1AW>APMDN0:>Test","src":"tnc","ts":$now}]',
-        'station_history_v1': '[]',
-      });
-      final prefs = await SharedPreferences.getInstance();
-      final svc = StationService();
-      await svc.loadPersistedHistory(prefs);
-
-      expect(svc.recentPackets.first.transportSource, PacketSource.tnc);
-      await svc.stop();
     });
   });
 
@@ -393,7 +396,8 @@ void main() {
       aprsIs.simulateLine('W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>via IS');
       bleTnc.simulateLine('W2BLE>APMDN0:!4903.50N/07201.75W>via BLE');
       serial.simulateLine('W3SER>APMDN0:!4903.50N/07201.75W>via Serial');
-      await Future<void>.delayed(Duration.zero);
+      // Allow ingest chain to drain.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(packets, hasLength(3));
       expect(
@@ -414,15 +418,8 @@ void main() {
 
     test('stop() cancels the registry subscription', () async {
       service.attach(registry);
-
-      // Capture the active line stream before stop closes packetStream.
-      // After stop, simulating a line must not throw and must not produce
-      // any further side effects.
       await service.stop();
 
-      // No throw is the assertion: the service has detached cleanly and
-      // late-arriving lines from the registry do not hit the closed
-      // packet controller.
       expect(
         () => aprsIs.simulateLine(
           'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W>after stop',

--- a/test/widget/messages/messages_screen_test.dart
+++ b/test/widget/messages/messages_screen_test.dart
@@ -34,6 +34,7 @@ import 'package:meridian_aprs/services/tx_service.dart';
 
 import '../../helpers/fake_meridian_connection.dart';
 import '../../helpers/fake_secure_credential_store.dart';
+import '../../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -94,7 +95,15 @@ class _Harness {
       aprsIsConn.setStatus(ConnectionStatus.connected);
     }
 
-    final stationService = StationService();
+    final db = buildTestDatabase();
+    final stationService = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
+    addTearDown(() async {
+      await stationService.stop();
+      await db.close();
+    });
     final tx = TxService(registry, settings);
 
     final groupSubs = GroupSubscriptionService(prefs: prefs);
@@ -103,6 +112,7 @@ class _Harness {
     await bulletinSubs.load();
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -119,6 +129,7 @@ class _Harness {
       stationService,
       groupSubscriptions: groupSubs,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
 
     // Seed notification prefs so downstream widgets that read them don't

--- a/test/widget/settings/messaging_screen_test.dart
+++ b/test/widget/settings/messaging_screen_test.dart
@@ -25,6 +25,7 @@ import 'package:meridian_aprs/services/tx_service.dart';
 import 'package:meridian_aprs/ui/widgets/in_app_banner_overlay.dart';
 
 import '../../helpers/fake_secure_credential_store.dart';
+import '../../helpers/test_database.dart';
 
 // ---------------------------------------------------------------------------
 // Test harness
@@ -58,7 +59,11 @@ class _Harness {
       store: FakeSecureCredentialStore(),
     );
     final registry = ConnectionRegistry();
-    final stationService = StationService();
+    final db = buildTestDatabase();
+    final stationService = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
     final tx = TxService(registry, settings);
 
     final groups = GroupSubscriptionService(prefs: prefs);
@@ -67,6 +72,7 @@ class _Harness {
     await bulletinSubs.load();
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -80,6 +86,7 @@ class _Harness {
       stationService,
       groupSubscriptions: groups,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
     final notifService = NotificationService(
       messageService: messageService,

--- a/test/widget/settings/messaging_screen_test.dart
+++ b/test/widget/settings/messaging_screen_test.dart
@@ -64,6 +64,10 @@ class _Harness {
       stationDao: db.stationDao,
       packetDao: db.packetDao,
     );
+    addTearDown(() async {
+      await stationService.stop();
+      await db.close();
+    });
     final tx = TxService(registry, settings);
 
     final groups = GroupSubscriptionService(prefs: prefs);

--- a/test/widget/station_info_sheet_test.dart
+++ b/test/widget/station_info_sheet_test.dart
@@ -27,6 +27,9 @@ Future<void> _pumpSheet(WidgetTester tester, {required Station station}) async {
     stationDao: db.stationDao,
     packetDao: db.packetDao,
   );
+  // Registered after db.close so it runs first (LIFO): stop the service's
+  // subscriptions/timers before the database they touch is closed.
+  addTearDown(stationService.stop);
   final stationSettings = StationSettingsService(
     prefs,
     store: FakeSecureCredentialStore(),

--- a/test/widget/station_info_sheet_test.dart
+++ b/test/widget/station_info_sheet_test.dart
@@ -16,11 +16,17 @@ import 'package:meridian_aprs/services/tx_service.dart';
 import 'package:meridian_aprs/ui/widgets/station_info_sheet.dart';
 
 import '../helpers/fake_secure_credential_store.dart';
+import '../helpers/test_database.dart';
 
 Future<void> _pumpSheet(WidgetTester tester, {required Station station}) async {
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
-  final stationService = StationService();
+  final db = buildTestDatabase();
+  addTearDown(db.close);
+  final stationService = StationService(
+    stationDao: db.stationDao,
+    packetDao: db.packetDao,
+  );
   final stationSettings = StationSettingsService(
     prefs,
     store: FakeSecureCredentialStore(),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -17,6 +17,7 @@ import 'package:meridian_aprs/services/tx_service.dart';
 
 import 'helpers/fake_meridian_connection.dart';
 import 'helpers/fake_secure_credential_store.dart';
+import 'helpers/test_database.dart';
 
 void main() {
   testWidgets('MapScreen renders without throwing', (
@@ -35,7 +36,15 @@ void main() {
     );
     registry.register(aprsIsConn);
 
-    final service = StationService();
+    final db = buildTestDatabase();
+    final service = StationService(
+      stationDao: db.stationDao,
+      packetDao: db.packetDao,
+    );
+    addTearDown(() async {
+      await service.stop();
+      await db.close();
+    });
     final stationSettings = StationSettingsService(
       prefs,
       store: FakeSecureCredentialStore(),
@@ -48,6 +57,7 @@ void main() {
     await bulletinSubs.load();
     final bulletins = BulletinService(
       subscriptions: bulletinSubs,
+      bulletinDao: db.bulletinDao,
       prefs: prefs,
     );
     await bulletins.load();
@@ -57,6 +67,7 @@ void main() {
       service,
       groupSubscriptions: groupSubs,
       bulletins: bulletins,
+      messageDao: db.messageDao,
     );
     final bgServiceManager = BackgroundServiceManager(
       registry: registry,


### PR DESCRIPTION
## Summary

Replaces SharedPreferences JSON blobs and in-memory collections with a single **drift-managed SQLite database** (`meridian.db`) for all structured, volumetric data: stations, position history, packets, conversations, direct/group messages, and incoming/outgoing bulletins. Implements **ADR-062** and graduates ROADMAP #87 from spike to implementation.

The headline win is correctness: the Android background isolate and the main isolate now share **one** database, which resolves the foreground/background outgoing-bulletin state drift documented in **ADR-057 / ADR-061**.

## What changed

**Database (`lib/database/`)**
- 8 tables, 4 DAOs (`Station` / `Packet` / `Message` / `Bulletin`), full-fidelity columns.
- `textEnum` storage for enums + a `TypeConverter` for the bulletin transports set.
- FK `ON DELETE CASCADE` (`PRAGMA foreign_keys = ON` in `beforeOpen`) + indexes on the hot query paths.
- **Multi-isolate sharing:** main spawns a `DriftIsolate` and registers its `connectPort` via `IsolateNameServer` (`meridian_drift_port`); the Android background isolate looks it up lazily and shares the same DB. (The handoff's pass-a-`SendPort` approach is impossible through `flutter_foreground_task`'s start-data channel — `IsolateNameServer` is the supported seam.)

**Service migration**
- **StationService** — watch-driven cached snapshots (sync getters preserved); per-packet writes in a transaction (append-previous-position + capped upsert); 60 s prune timer started in `attach()`.
- **MessageService** — in-memory working set with **targeted write-through** (deliberately *no* watch — the retry scheduler holds live `MessageEntry` references that a watch rebuild would orphan); startup sweep demotes in-flight (`pending`/`retrying`) entries to `failed`; age + empty-conversation pruning.
- **BulletinService / BulletinScheduler** — incoming write-through; outgoing **polled per tick** via `refreshOutgoing()` (fresh read, not watch — avoids a write-through/watch revert race that could re-transmit a just-disabled bulletin) and on app resume.
- **meridian_connection_task** — background bulletin tick reads/writes the shared DB; the SharedPreferences JSON path is removed.

**Behavior notes**
- First launch **silently resets** (old JSON keys orphaned, not migrated) — consistent with ADR-062.
- Settings scalars stay in SharedPreferences. Message retention stays in **Settings → History** (existing convention).

## Testing

**Automated** — 791 tests pass (`flutter test`); `dart format` clean; `flutter analyze` clean; `flutter build linux --debug` succeeds (CI parity). New coverage:
- `test/database/` — per-DAO unit tests (history cap, FK cascade, `demoteInFlightToFailed` enum comparison, `pruneEmptyConversations`, transports converter, on-conflict upsert, autoincrement).
- `test/integration/drift_isolate_test.dart` — cross-isolate write → main watch-stream propagation.
- `test/integration/bulletin_cross_isolate_test.dart` — background bumps outgoing transmission count, main sees it after `refreshOutgoing()`.
- Service + widget tests updated for DAO injection.

**Manual smoke (Android + Linux)** — confirmed by maintainer:
- Send/receive direct messages, group messages, and bulletins.
- Foreground and background operation.
- Close/reopen → persistence verified.
- Both APRS-IS and BLE transports on Android.

## Docs
- `docs/DECISIONS.md` — ADR-062 (as-built, documenting the `IsolateNameServer`, no-watch MessageService, polled-outgoing, and reserved `group_message_entries` deviations).
- `docs/CAPABILITIES.md` — persistence sections updated.
- `docs/ROADMAP.md` — #87 marked complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent SQLite-backed storage for stations, messages, bulletins, and packet logs across restarts.
  * Cross-isolate/background synchronization so outgoing bulletins and transmissions stay in sync.

* **Improvements**
  * Configurable retention (history/pruning) for messages, stations, and packets with immediate application of changes.
  * More reliable message/bulletin state (demotion of in-flight sends on restart, accurate counters/timestamps).

* **Documentation**
  * Updated capability, decision, and roadmap docs reflecting the new persistence and retention behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meridian-aprs/meridian-aprs/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->