### PR TITLE
infra(ci): pin Flutter to 3.41.7 for reproducible CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned for reproducible CI. The `stable` channel floats, and a
+          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
+          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
+          # follow-up issue before raising this past 3.44.
+          flutter-version: 3.41.7
 
       - name: Install Linux build dependencies
         run: |
@@ -58,6 +63,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned for reproducible CI. The `stable` channel floats, and a
+          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
+          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
+          # follow-up issue before raising this past 3.44.
+          flutter-version: 3.41.7
 
       - name: Install dependencies
         run: flutter pub get
@@ -81,6 +91,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned for reproducible CI. The `stable` channel floats, and a
+          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
+          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
+          # follow-up issue before raising this past 3.44.
+          flutter-version: 3.41.7
 
       - name: Install dependencies
         run: flutter pub get
@@ -102,6 +117,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned for reproducible CI. The `stable` channel floats, and a
+          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
+          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
+          # follow-up issue before raising this past 3.44.
+          flutter-version: 3.41.7
 
       - name: Install macOS build dependencies
         # libserialport (transitive native dep of flutter_libserialport) requires
@@ -128,6 +148,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Pinned for reproducible CI. The `stable` channel floats, and a
+          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
+          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
+          # follow-up issue before raising this past 3.44.
+          flutter-version: 3.41.7
 
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
## Summary

CI's five build jobs used `subosito/flutter-action@v2` with the **floating `stable` channel**. Between the last green run (May 3, Flutter 3.41.x) and now, `stable` floated to **3.44.0**, which added a new `onReorder` deprecation in `messaging_screen.dart`. `flutter analyze` (a step shared by every job) treats it as fatal, so **all jobs failed on code unrelated to whatever PR was under test** — first observed on #121.

This pins all five jobs to **Flutter 3.41.7** (the team's current local toolchain) so CI is reproducible and toolchain upgrades are a deliberate, reviewable change rather than a silent surprise.

## Why pin instead of fixing the deprecation here

The replacement `onReorderItem` API **does not exist in Flutter 3.41.x** — it ships with the same release that deprecated `onReorder`. Migrating now would break local 3.41.7 builds (the reverse skew). The migration is tracked in **#122** and is gated on a deliberate Flutter bump to ≥ 3.44.

## Changes

- `.github/workflows/ci.yml` — add `flutter-version: 3.41.7` to all five `flutter-action` steps (CI, Android, iOS, macOS, Windows), with a comment explaining the pin and pointing at #122.

No application code changes. `update-deviceid.yml` is intentionally left out of scope (independent scheduled workflow).

## Impact

- Unblocks #121 (drift/SQLite persistence) and any other open PR.
- Trade-off: CI no longer auto-surfaces new deprecations from floating `stable`. Intentional — bumps become explicit (see #122 for the next one).

Follow-up: #122 (migrate `onReorder` → `onReorderItem` when bumping to ≥ 3.44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)