### PR TITLE
fix: Flutter 3.44 upgrade + Linux release DB path crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          # Pinned for reproducible CI. The `stable` channel floats, and a
-          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
-          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
-          # follow-up issue before raising this past 3.44.
-          flutter-version: 3.41.7
+          # Pinned for reproducible CI. The `stable` channel floats; bump
+          # deliberately so deprecation churn surfaces in a dedicated PR
+          # instead of unrelated ones.
+          flutter-version: 3.44.0
 
       - name: Install Linux build dependencies
         run: |
@@ -63,11 +62,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          # Pinned for reproducible CI. The `stable` channel floats, and a
-          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
-          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
-          # follow-up issue before raising this past 3.44.
-          flutter-version: 3.41.7
+          # Pinned for reproducible CI. The `stable` channel floats; bump
+          # deliberately so deprecation churn surfaces in a dedicated PR
+          # instead of unrelated ones.
+          flutter-version: 3.44.0
 
       - name: Install dependencies
         run: flutter pub get
@@ -91,11 +89,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          # Pinned for reproducible CI. The `stable` channel floats, and a
-          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
-          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
-          # follow-up issue before raising this past 3.44.
-          flutter-version: 3.41.7
+          # Pinned for reproducible CI. The `stable` channel floats; bump
+          # deliberately so deprecation churn surfaces in a dedicated PR
+          # instead of unrelated ones.
+          flutter-version: 3.44.0
 
       - name: Install dependencies
         run: flutter pub get
@@ -117,11 +114,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          # Pinned for reproducible CI. The `stable` channel floats, and a
-          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
-          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
-          # follow-up issue before raising this past 3.44.
-          flutter-version: 3.41.7
+          # Pinned for reproducible CI. The `stable` channel floats; bump
+          # deliberately so deprecation churn surfaces in a dedicated PR
+          # instead of unrelated ones.
+          flutter-version: 3.44.0
 
       - name: Install macOS build dependencies
         # libserialport (transitive native dep of flutter_libserialport) requires
@@ -148,11 +144,10 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          # Pinned for reproducible CI. The `stable` channel floats, and a
-          # silent bump to 3.44.0 surfaced a new `onReorder` deprecation that
-          # broke unrelated PRs. Bump deliberately; see onReorder→onReorderItem
-          # follow-up issue before raising this past 3.44.
-          flutter-version: 3.41.7
+          # Pinned for reproducible CI. The `stable` channel floats; bump
+          # deliberately so deprecation churn surfaces in a dedicated PR
+          # instead of unrelated ones.
+          flutter-version: 3.44.0
 
       - name: Install dependencies
         run: flutter pub get

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -30,7 +30,17 @@ Future<MeridianDatabase> openMeridianDatabase() async {
 
   IsolateNameServer.removePortNameMapping(meridianDriftPortName);
 
-  final dbFolder = await getApplicationDocumentsDirectory();
+  // Use the application *support* directory, not the documents directory, for
+  // the database file:
+  //   * Linux: support dir derives from `$XDG_DATA_HOME` (~/.local/share) using
+  //     env vars only. The documents dir resolves by spawning the `xdg-user-dir`
+  //     subprocess, which returns nothing inside a release bundle's stripped
+  //     environment and makes path_provider throw MissingPlatformDirectoryException.
+  //   * iOS: the documents dir is iCloud-backed and visible in the Files app — a
+  //     SQLite DB has no business there. Support dir is the conventional home.
+  //   * macOS: support dir is the sandbox-correct ~/Library/Application Support.
+  //   * Android: both resolve to internal app storage; no user-facing difference.
+  final dbFolder = await getApplicationSupportDirectory();
   final dbPath = '${dbFolder.path}${Platform.pathSeparator}meridian.db';
 
   final isolate = await DriftIsolate.spawn(

--- a/lib/screens/settings/category/messaging_screen.dart
+++ b/lib/screens/settings/category/messaging_screen.dart
@@ -157,8 +157,7 @@ class _GroupsList extends StatelessWidget {
         final sub = subs[idx];
         return _GroupListItem(key: ValueKey(sub.id), sub: sub, groups: groups);
       },
-      onReorder: (oldIndex, newIndex) {
-        if (newIndex > oldIndex) newIndex -= 1;
+      onReorderItem: (oldIndex, newIndex) {
         final ids = subs.map((s) => s.id).toList();
         final moved = ids.removeAt(oldIndex);
         ids.insert(newIndex, moved);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -857,18 +857,18 @@ packages:
     dependency: "direct main"
     description:
       name: material_symbols_icons
-      sha256: c62b15f2b3de98d72cbff0148812f5ef5159f05e61fc9f9a089ec2bb234df082
+      sha256: "10a74aaa9e566c92f8aa14809d2dd78156fb93743348ebffec0345c38eb35706"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2906.0"
+    version: "4.2928.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1342,26 +1342,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   m3e_design: ^0.1.0
   flutter_m3shapes: ^1.0.0
   animations: ^2.0.11
-  material_symbols_icons: ^4.2906.0
+  material_symbols_icons: ^4.2928.1
   # v2.x is proprietary-licensed and GPL-incompatible; see ADR-065 (#114)
   flutter_blue_plus: ">=1.36.0 <2.0.0"
   geolocator: ^13.0.0


### PR DESCRIPTION
## Summary
- Bump CI Flutter pin **3.41.7 → 3.44.0** across all five jobs and refresh the pin comment now that the `onReorder` deprecation is addressed.
- Migrate the Messaging settings `ReorderableListView` from `onReorder` → `onReorderItem` (3.44 deprecated the old signature; new callback no longer needs the `if (newIndex > oldIndex) newIndex -= 1` correction).
- **Drift DB path fix:** move the database file from `getApplicationDocumentsDirectory()` to `getApplicationSupportDirectory()`. The documents resolver shells out to `xdg-user-dir` on Linux, which returns empty inside a release bundle's stripped environment and crashes the app at startup with `MissingPlatformDirectoryException`. Support dir derives from env vars only, and is the conventionally correct home on iOS (no iCloud backup) and macOS (sandbox) as well.
- Bump `material_symbols_icons` 4.2906.0 → 4.2928.1.

## Test plan
- [x] `dart format .` clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 791 tests pass locally
- [ ] CI green on the new 3.44.0 pin (Linux / Android / Web / macOS / Windows)
- [ ] Manual smoke: launch a Linux release build and confirm it no longer crashes opening the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Flutter development framework to version 3.44.0 across all build environments for improved stability and platform compatibility
  * Updated icon library to the latest version with new icons and visual enhancements for better interface consistency

* **Improvements**
  * Optimized application database storage location by moving data to the system's application support directory for better organization and accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meridian-aprs/meridian-aprs/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->