### PR TITLE
feat(v0.21): Classic Bluetooth SPP transport — Android (ADR-069)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Each layer depends only on layers below it. The **Packet Core is pure Dart** —
 
 **v0.21 shipped on Android (Classic Bluetooth SPP — native RFCOMM channel, ADR-069; hardware-validated on a TH-D75; desktop deferred). Next: v0.22 — Polish & A11y.**
 
-The full milestone list, per-task breakdowns, and completion state live in `docs/ROADMAP.md`; architectural decisions in `docs/DECISIONS.md` (ADRs 001–068). Do not duplicate that state here.
+The full milestone list, per-task breakdowns, and completion state live in `docs/ROADMAP.md`; architectural decisions in `docs/DECISIONS.md` (ADRs 001–069). Do not duplicate that state here.
 
 > v0.15 / v0.16 milestone numbers are retired (the historical "Battery & Performance" / "Bug Triage" milestones) and are not reused.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Each layer depends only on layers below it. The **Packet Core is pure Dart** —
 
 ## Current Status
 
-**v0.20 shipped (BLE Plugin Replacement — `universal_ble`). Next: v0.21 — Classic Bluetooth SPP.**
+**v0.21 shipped on Android (Classic Bluetooth SPP — native RFCOMM channel, ADR-069; hardware-validated on a TH-D75; desktop deferred). Next: v0.22 — Polish & A11y.**
 
 The full milestone list, per-task breakdowns, and completion state live in `docs/ROADMAP.md`; architectural decisions in `docs/DECISIONS.md` (ADRs 001–068). Do not duplicate that state here.
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <!-- Legacy Bluetooth permission for API <= 30 (Classic BT SPP, ADR-069):
+         bondedDevices / RFCOMM connect require BLUETOOTH on pre-Android-12.
+         BLUETOOTH_CONNECT covers API 31+. -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/ClassicBtChannel.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/ClassicBtChannel.kt
@@ -1,0 +1,241 @@
+package com.meridianaprs.meridian_aprs
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothSocket
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.IOException
+import java.util.UUID
+
+/**
+ * Classic Bluetooth SPP (RFCOMM) bridge for Meridian's KISS TNC transport.
+ *
+ * Phase 1 spike (ADR-069): a deliberately thin native surface. The OS owns
+ * pairing/bonding — this only lists already-bonded devices, opens an RFCOMM
+ * socket to one of them over the standard SPP UUID, and pumps a raw byte stream
+ * in both directions. KISS framing, AX.25, and reconnect all live in Dart.
+ *
+ * Contract:
+ *   MethodChannel `meridian/classic_bt`:
+ *     isSupported  -> Bool
+ *     listPaired   -> List<Map{address,name}>
+ *     connect      {address: String} -> null (outcome arrives via the rx event)
+ *     disconnect   -> null
+ *     write        {bytes: ByteArray} -> null
+ *   EventChannel `meridian/classic_bt/rx` emits Map envelopes:
+ *     {event:"data",  bytes: ByteArray}
+ *     {event:"state", state:"connecting"|"connected"|"disconnected"|"error",
+ *                     message: String?}
+ */
+class ClassicBtChannel(
+    private val context: Context,
+    messenger: BinaryMessenger,
+) : MethodChannel.MethodCallHandler, EventChannel.StreamHandler {
+
+    companion object {
+        const val METHOD_CHANNEL = "meridian/classic_bt"
+        const val EVENT_CHANNEL = "meridian/classic_bt/rx"
+
+        // Standard Serial Port Profile UUID (RFCOMM).
+        private val SPP_UUID: UUID =
+            UUID.fromString("00001101-0000-1000-8000-00805F9B34FB")
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var eventSink: EventChannel.EventSink? = null
+
+    // Active session state. `@Volatile` because the read/connect/write worker
+    // threads and the platform thread all touch these.
+    @Volatile private var socket: BluetoothSocket? = null
+    @Volatile private var readThread: Thread? = null
+
+    init {
+        MethodChannel(messenger, METHOD_CHANNEL).setMethodCallHandler(this)
+        EventChannel(messenger, EVENT_CHANNEL).setStreamHandler(this)
+    }
+
+    private fun adapter(): BluetoothAdapter? =
+        (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter
+
+    // ---------------------------------------------------------------------------
+    // MethodChannel
+    // ---------------------------------------------------------------------------
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "isSupported" -> result.success(adapter() != null)
+            "listPaired" -> handleListPaired(result)
+            "connect" -> handleConnect(call.argument<String>("address"), result)
+            "disconnect" -> {
+                teardown(emitState = true, reason = null)
+                result.success(null)
+            }
+            "write" -> handleWrite(call.argument<ByteArray>("bytes"), result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun handleListPaired(result: MethodChannel.Result) {
+        val adapter = adapter()
+        if (adapter == null) {
+            result.error("unsupported", "No Bluetooth adapter", null)
+            return
+        }
+        try {
+            val devices = adapter.bondedDevices.orEmpty().map {
+                mapOf("address" to it.address, "name" to (it.name ?: it.address))
+            }
+            result.success(devices)
+        } catch (e: SecurityException) {
+            result.error("permission", "BLUETOOTH_CONNECT not granted", e.message)
+        }
+    }
+
+    private fun handleConnect(address: String?, result: MethodChannel.Result) {
+        val adapter = adapter()
+        if (adapter == null) {
+            result.error("unsupported", "No Bluetooth adapter", null)
+            return
+        }
+        if (address.isNullOrEmpty()) {
+            result.error("bad_args", "address required", null)
+            return
+        }
+        // Tear down any prior session, then connect off the platform thread —
+        // RFCOMM connect() blocks for seconds. The outcome is reported through
+        // the rx event stream, not this Result (which returns immediately).
+        teardown(emitState = false, reason = null)
+        emitState("connecting", null)
+
+        Thread({
+            // Discovery is heavy and slows/breaks an RFCOMM connect.
+            try {
+                adapter.cancelDiscovery()
+            } catch (_: SecurityException) {
+            }
+            val sock: BluetoothSocket = try {
+                adapter.getRemoteDevice(address)
+                    .createRfcommSocketToServiceRecord(SPP_UUID)
+            } catch (e: Exception) {
+                emitState("error", e.message ?: "socket create failed")
+                return@Thread
+            }
+            try {
+                sock.connect()
+            } catch (e: IOException) {
+                try { sock.close() } catch (_: IOException) {}
+                emitState("error", e.message ?: "connect failed")
+                return@Thread
+            } catch (e: SecurityException) {
+                try { sock.close() } catch (_: IOException) {}
+                emitState("error", "BLUETOOTH_CONNECT not granted")
+                return@Thread
+            }
+            socket = sock
+            emitState("connected", null)
+            startReadLoop(sock)
+        }, "classic-bt-connect").start()
+
+        result.success(null)
+    }
+
+    private fun handleWrite(bytes: ByteArray?, result: MethodChannel.Result) {
+        val sock = socket
+        if (sock == null || bytes == null) {
+            result.error("not_connected", "No active SPP socket", null)
+            return
+        }
+        // Writes can block; keep them off the platform thread.
+        Thread({
+            try {
+                sock.outputStream.write(bytes)
+                sock.outputStream.flush()
+            } catch (e: IOException) {
+                teardown(emitState = true, reason = e.message ?: "write failed")
+            }
+        }, "classic-bt-write").start()
+        result.success(null)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Read loop
+    // ---------------------------------------------------------------------------
+
+    private fun startReadLoop(sock: BluetoothSocket) {
+        val t = Thread({
+            val buffer = ByteArray(1024)
+            val input = try {
+                sock.inputStream
+            } catch (e: IOException) {
+                teardown(emitState = true, reason = e.message ?: "stream open failed")
+                return@Thread
+            }
+            while (!Thread.currentThread().isInterrupted && socket === sock) {
+                val n = try {
+                    input.read(buffer)
+                } catch (e: IOException) {
+                    if (socket === sock) {
+                        teardown(emitState = true, reason = e.message ?: "read failed")
+                    }
+                    return@Thread
+                }
+                if (n < 0) {
+                    teardown(emitState = true, reason = "stream closed")
+                    return@Thread
+                }
+                if (n > 0) {
+                    emitData(buffer.copyOf(n))
+                }
+            }
+        }, "classic-bt-read")
+        readThread = t
+        t.start()
+    }
+
+    // ---------------------------------------------------------------------------
+    // Teardown
+    // ---------------------------------------------------------------------------
+
+    private fun teardown(emitState: Boolean, reason: String?) {
+        val sock = socket
+        socket = null
+        readThread?.interrupt()
+        readThread = null
+        if (sock != null) {
+            try { sock.close() } catch (_: IOException) {}
+        }
+        if (emitState) {
+            emitState(if (reason != null) "error" else "disconnected", reason)
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // EventChannel — sink lives on the main thread
+    // ---------------------------------------------------------------------------
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        eventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        eventSink = null
+    }
+
+    private fun emitData(bytes: ByteArray) {
+        val sink = eventSink ?: return
+        mainHandler.post { sink.success(mapOf("event" to "data", "bytes" to bytes)) }
+    }
+
+    private fun emitState(state: String, message: String?) {
+        val sink = eventSink ?: return
+        mainHandler.post {
+            sink.success(mapOf("event" to "state", "state" to state, "message" to message))
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/ClassicBtChannel.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/ClassicBtChannel.kt
@@ -12,6 +12,8 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.IOException
 import java.util.UUID
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * Classic Bluetooth SPP (RFCOMM) bridge for Meridian's KISS TNC transport.
@@ -54,6 +56,15 @@ class ClassicBtChannel(
     // threads and the platform thread all touch these.
     @Volatile private var socket: BluetoothSocket? = null
     @Volatile private var readThread: Thread? = null
+
+    // Bumped on every teardown. A connect worker captures the epoch when it
+    // starts and bails if it changed by the time its blocking connect() returns,
+    // so a stale worker can't resurrect a torn-down session or leak a socket.
+    @Volatile private var connectEpoch = 0
+
+    // Serializes writes so concurrent KISS frames cannot interleave on the
+    // output stream. Single-threaded → FIFO ordering.
+    private val writeExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
     init {
         MethodChannel(messenger, METHOD_CHANNEL).setMethodCallHandler(this)
@@ -112,6 +123,7 @@ class ClassicBtChannel(
         // the rx event stream, not this Result (which returns immediately).
         teardown(emitState = false, reason = null)
         emitState("connecting", null)
+        val myEpoch = connectEpoch
 
         Thread({
             // Discovery is heavy and slows/breaks an RFCOMM connect.
@@ -137,6 +149,14 @@ class ClassicBtChannel(
                 emitState("error", "BLUETOOTH_CONNECT not granted")
                 return@Thread
             }
+            // A teardown (or newer connect) happened while we blocked in
+            // connect() — this worker is stale. Close and bail without touching
+            // shared state, so we neither resurrect a dead session nor leak the
+            // socket.
+            if (myEpoch != connectEpoch) {
+                try { sock.close() } catch (_: IOException) {}
+                return@Thread
+            }
             socket = sock
             emitState("connected", null)
             startReadLoop(sock)
@@ -151,16 +171,27 @@ class ClassicBtChannel(
             result.error("not_connected", "No active SPP socket", null)
             return
         }
-        // Writes can block; keep them off the platform thread.
-        Thread({
+        // Enqueue on the single write worker so concurrent frames serialize and
+        // cannot interleave on the output stream. The Result is completed only
+        // after write+flush finishes, and always back on the platform thread.
+        writeExecutor.execute {
+            if (socket !== sock) {
+                mainHandler.post {
+                    result.error("not_connected", "Socket no longer active", null)
+                }
+                return@execute
+            }
             try {
                 sock.outputStream.write(bytes)
                 sock.outputStream.flush()
+                mainHandler.post { result.success(null) }
             } catch (e: IOException) {
                 teardown(emitState = true, reason = e.message ?: "write failed")
+                mainHandler.post {
+                    result.error("write_failed", e.message ?: "write failed", null)
+                }
             }
-        }, "classic-bt-write").start()
-        result.success(null)
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -203,6 +234,7 @@ class ClassicBtChannel(
     // ---------------------------------------------------------------------------
 
     private fun teardown(emitState: Boolean, reason: String?) {
+        connectEpoch++
         val sock = socket
         socket = null
         readThread?.interrupt()

--- a/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/meridianaprs/meridian_aprs/MainActivity.kt
@@ -17,6 +17,7 @@ class MainActivity : FlutterActivity() {
 
     private lateinit var appContext: Context
     private var pendingNavCallsign: String? = null
+    private var classicBtChannel: ClassicBtChannel? = null
 
     companion object {
         const val MAIN_ENGINE_ID = "meridian_main_engine"
@@ -51,6 +52,10 @@ class MainActivity : FlutterActivity() {
                     else -> result.notImplemented()
                 }
             }
+
+        // Classic Bluetooth SPP (RFCOMM) bridge — ADR-069. Owns its own
+        // MethodChannel + EventChannel; held for the engine's lifetime.
+        classicBtChannel = ClassicBtChannel(appContext, flutterEngine.dartExecutor.binaryMessenger)
     }
 
     override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -307,7 +307,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 ## 15. Reference Inventory
 
 - **Architecture overview:** `docs/ARCHITECTURE.md`
-- **Decisions:** `docs/DECISIONS.md` (ADR-001 through ADR-067)
+- **Decisions:** `docs/DECISIONS.md` (ADR-001 through ADR-069)
 - **Roadmap:** `docs/ROADMAP.md`
 - **Future features:** `docs/FUTURE_FEATURES.md`
 - **Theming strategy:** `docs/THEME_PLATFORM_STRATEGY.md`

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -4,13 +4,13 @@ A consolidated reference of what Meridian can do today, organized by user-facing
 
 > **Maintenance:** This document is generated and maintained by Claude Code as part of milestone close-out. When a milestone changes user-visible capabilities or platform behavior, update this file alongside `ROADMAP.md` and `DECISIONS.md`. Source of truth is the codebase, not aspiration — partially implemented or untested capabilities are flagged explicitly.
 
-**Last updated:** 2026-05-30 (v0.20 BLE Plugin Replacement shipped — `universal_ble`, ADR-068; v0.21 Classic Bluetooth SPP next)
+**Last updated:** 2026-05-30 (v0.21 Classic Bluetooth SPP shipped on Android — native RFCOMM channel, ADR-069, hardware-validated on a TH-D75; desktop deferred)
 
 ---
 
 ## 1. Connectivity / Transports
 
-Three concurrent transports, each modeled as a `MeridianConnection` and registered with a single `ConnectionRegistry`. The registry is the single source of truth for connection state and available transports per platform.
+Four concurrent transports, each modeled as a `MeridianConnection` and registered with a single `ConnectionRegistry`. The registry is the single source of truth for connection state and available transports per platform.
 
 | Transport | Platforms | Status |
 |---|---|---|
@@ -18,15 +18,17 @@ Three concurrent transports, each modeled as a `MeridianConnection` and register
 | APRS-IS (WebSocket proxy) | Web | Architectural placeholder; proxy server not yet deployed |
 | BLE TNC | Android, iOS | Shipped (v0.4); validated on common BLE-UART hardware. Plugin: `universal_ble` (BSD-3-Clause) since v0.20. Architecturally cross-platform (incl. Windows/Linux/web) but wired mobile-only pending desktop hardware validation |
 | USB Serial TNC | macOS, Windows, Linux | Shipped (v0.3); Linux validated, macOS / Windows pending physical testing |
+| Classic Bluetooth SPP | Android | Shipped (v0.21, ADR-069); hardware-validated on a Kenwood TH-D75. Native RFCOMM channel. Desktop (Linux/Windows/macOS) deferred to a follow-on phase; iOS not possible (MFi restriction) |
 
 - **APRS-IS:** server `rotate.aprs2.net:14580`; user-overridable host/port; passcode in platform secure storage; viewport-adaptive bounding-box filter (`b/`) with 25 % padding and 50 km minimum radius
 - **BLE TNC:** scan + connect from in-app sheet; two BLE-KISS GATT families autodetected (aprs-specs / Benshi, ADR-066); MTU-negotiated chunking; auto-reconnect via `ReconnectableMixin`. Built on `universal_ble` behind the plugin-agnostic `BleDeviceAdapter` seam (ADR-068)
 - **USB Serial TNC:** static preset registry of common TNC hardware; runtime KISS configuration
-- **TX routing:** unconditional priority Serial > BLE > APRS-IS (ADR-029, ADR-051) — no per-message override
+- **Classic Bluetooth SPP (Android):** connect to an already-paired (OS-bonded) Classic BT KISS TNC over RFCOMM — no in-app scan (pairing is owned by Android Bluetooth settings); surfaced under a merged "Bluetooth" segment with a `[BLE | Classic]` sub-selector. Serial twin of the USB path: raw byte stream through the shared `KissFramer`. Radios with a built-in TNC (e.g. Kenwood TH-D75) must be in **KISS mode with the radio's own beaconing (BCON) off** to forward decoded packets to the host
+- **TX routing:** unconditional priority Serial > Classic BT > BLE > APRS-IS (ADR-029, ADR-051) — no per-message override
 - **Per-connection beaconing toggle:** each connection has its own `beacon_enabled_<id>` preference
 
 ### Explicit non-support
-- Classic Bluetooth SPP — planned v0.21 (not supported on iOS due to platform restriction)
+- Classic Bluetooth SPP on iOS — not possible (Apple restricts Classic BT to MFi-certified accessories); shipped on Android (v0.21), desktop deferred
 - TCP KISS TNC (server software TNCs over LAN) — tracked in `FUTURE_FEATURES.md`
 - AFSK soft-modem (audio over phone speaker / mic) — no plans
 - AGW packet engine, KISS-over-IP variants beyond standard KISS-over-TCP
@@ -123,7 +125,7 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 | SmartBeaconing | Adaptive rate via speed + heading-change threshold; `turnSlope` units = degrees·mph (ADR-021) |
 | GPS source | `geolocator` package (foreground); platform background-location permission for backgrounded beaconing |
 | Per-connection enable | `conn.beaconingEnabled` toggle; persisted as `beacon_enabled_<id>` |
-| TX routing | Unconditional Serial > BLE > APRS-IS (ADR-029, ADR-051); no per-message override |
+| TX routing | Unconditional Serial > Classic BT > BLE > APRS-IS (ADR-029, ADR-051); no per-message override |
 | Tocall | `APMDN0` (v0.x); `APMDN?` allocated for v1.0; `APMDNZ` reserved for dev/nightly |
 | Manual beacon | One-tap via `BeaconFAB` while in `manual` mode |
 | Long-press cooldown | Cooldown guard on `BeaconFAB` to prevent accidental rapid send |
@@ -253,7 +255,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 | APRS-IS RX | Y | Y | Y | Y | Y | P (proxy not deployed) |
 | BLE TNC | Y | Y | — | — | — | — |
 | USB Serial TNC | — | — | P | P | Y | — |
-| Classic BT SPP | Planned v0.21 | — (platform restriction) | Planned v0.21 | Planned v0.21 | Planned v0.21 | — |
+| Classic BT SPP | Y (v0.21) | — (platform restriction) | Deferred | Deferred | Deferred | — |
 | TX (beacon + message) | Y | Y | Y | Y | Y | P (depends on transport) |
 | Background packet RX | Y | Y | — | — | — | — |
 | Background beaconing | Y | Y | — | — | — | — |
@@ -271,7 +273,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 ## 13. Known Limitations / Explicit Non-Support
 
 ### Tracked, planned, deferred
-- **Classic Bluetooth SPP** — v0.21
+- **Classic Bluetooth SPP (desktop)** — Linux/Windows/macOS deferred to a follow-on phase (Android shipped v0.21)
 - **Offline maps** — v0.23
 - **TCP KISS TNC** — `FUTURE_FEATURES.md`
 - **Inter-app API** — `FUTURE_FEATURES.md`

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1779,7 +1779,7 @@ checks rather than open architectural questions, so they do not change any decis
 ## ADR-069: Classic Bluetooth SPP via a native platform channel (not a Flutter plugin)
 
 **Date:** 2026-05-30
-**Status:** Accepted (approved on design at the Phase 1 gate; on-device byte-flow validation folds into Phase 2 — see Hardware validation)
+**Status:** Accepted & shipped (Android, v0.21; on-device byte-flow validated on a Kenwood TH-D75 — see Hardware validation)
 **Milestone:** v0.21 — Classic Bluetooth SPP
 **Related:** ADR-002 (GPL v3), ADR-065 / ADR-068 (BLE-plugin license analysis), ADR-029 / ADR-051 (TX-routing hierarchy), ADR-060 (foreground-service types), ADR-019/020 (transport seam)
 
@@ -1889,13 +1889,22 @@ untouched. `ClassicBtConnection` mirrors `SerialConnection` (active-polling reco
 ### Hardware validation (Phase 1 spike)
 
 The Phase 1 spike delivered the native RFCOMM bridge (`ClassicBtChannel.kt`) and the Dart wrapper
-(`classic_bt_spp_channel.dart`), both compiling and unit-clean. Rather than build a throwaway test
-harness, the **on-device byte-flow validation folds into Phase 2's first runnable milestone** (the
-Bluetooth tab + Classic device list): against a **Kenwood TH-D75** over the standard SPP UUID
-`00001101-0000-1000-8000-00805F9B34FB`, list the bonded TH-D75, connect, confirm RX bytes flow into
-`KissFramer` and decode to APRS lines, and confirm a TX beacon reaches the radio (aprs.fi). The
-RFCOMM approach is well-trodden and the native surface is thin, so the decision was approved on
-design; this section is the standing validation checklist to satisfy before v0.21 close.
+(`classic_bt_spp_channel.dart`); the on-device byte-flow proof folded into Phase 2's first runnable
+milestone (the Bluetooth tab + Classic device list).
+
+**Validated (Phase 2, 2026-05-30) on a Kenwood TH-D75** over the standard SPP UUID
+`00001101-0000-1000-8000-00805F9B34FB`: listed the bonded radio, connected over a *secure* RFCOMM
+socket, confirmed RX bytes flow into `KissFramer` and decode to APRS lines in the packet log,
+confirmed a TX beacon keys the radio and appears on aprs.fi, and confirmed background reconnect +
+background RX after a screen lock. The secure socket was sufficient — no
+`createInsecureRfcommSocketToServiceRecord` fallback was needed.
+
+**Radio-side requirement discovered during validation:** the TH-D75's built-in TNC only forwards
+decoded packets over KISS when it is in **KISS mode ("KISS 12")** *and the radio's own beaconing
+(BCON) is off*. With BCON enabled the radio retains the data path for its internal APRS engine and
+passes nothing to the host — connection succeeds but the byte stream stays silent in both
+directions. This is a radio configuration requirement, not an app defect; it is documented in
+`docs/CAPABILITIES.md` and `docs/ROADMAP.md` so users with built-in-TNC radios can self-serve.
 
 ### References
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1774,3 +1774,131 @@ checks rather than open architectural questions, so they do not change any decis
 - `lib/ui/widgets/ble_scanner_sheet.dart` — universal_ble scan/connect
 - [universal_ble on pub.dev](https://pub.dev/packages/universal_ble) (BSD-3-Clause)
 
+---
+
+## ADR-069: Classic Bluetooth SPP via a native platform channel (not a Flutter plugin)
+
+**Date:** 2026-05-30
+**Status:** Proposed (Phase 1 gate — finalize at v0.21 close)
+**Milestone:** v0.21 — Classic Bluetooth SPP
+**Related:** ADR-002 (GPL v3), ADR-065 / ADR-068 (BLE-plugin license analysis), ADR-029 / ADR-051 (TX-routing hierarchy), ADR-060 (foreground-service types), ADR-019/020 (transport seam)
+
+> **ADR numbering note.** The v0.21 milestone brief said "write ADR-066," but ADR-066
+> ("Standards-aware BLE-KISS naming and multi-family TNC support") already exists. This decision
+> takes the next free number, **069**.
+
+### Context
+
+Meridian speaks three transports: APRS-IS (TCP), BLE TNC (GATT), and Serial TNC (USB). A meaningful
+slice of installed-base hardware is reachable only over **Classic** Bluetooth **SPP** (Serial Port
+Profile / RFCOMM): Kenwood HTs (TH-D74/D75), older mobiles, and Bluetooth TNCs that predate BLE.
+SPP is architecturally a **serial twin** — a raw bidirectional byte stream — so it drops into the
+existing `KissTncTransport` / `MeridianConnection` / `ReconnectableMixin` seam exactly like
+`SerialConnection`, reusing the transport-agnostic `KissFramer`, AX.25 decode, and beaconing
+unchanged. The only open question is *how* to open the RFCOMM socket on each platform.
+
+### Decision
+
+Reach Classic BT SPP through a **thin native platform channel**, not a third-party Flutter plugin.
+Android ships first (Phase 2) via a Kotlin `MethodChannel` + `EventChannel`
+(`meridian/classic_bt`); desktop (Phase 3) adds per-OS native backends behind the same Dart-side
+channel contract. **iOS is excluded by platform restriction** (see below).
+
+### Rationale
+
+- **No GPL-clean, maintained plugin exists.** The most-established option, `flutter_bluetooth_serial`,
+  is effectively unmaintained (no null-safety-era cadence, Android-12 permission support landed only
+  via community forks) and is Android-only. The GPL-v3-incompatibility burn of ADR-065 (FBP v2's
+  commercial relicense) makes any dependency with an ambiguous or commercial license a hard stop
+  (ADR-002 requires GPL-v3 compatibility). A plugin we'd have to fork-and-maintain is the same
+  open-ended commitment ADR-068 rejected for BLE.
+- **A native channel is the only path to the cross-platform target anyway.** Phase 3 needs Linux
+  (`bluez`/D-Bus), Windows (`Windows.Devices.Bluetooth`), and macOS (`IOBluetooth`) — no single
+  plugin covers Classic SPP across them. Owning a thin channel from the start avoids adopting a
+  plugin for Android only to rip it out for desktop.
+- **The native surface is genuinely thin.** Android RFCOMM is five operations
+  (`isSupported`, list bonded devices, connect, disconnect, write) plus an RX byte stream. The app
+  already owns native Kotlin (notification MethodChannel in `MainActivity`), so the pattern is
+  established and the maintenance burden is small and self-contained.
+- **Matches the project's stated native-over-fork preference** for small method-channel work.
+
+The channel contract (stable across platforms):
+
+| Direction | Mechanism | Operations |
+|---|---|---|
+| Dart → native | `MethodChannel('meridian/classic_bt')` | `isSupported` · `listPaired` · `connect(address)` · `disconnect` · `write(bytes)` |
+| native → Dart | `EventChannel('meridian/classic_bt/rx')` | RX `ByteArray` frames · connection-state transitions |
+
+RX bytes feed `KissFramer.addBytes()`; TX is `KissFramer.encode(ax25)` → `write`. Pairing is **not**
+in scope — the OS owns bonding; the app only lists already-bonded devices and connects.
+
+### iOS exclusion (platform restriction, not a bug)
+
+Apple does **not** permit third-party apps to open Classic Bluetooth SPP to non-MFi-certified
+accessories — the ExternalAccessory framework requires the accessory to carry an MFi chip and declare
+a protocol string, which ham radios do not. This is an Apple platform constraint, not a Meridian
+limitation. It is documented here and in `CAPABILITIES.md`; it is **not** surfaced as an in-app error
+and **not** filed as an issue. iOS users with Classic-BT-only hardware need an external BLE↔Classic
+bridge. (iOS retains full BLE and APRS-IS support.)
+
+### Android 12+ permissions
+
+`BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` are already declared in `AndroidManifest.xml` (added for
+BLE; both cover Classic). On API 31+ the app must hold a runtime `BLUETOOTH_CONNECT` grant before
+listing bonded devices or connecting — requested through the existing `permission_handler` flow. No
+new manifest entries are required. Per ADR-060, the foreground service keeps its `dataSync|location`
+types and does **not** re-add `connectedDevice` (which crashes APRS-IS-only sessions on targetSdk
+34+); Classic sessions run under the existing types.
+
+### TX-routing placement
+
+Classic BT is a **peer of Serial** (both are RF KISS byte streams), inserted into the existing
+hierarchy (ADR-029/051) as **Serial > Classic BT > BLE > APRS-IS**. The Serial-vs-Classic ordering is
+immaterial in practice (no user runs a USB TNC and a Classic-BT TNC simultaneously); the position is
+chosen for determinism.
+
+### Enum & seam impact
+
+One append-only change each to `ConnectionType` (`classicBtTnc`) and `PacketSource` (`classicBtTnc`).
+`MeridianConnection`, `ConnectionRegistry`, `ReconnectableMixin`, and `KissFramer` are otherwise
+untouched. `ClassicBtConnection` mirrors `SerialConnection` (active-polling reconnect; **no** BLE-style
+`doWaitingPhaseReconnect`).
+
+### Alternatives considered
+
+- **`flutter_bluetooth_serial`.** Android-only, effectively unmaintained, shaky Android-12 permission
+  story, and license/Phase-3 reach both fail the bar. Rejected.
+- **A community fork of the above.** Same fork-and-maintain commitment ADR-068 rejected for BLE, for a
+  narrower (Android-only) payoff. Rejected.
+- **A cross-platform BLE+Classic plugin.** None exists with maintained Classic SPP across Android +
+  desktop under a GPL-compatible license. Rejected.
+- **Reuse `flutter_libserialport`.** Serial port abstraction; does not speak RFCOMM/bonded-device
+  Bluetooth. Not applicable.
+
+### Consequences
+
+- New, self-contained native code per platform (Android Kotlin first). No new pub dependency, so no
+  license surface added and CI's Linux build list is unchanged at Phase 2.
+- The Dart-side channel wrapper compiles on every platform (plain `MethodChannel`); it is exercised
+  only where `ClassicBtConnection.isAvailable` is true (Android in Phase 2), and a stub guards
+  web/unsupported targets.
+- Desktop backends (Phase 3) are additive behind the same channel contract and gated by widening
+  `isAvailable`; desktop BLE is enabled in the same Phase 3 validation pass for a consistent Bluetooth
+  UI (see ROADMAP / v0.21 plan).
+
+### Hardware validation (Phase 1 spike)
+
+The decision is validated by a minimal Android RFCOMM spike against a **Kenwood TH-D75** over the
+standard SPP UUID `00001101-0000-1000-8000-00805F9B34FB`: list the bonded TH-D75, connect, confirm RX
+bytes flow into `KissFramer` and decode to APRS lines, and confirm a TX frame reaches the radio.
+**Pending on-device run** — this ADR is *Proposed* until the spike confirms bytes flow; it is then
+promoted to *Accepted* and finalized at v0.21 close.
+
+### References
+
+- ADR-065 / ADR-068 — BLE-plugin license analysis (the GPL-compatibility bar this decision inherits)
+- ADR-002 — GPL v3 license requirement
+- ADR-060 — foreground-service type constraints
+- `docs/ROADMAP.md` — v0.21 Classic Bluetooth SPP milestone (platform matrix, iOS caveat)
+- Android RFCOMM: `BluetoothDevice.createRfcommSocketToServiceRecord` / `BluetoothAdapter.bondedDevices`
+

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1779,7 +1779,7 @@ checks rather than open architectural questions, so they do not change any decis
 ## ADR-069: Classic Bluetooth SPP via a native platform channel (not a Flutter plugin)
 
 **Date:** 2026-05-30
-**Status:** Proposed (Phase 1 gate — finalize at v0.21 close)
+**Status:** Accepted (approved on design at the Phase 1 gate; on-device byte-flow validation folds into Phase 2 — see Hardware validation)
 **Milestone:** v0.21 — Classic Bluetooth SPP
 **Related:** ADR-002 (GPL v3), ADR-065 / ADR-068 (BLE-plugin license analysis), ADR-029 / ADR-051 (TX-routing hierarchy), ADR-060 (foreground-service types), ADR-019/020 (transport seam)
 
@@ -1888,11 +1888,14 @@ untouched. `ClassicBtConnection` mirrors `SerialConnection` (active-polling reco
 
 ### Hardware validation (Phase 1 spike)
 
-The decision is validated by a minimal Android RFCOMM spike against a **Kenwood TH-D75** over the
-standard SPP UUID `00001101-0000-1000-8000-00805F9B34FB`: list the bonded TH-D75, connect, confirm RX
-bytes flow into `KissFramer` and decode to APRS lines, and confirm a TX frame reaches the radio.
-**Pending on-device run** — this ADR is *Proposed* until the spike confirms bytes flow; it is then
-promoted to *Accepted* and finalized at v0.21 close.
+The Phase 1 spike delivered the native RFCOMM bridge (`ClassicBtChannel.kt`) and the Dart wrapper
+(`classic_bt_spp_channel.dart`), both compiling and unit-clean. Rather than build a throwaway test
+harness, the **on-device byte-flow validation folds into Phase 2's first runnable milestone** (the
+Bluetooth tab + Classic device list): against a **Kenwood TH-D75** over the standard SPP UUID
+`00001101-0000-1000-8000-00805F9B34FB`, list the bonded TH-D75, connect, confirm RX bytes flow into
+`KissFramer` and decode to APRS lines, and confirm a TX beacon reaches the radio (aprs.fi). The
+RFCOMM approach is well-trodden and the native surface is thin, so the decision was approved on
+design; this section is the standing validation checklist to satisfy before v0.21 close.
 
 ### References
 

--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -139,4 +139,4 @@ A centralized widget (or formatter) for rendering callsigns consistently across 
 
 ---
 
-*Last updated: 2026-04-26*
+*Last updated: 2026-05-30*

--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -40,6 +40,9 @@ Two related capabilities sharing the same KISS-over-TCP framing surface:
 
 Should also consider DNS-SD / mDNS discovery of `_kiss-tnc._tcp` services for zero-config pairing on the LAN. The existing `ConnectionRegistry` and `MeridianConnection` abstractions are well-positioned for both directions. Available on all platforms except web (no raw TCP sockets in browser; would need WebSocket bridging). `ReconnectableMixin` handles Wi-Fi drops.
 
+### Desktop Classic Bluetooth SPP
+Extend the Android Classic BT SPP transport (shipped v0.21, ADR-069) to desktop: Linux (BlueZ over D-Bus, the primary dev environment, first), then Windows (`Windows.Devices.Bluetooth`) and macOS (`IOBluetooth`). Each needs its own native RFCOMM channel mirroring `ClassicBtChannel.kt`; the Dart `ClassicBtConnection` / `ClassicBtTncTransport` layer is already cross-platform and only `isAvailable` widens. Best done in a single validation pass that also flips `BleConnection.isAvailable` on for desktop (re-exercising the v0.20 BLE stack against BlueZ/CoreBluetooth/WinRT — note the `autoConnect` gap on Windows/Linux per ADR-068), so the merged "Bluetooth" tab shows BLE + Classic chips consistently across platforms. Plan-mode required before the native work.
+
 ### Inter-app API
 A documented integration surface that lets third-party tools (loggers, dashboards, contest software, automation) observe received traffic and trigger transmissions through Meridian. Android can use broadcast Intents; other platforms likely need URL schemes / shared files / a local HTTP endpoint. Surface candidates include service-state events, received-message events, position-update events, and outbound message / raw packet send. Open question whether to align with any existing community API surface for ecosystem compatibility or design fresh.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ Each milestone represents a shippable increment with a focused scope. Features d
 | v0.18 — Foundations | Architecture, testing, and dependency foundations that unblock subsequent performance, polish, and launch work | ✅ Complete |
 | v0.19 — Performance | Performance pass — Selector adoption, MapScreen rebuild fix, ListView hygiene, SQLite spike, battery / memory / throughput baselines | ✅ Complete |
 | v0.20 — BLE Plugin Replacement | Replaced `flutter_blue_plus` with `universal_ble` (BSD-3-Clause) behind the `BleDeviceAdapter` seam (#114, ADR-068) | ✅ Complete |
-| v0.21 — Classic Bluetooth SPP | Classic Bluetooth SPP transport for KISS TNCs on Android, Linux, Windows, macOS (iOS excluded by platform restriction) | — |
+| v0.21 — Classic Bluetooth SPP | Classic Bluetooth SPP transport for KISS TNCs (ADR-069). Android shipped & hardware-validated on a TH-D75; desktop (Linux/Windows/macOS) carried forward to a follow-on phase; iOS excluded by platform restriction | ✅ Android shipped |
 | v0.22 — Polish & A11y | Pre-launch polish — accessibility audit, iOS adaptive widget consistency, screen refactors, remaining widget tests | — |
 | v0.23 — Offline Maps | Offline tile caching for portable / field / SAR use without cell service, layered onto the existing `MeridianTileProvider` abstraction | — |
 | v1.0 — Launch | Final release pipeline — Android signing, iOS App Group, release-build CI, physical-device validation, tocall bump, store submission | — |
@@ -201,30 +201,32 @@ Delivered:
 
 ---
 
-### v0.21 — Classic Bluetooth SPP
+### v0.21 — Classic Bluetooth SPP ✅ Android shipped
 
-Add Classic Bluetooth SPP as a fourth transport alongside APRS-IS, BLE TNC, and Serial TNC. Unlocks a meaningful slice of installed-base hardware — APRS-capable HTs and mobiles with built-in or add-on classic Bluetooth, and older Bluetooth-equipped TNCs that predate BLE.
+Classic Bluetooth SPP added as a fourth transport alongside APRS-IS, BLE TNC, and Serial TNC (ADR-069). Unlocks a meaningful slice of installed-base hardware — APRS-capable HTs and mobiles with built-in or add-on classic Bluetooth, and older Bluetooth-equipped TNCs that predate BLE.
 
-**Critical platform caveat — must be documented in this milestone's scope and in an ADR:** iOS does not allow third-party apps to speak Classic Bluetooth SPP to non-MFi-certified accessories. This is a platform restriction, not a Meridian limitation. Practical impact:
+**Critical platform caveat (documented in ADR-069):** iOS does not allow third-party apps to speak Classic Bluetooth SPP to non-MFi-certified accessories. This is a platform restriction, not a Meridian limitation:
 
-- Android, Linux, Windows, macOS — Classic BT SPP is implementable
+- Android — shipped (v0.21)
+- Linux, Windows, macOS — implementable; carried forward to the desktop follow-on phase
 - iOS — not possible from the app; iOS users with classic-BT-only hardware need an external BLE↔Classic bridge
 
-Tooling notes:
+**Approach (ADR-069):** a thin native Kotlin platform channel (`meridian/classic_bt` + RX `EventChannel`) opening an RFCOMM socket over the standard SPP UUID, rather than a Flutter plugin — no maintained GPL-compatible Classic-SPP plugin exists, and a native channel is the only desktop path anyway. SPP is the **serial twin** of `SerialConnection`: a raw byte stream through the shared, transport-agnostic `KissFramer`, not the BLE/GATT model.
 
-- The current BLE library is BLE-only — does not cover classic SPP
-- Android: existing third-party packages exist but are lightly maintained; a platform channel may be cleaner
-- Desktop: each platform needs its own classic-BT integration
-- An ADR will document the chosen approach and the iOS exclusion
+Shipped (Android):
 
-Deliverables:
+- `ClassicBtTncTransport implements KissTncTransport` over a shared, single-sink `ClassicBtSppChannel`
+- `ClassicBtConnection extends MeridianConnection with ReconnectableMixin` (active-polling reconnect, like Serial)
+- `ConnectionType.classicBtTnc` / `PacketSource.classicBtTnc` (append-only); TX hierarchy now Serial > Classic > BLE > APRS-IS
+- Merged "Bluetooth" segment in the Connection screen with a `[BLE | Classic]` `ChoiceChip` sub-selector; paired-device picker (no in-app scan — OS owns pairing); runtime `BLUETOOTH_CONNECT` request + legacy `BLUETOOTH` (`maxSdkVersion=30`)
+- Reuses existing KISS framing, AX.25 decode, beaconing, and `ReconnectableMixin`
+- **Hardware-validated on a Kenwood TH-D75:** RX in packet log, TX beacon keys the radio (confirmed on aprs.fi), background reconnect + background RX after screen lock
 
-- New `ClassicBtTncTransport` implementing `KissTncTransport`, registered as a `MeridianConnection` peer of BLE / Serial
-- Pairing UI in the Connection screen, parallel to `BleScannerSheet`
-- Reuse of existing KISS framing, AX.25 decode, beaconing, and `ReconnectableMixin`
-- Per-platform integration covering Android first, then Linux / Windows / macOS
-- ADR documenting the platform-channel strategy and the iOS exclusion
-- Settings copy / connection screen messaging that explains the iOS limitation rather than hiding it
+> **Radio setup note (TH-D75 and similar built-in TNCs):** the internal TNC only forwards decoded packets over KISS when it is in **KISS mode (e.g. "KISS 12")** *and the radio's own beaconing (BCON) is off* — with BCON on, the radio keeps the data path for its own APRS engine and won't pass frames to the host.
+
+Deferred to the desktop follow-on phase (was Phase 3):
+
+- Desktop Classic BT (Linux BlueZ/D-Bus first, then Windows/macOS) and enabling desktop BLE in the same validation pass — see [Future Features](FUTURE_FEATURES.md). Plan-mode required before that native work.
 
 ---
 

--- a/lib/core/connection/classic_bt_connection.dart
+++ b/lib/core/connection/classic_bt_connection.dart
@@ -1,0 +1,9 @@
+/// Platform-conditional export for [ClassicBtConnection].
+///
+/// On platforms with `dart:io` the real implementation is used; on web the
+/// stub is exported, which throws [UnsupportedError]. Instantiation is further
+/// gated to Android via [ClassicBtConnection.isAvailable].
+library;
+
+export 'classic_bt_connection_stub.dart'
+    if (dart.library.io) 'classic_bt_connection_impl.dart';

--- a/lib/core/connection/classic_bt_connection_impl.dart
+++ b/lib/core/connection/classic_bt_connection_impl.dart
@@ -1,0 +1,377 @@
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../ax25/ax25_encoder.dart';
+import '../packet/aprs_parser.dart';
+import '../transport/classic_bt_spp_channel.dart';
+import '../transport/classic_bt_tnc_transport.dart';
+import '../transport/kiss_tnc_transport.dart';
+import '../util/clock.dart';
+import 'meridian_connection.dart';
+import 'reconnectable_mixin.dart';
+
+/// Classic Bluetooth SPP (RFCOMM) KISS TNC connection (ADR-069).
+///
+/// The serial twin of [SerialConnection] — a raw byte stream through the
+/// transport-agnostic `KissFramer`, **not** the BLE/GATT model. Wraps
+/// [ClassicBtTncTransport] (one instance per connect attempt) and exposes it
+/// through the [MeridianConnection] interface; AX.25 frames are decoded to APRS
+/// text internally, callers only see [lines].
+///
+/// Reconnects via [ReconnectableMixin] active polling (like Serial, not BLE's
+/// OS-managed background scan): exponential backoff 2 s → 4 s → 8 s → 16 s →
+/// 30 s, up to 5 fast retries, then keeps retrying every 30 s.
+///
+/// Owns **one** long-lived [ClassicBtSppChannel] for the connection's lifetime.
+/// The native bridge's RX [EventChannel] is single-sink; sharing one channel
+/// across per-connect transports avoids the listener race that would otherwise
+/// drop the sink on reconnect.
+///
+/// Android only in v0.21 (Phase 3 widens to desktop). iOS is excluded by
+/// platform restriction (Classic BT requires MFi/ExternalAccessory).
+class ClassicBtConnection extends MeridianConnection with ReconnectableMixin {
+  ClassicBtConnection({
+    Clock clock = DateTime.now,
+    ClassicBtSppChannel? channel,
+  }) : _clock = clock,
+       _channel = channel ?? ClassicBtSppChannel();
+
+  final Clock _clock;
+  final ClassicBtSppChannel _channel;
+
+  static const _kBeaconingKey = 'beacon_enabled_classic_bt_tnc';
+  static const _kAddressKey = 'classic_bt_address';
+  static const _kNameKey = 'classic_bt_name';
+
+  // ---------------------------------------------------------------------------
+  // Persistent stream infrastructure
+  // ---------------------------------------------------------------------------
+
+  /// Outer [lines] stream — lives for the lifetime of this object.
+  final _linesController = StreamController<String>.broadcast();
+
+  /// Outer [connectionState] stream — same lifetime guarantee.
+  final _stateController = StreamController<ConnectionStatus>.broadcast();
+
+  ConnectionStatus _status = ConnectionStatus.disconnected;
+
+  // ---------------------------------------------------------------------------
+  // Inner transport state
+  // ---------------------------------------------------------------------------
+
+  KissTncTransport? _transport;
+
+  StreamSubscription<Uint8List>? _frameSub;
+  StreamSubscription<ConnectionStatus>? _transportStateSub;
+
+  final _parser = AprsParser();
+  bool _beaconingEnabled = true;
+
+  /// Bluetooth MAC address of the target device, retained so reconnect attempts
+  /// target the same device. Null when no device is set.
+  String? _address;
+
+  /// Friendly device name (from the paired-device list) for diagnostics and UI.
+  String? _deviceName;
+
+  String? _lastErrorMessage;
+
+  // ---------------------------------------------------------------------------
+  // Test injection
+  // ---------------------------------------------------------------------------
+
+  /// Override in tests to inject a fake transport instead of a real
+  /// [ClassicBtTncTransport]. Receives the target device address.
+  @visibleForTesting
+  KissTncTransport Function(String address)? transportFactory;
+
+  // ---------------------------------------------------------------------------
+  // MeridianConnection — identity
+  // ---------------------------------------------------------------------------
+
+  @override
+  String get id => 'classic_bt_tnc';
+
+  @override
+  String get displayName => 'Classic BT';
+
+  @override
+  ConnectionType get type => ConnectionType.classicBtTnc;
+
+  @override
+  bool get isAvailable {
+    if (kIsWeb) return false;
+    // Android only in v0.21. iOS is excluded by platform restriction (MFi).
+    // Phase 3 widens this to Linux/macOS/Windows.
+    return defaultTargetPlatform == TargetPlatform.android;
+  }
+
+  // ---------------------------------------------------------------------------
+  // MeridianConnection — state
+  // ---------------------------------------------------------------------------
+
+  @override
+  ConnectionStatus get status {
+    if (_status == ConnectionStatus.reconnecting ||
+        _status == ConnectionStatus.waitingForDevice) {
+      return _status;
+    }
+    return _transport?.currentStatus ?? _status;
+  }
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  @override
+  bool get isConnected => status == ConnectionStatus.connected;
+
+  // ---------------------------------------------------------------------------
+  // Classic-BT-specific getters
+  // ---------------------------------------------------------------------------
+
+  /// MAC address of the active or last-used device.
+  String? get deviceAddress => _address;
+
+  /// Friendly name of the active or last-used device.
+  String? get deviceName => _deviceName;
+
+  /// Human-readable error description. Non-null when [status] is
+  /// [ConnectionStatus.error].
+  String? get lastErrorMessage => _lastErrorMessage;
+
+  // ---------------------------------------------------------------------------
+  // MeridianConnection — beaconing
+  // ---------------------------------------------------------------------------
+
+  @override
+  bool get beaconingEnabled => _beaconingEnabled;
+
+  @override
+  Future<void> setBeaconingEnabled(bool enabled) async {
+    if (_beaconingEnabled == enabled) return;
+    _beaconingEnabled = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kBeaconingKey, enabled);
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // MeridianConnection — data I/O
+  // ---------------------------------------------------------------------------
+
+  @override
+  Stream<String> get lines => _linesController.stream;
+
+  @override
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) async {
+    final transport = _transport;
+    if (transport == null || !transport.isConnected) {
+      throw StateError('ClassicBtConnection: not connected');
+    }
+    final ax25Bytes = _buildAx25Bytes(aprsLine, digipeaterPath: digipeaterPath);
+    if (ax25Bytes != null) {
+      await transport.sendFrame(ax25Bytes);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // MeridianConnection — lifecycle
+  // ---------------------------------------------------------------------------
+
+  /// Set the target device and connect.
+  ///
+  /// Persists [address] / [name] to SharedPreferences for next-launch restore.
+  /// On failure, sets [lastErrorMessage] and emits [ConnectionStatus.error].
+  Future<void> connectToDevice(String address, {String? name}) async {
+    _address = address;
+    _deviceName = name;
+    _lastErrorMessage = null;
+    await _saveDevice(address, name);
+    return connect();
+  }
+
+  @override
+  Future<void> connect() async {
+    final address = _address;
+    if (address == null) {
+      throw StateError(
+        'ClassicBtConnection: no device set — call connectToDevice() first',
+      );
+    }
+    await _tearDownTransport();
+    _buildAndAttachTransport(address);
+    try {
+      await _transport!.connect();
+    } catch (e) {
+      _lastErrorMessage = 'Could not connect to ${_deviceName ?? address}';
+      _emitStatus(ConnectionStatus.error);
+      notifyListeners();
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    cancelReconnect();
+    await _tearDownTransport();
+    _emitStatus(ConnectionStatus.disconnected);
+    notifyListeners();
+  }
+
+  @override
+  Future<void> dispose() async {
+    cancelReconnect();
+    await _tearDownTransport();
+    await _channel.dispose();
+    await _linesController.close();
+    await _stateController.close();
+    super.dispose();
+  }
+
+  @override
+  Future<void> loadPersistedSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    _beaconingEnabled = prefs.getBool(_kBeaconingKey) ?? true;
+    _address = prefs.getString(_kAddressKey);
+    _deviceName = prefs.getString(_kNameKey);
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Classic-BT-specific helpers
+  // ---------------------------------------------------------------------------
+
+  /// Returns the already-paired (OS-bonded) Classic BT devices. Pairing itself
+  /// is owned by Android Bluetooth settings — there is no in-app discovery.
+  ///
+  /// May throw a [PlatformException] if `BLUETOOTH_CONNECT` is not granted; the
+  /// caller is expected to request the runtime permission first.
+  Future<List<ClassicBtPairedDevice>> pairedDevices() =>
+      ClassicBtTncTransport.pairedDevices();
+
+  // ---------------------------------------------------------------------------
+  // Internal — transport management
+  // ---------------------------------------------------------------------------
+
+  KissTncTransport _buildTransport(String address) =>
+      transportFactory?.call(address) ??
+      ClassicBtTncTransport(address, channel: _channel);
+
+  void _buildAndAttachTransport(String address) {
+    final t = _buildTransport(address);
+    _transport = t;
+    _transportStateSub = t.connectionState.listen(_onTransportStatus);
+    _frameSub = t.frameStream.listen(_onFrame);
+  }
+
+  Future<void> _tearDownTransport() async {
+    await _transportStateSub?.cancel();
+    _transportStateSub = null;
+    await _frameSub?.cancel();
+    _frameSub = null;
+    try {
+      await _transport?.disconnect();
+    } catch (_) {}
+    _transport = null;
+  }
+
+  void _onTransportStatus(ConnectionStatus s) {
+    if (s == ConnectionStatus.error) {
+      _lastErrorMessage ??=
+          'Could not connect to ${_deviceName ?? _address ?? 'Classic BT'}';
+    }
+    _emitStatus(s);
+    notifyListeners();
+
+    if (s == ConnectionStatus.connected) {
+      _lastErrorMessage = null;
+      markSessionConnected();
+    } else if (s == ConnectionStatus.error && shouldAttemptReconnect()) {
+      scheduleReconnect(_emitStatus);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // ReconnectableMixin — reconnect implementation
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> doAttemptReconnect() async {
+    final address = _address;
+    if (address == null) return; // disconnect() was called
+
+    debugPrint('ClassicBtConnection: attempting reconnect to $address');
+    await _tearDownTransport();
+    if (_address == null) return; // disconnect() called during teardown
+
+    _buildAndAttachTransport(address);
+    try {
+      await _transport!.connect();
+    } catch (e) {
+      debugPrint('ClassicBtConnection: reconnect attempt failed: $e');
+      // Transport already emitted error → _onTransportStatus → scheduleReconnect
+    }
+  }
+
+  void _onFrame(Uint8List frameBytes) {
+    final packet = _parser.parseFrame(frameBytes, receivedAt: _clock().toUtc());
+    if (packet.rawLine.isNotEmpty && !_linesController.isClosed) {
+      _linesController.add(packet.rawLine);
+    }
+  }
+
+  void _emitStatus(ConnectionStatus s) {
+    _status = s;
+    if (!_stateController.isClosed) {
+      _stateController.add(s);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — persistence
+  // ---------------------------------------------------------------------------
+
+  Future<void> _saveDevice(String address, String? name) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kAddressKey, address);
+    if (name != null) {
+      await prefs.setString(_kNameKey, name);
+    } else {
+      await prefs.remove(_kNameKey);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal — AX.25 encoding
+  // ---------------------------------------------------------------------------
+
+  Uint8List? _buildAx25Bytes(String aprsLine, {List<String>? digipeaterPath}) {
+    final gtIdx = aprsLine.indexOf('>');
+    final colonIdx = aprsLine.indexOf(':');
+    if (gtIdx < 0 || colonIdx < 0 || colonIdx <= gtIdx) return null;
+
+    final sourceRaw = aprsLine.substring(0, gtIdx).trim();
+    final infoField = aprsLine.substring(colonIdx + 1);
+
+    final sourceParts = sourceRaw.split('-');
+    final callsign = sourceParts[0].toUpperCase();
+    final ssid = sourceParts.length > 1 ? int.tryParse(sourceParts[1]) ?? 0 : 0;
+
+    final frame = digipeaterPath != null && digipeaterPath.isNotEmpty
+        ? Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            digipeaterAliases: digipeaterPath,
+            infoField: infoField,
+          )
+        : Ax25Encoder.buildAprsFrame(
+            sourceCallsign: callsign,
+            sourceSsid: ssid,
+            infoField: infoField,
+          );
+    return Ax25Encoder.encodeUiFrame(frame);
+  }
+}

--- a/lib/core/connection/classic_bt_connection_stub.dart
+++ b/lib/core/connection/classic_bt_connection_stub.dart
@@ -1,0 +1,79 @@
+library;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+import '../transport/classic_bt_spp_channel.dart';
+import '../transport/kiss_tnc_transport.dart';
+import '../util/clock.dart';
+import 'meridian_connection.dart';
+
+/// Stub [ClassicBtConnection] for platforms without Classic BT SPP (web).
+class ClassicBtConnection extends MeridianConnection {
+  ClassicBtConnection({
+    Clock clock = DateTime.now,
+    ClassicBtSppChannel? channel,
+  });
+
+  @visibleForTesting
+  KissTncTransport Function(String address)? transportFactory;
+
+  @override
+  String get id => 'classic_bt_tnc';
+
+  @override
+  String get displayName => 'Classic BT';
+
+  @override
+  ConnectionType get type => ConnectionType.classicBtTnc;
+
+  @override
+  bool get isAvailable => false;
+
+  @override
+  ConnectionStatus get status => ConnectionStatus.disconnected;
+
+  @override
+  Stream<ConnectionStatus> get connectionState =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  bool get beaconingEnabled => false;
+
+  @override
+  Future<void> setBeaconingEnabled(bool enabled) =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  @override
+  Stream<String> get lines =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  @override
+  Future<void> sendLine(String aprsLine, {List<String>? digipeaterPath}) =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  @override
+  Future<void> connect() =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  Future<void> connectToDevice(String address, {String? name}) =>
+      throw UnsupportedError('Classic BT not supported on this platform');
+
+  String? get deviceAddress => null;
+  String? get deviceName => null;
+  String? get lastErrorMessage => null;
+  Future<List<ClassicBtPairedDevice>> pairedDevices() async => const [];
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {
+    super.dispose();
+  }
+
+  @override
+  Future<void> loadPersistedSettings() async {}
+}

--- a/lib/core/connection/meridian_connection.dart
+++ b/lib/core/connection/meridian_connection.dart
@@ -10,7 +10,7 @@ export '../transport/aprs_transport.dart' show ConnectionStatus;
 ///
 /// Used by the UI layer to dispatch connection-specific form builders and by
 /// [StationService] to tag ingested packets with the correct [PacketSource].
-enum ConnectionType { aprsIs, bleTnc, serialTnc }
+enum ConnectionType { aprsIs, bleTnc, serialTnc, classicBtTnc }
 
 /// Unified abstraction over all APRS transport connections.
 ///

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -3,7 +3,7 @@
 /// [tnc] is kept as a legacy deserialization alias; new code should use
 /// [bleTnc] or [serialTnc]. Both [tnc] and [bleTnc] represent KISS/BLE
 /// packets — they are treated equivalently in the UI.
-enum PacketSource { aprsIs, tnc, bleTnc, serialTnc }
+enum PacketSource { aprsIs, tnc, bleTnc, serialTnc, classicBtTnc }
 
 /// Typed APRS packet model hierarchy.
 ///

--- a/lib/core/transport/classic_bt_spp_channel.dart
+++ b/lib/core/transport/classic_bt_spp_channel.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Link-state transitions reported by the native Classic BT bridge.
+enum ClassicBtLinkState { connecting, connected, disconnected, error }
+
+/// A bonded (already-paired) Classic Bluetooth device. Pairing is owned by the
+/// OS; Meridian only lists and connects to devices the user paired in system
+/// Bluetooth settings.
+typedef ClassicBtPairedDevice = ({String address, String name});
+
+/// A link-state event with an optional human-readable failure reason.
+typedef ClassicBtStateEvent = ({ClassicBtLinkState state, String? message});
+
+/// Thin Dart wrapper over the native Classic Bluetooth SPP (RFCOMM) bridge
+/// (ADR-069). Mirrors a serial port: a raw bidirectional byte stream. KISS
+/// framing, AX.25, and reconnect live above this — see [ClassicBtTncTransport].
+///
+/// One active socket at a time. RX bytes and link-state transitions arrive on a
+/// single native [EventChannel] and are demultiplexed into [rxBytes] / [states].
+/// Instantiate only where the platform supports it (Android in v0.21); the
+/// methods otherwise reject with a [PlatformException].
+class ClassicBtSppChannel {
+  ClassicBtSppChannel({
+    MethodChannel? methodChannel,
+    EventChannel? eventChannel,
+  }) : _method = methodChannel ?? const MethodChannel(_methodName),
+       _event = eventChannel ?? const EventChannel(_eventName);
+
+  static const _methodName = 'meridian/classic_bt';
+  static const _eventName = 'meridian/classic_bt/rx';
+
+  final MethodChannel _method;
+  final EventChannel _event;
+
+  final _rxController = StreamController<Uint8List>.broadcast();
+  final _stateController = StreamController<ClassicBtStateEvent>.broadcast();
+  StreamSubscription<dynamic>? _eventSub;
+  bool _listening = false;
+
+  /// Raw bytes received from the device. Feed into `KissFramer.addBytes`.
+  Stream<Uint8List> get rxBytes {
+    _ensureListening();
+    return _rxController.stream;
+  }
+
+  /// Link-state transitions (connecting → connected, or → error/disconnected).
+  Stream<ClassicBtStateEvent> get states {
+    _ensureListening();
+    return _stateController.stream;
+  }
+
+  /// Whether the device has a usable Bluetooth adapter.
+  Future<bool> isSupported() async =>
+      await _method.invokeMethod<bool>('isSupported') ?? false;
+
+  /// All already-bonded Classic BT devices (OS-paired). No in-app discovery.
+  Future<List<ClassicBtPairedDevice>> listPaired() async {
+    final raw =
+        await _method.invokeListMethod<dynamic>('listPaired') ?? const [];
+    return raw
+        .map<ClassicBtPairedDevice>((e) {
+          final m = (e as Map).cast<dynamic, dynamic>();
+          final address = m['address'] as String? ?? '';
+          return (address: address, name: m['name'] as String? ?? address);
+        })
+        .toList(growable: false);
+  }
+
+  /// Open an RFCOMM socket to [address]. Returns once the request is dispatched;
+  /// the actual connected/error outcome arrives on [states].
+  Future<void> connect(String address) =>
+      _method.invokeMethod<void>('connect', {'address': address});
+
+  /// Close the active socket, if any.
+  Future<void> disconnect() => _method.invokeMethod<void>('disconnect');
+
+  /// Write raw bytes to the device (KISS-encoded frame).
+  Future<void> write(Uint8List bytes) =>
+      _method.invokeMethod<void>('write', {'bytes': bytes});
+
+  void _ensureListening() {
+    if (_listening) return;
+    _listening = true;
+    _eventSub = _event.receiveBroadcastStream().listen(
+      _onEvent,
+      onError: (Object e) {
+        if (!_stateController.isClosed) {
+          _stateController.add((
+            state: ClassicBtLinkState.error,
+            message: e.toString(),
+          ));
+        }
+      },
+    );
+  }
+
+  void _onEvent(dynamic event) {
+    if (event is! Map) return;
+    switch (event['event']) {
+      case 'data':
+        final bytes = event['bytes'];
+        if (bytes is Uint8List && !_rxController.isClosed) {
+          _rxController.add(bytes);
+        }
+      case 'state':
+        final state = switch (event['state']) {
+          'connecting' => ClassicBtLinkState.connecting,
+          'connected' => ClassicBtLinkState.connected,
+          'disconnected' => ClassicBtLinkState.disconnected,
+          _ => ClassicBtLinkState.error,
+        };
+        if (!_stateController.isClosed) {
+          _stateController.add((
+            state: state,
+            message: event['message'] as String?,
+          ));
+        }
+      default:
+        debugPrint('ClassicBtSppChannel: unknown event $event');
+    }
+  }
+
+  Future<void> dispose() async {
+    await _eventSub?.cancel();
+    _eventSub = null;
+    await _rxController.close();
+    await _stateController.close();
+  }
+}

--- a/lib/core/transport/classic_bt_tnc_transport.dart
+++ b/lib/core/transport/classic_bt_tnc_transport.dart
@@ -1,0 +1,10 @@
+/// Platform-conditional export for [ClassicBtTncTransport].
+///
+/// On platforms with `dart:io` (Android/desktop) this re-exports the real
+/// implementation backed by the native RFCOMM bridge. On web the stub is used,
+/// which throws [UnsupportedError]. The connection layer additionally gates
+/// instantiation to Android via [ClassicBtConnection.isAvailable].
+library;
+
+export 'classic_bt_tnc_transport_stub.dart'
+    if (dart.library.io) 'classic_bt_tnc_transport_impl.dart';

--- a/lib/core/transport/classic_bt_tnc_transport_impl.dart
+++ b/lib/core/transport/classic_bt_tnc_transport_impl.dart
@@ -1,0 +1,179 @@
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'classic_bt_spp_channel.dart';
+import 'kiss_framer.dart';
+import 'kiss_tnc_transport.dart';
+
+/// Classic Bluetooth SPP (RFCOMM) KISS TNC transport (ADR-069).
+///
+/// The serial twin of [SerialKissTransport]: a raw bidirectional byte stream,
+/// not a GATT model. Implements [KissTncTransport], emitting raw AX.25 frame
+/// payloads on [frameStream]. Internally:
+///   native RX bytes → [KissFramer] → AX.25 bytes on [frameStream]
+///   [sendFrame] → [KissFramer.encode] → native `write`
+///
+/// Android only in v0.21. Use the conditional-import shim at
+/// `classic_bt_tnc_transport.dart` rather than importing this file directly.
+///
+/// The native [EventChannel] is single-sink: only one `receiveBroadcastStream`
+/// listener can be active at a time. To avoid sink races across reconnect
+/// churn, the owning [ClassicBtConnection] creates **one** long-lived
+/// [ClassicBtSppChannel] and injects it here; per-connect transports merely
+/// subscribe to the channel's Dart-side broadcast streams. The transport
+/// therefore never disposes the channel — it only closes the active socket via
+/// [ClassicBtSppChannel.disconnect].
+class ClassicBtTncTransport extends KissTncTransport {
+  ClassicBtTncTransport(this._address, {ClassicBtSppChannel? channel})
+    : _channel = channel ?? ClassicBtSppChannel();
+
+  final String _address;
+  final ClassicBtSppChannel _channel;
+
+  final _kissFramer = KissFramer();
+  StreamSubscription<Uint8List>? _rxSub;
+  StreamSubscription<ClassicBtStateEvent>? _stateSub;
+  StreamSubscription<Uint8List>? _frameSub;
+
+  final _framesController = StreamController<Uint8List>.broadcast();
+  final _stateController = StreamController<ConnectionStatus>.broadcast();
+  ConnectionStatus _status = ConnectionStatus.disconnected;
+
+  /// Last human-readable failure reason reported by the native bridge.
+  String? get lastErrorMessage => _lastErrorMessage;
+  String? _lastErrorMessage;
+
+  /// Guards against concurrent or re-entrant disconnect calls.
+  bool _disconnecting = false;
+
+  @override
+  Stream<Uint8List> get frameStream => _framesController.stream;
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  @override
+  ConnectionStatus get currentStatus => _status;
+
+  @override
+  bool get isConnected => _status == ConnectionStatus.connected;
+
+  @override
+  Future<void> connect() async {
+    _setStatus(ConnectionStatus.connecting);
+
+    // Subscribe KISS frames → frameStream.
+    _frameSub = _kissFramer.frames.listen(_onAx25Frame);
+
+    // Subscribe native RX bytes → KISS framer. Accessing the channel streams
+    // lazily starts the single native EventChannel subscription (once for the
+    // channel's lifetime).
+    _rxSub = _channel.rxBytes.listen(
+      (bytes) => _kissFramer.addBytes(bytes),
+      onError: (Object e) {
+        debugPrint('ClassicBtTncTransport rx error: $e');
+        _lastErrorMessage = e.toString();
+        _setStatus(ConnectionStatus.error);
+        Future.microtask(_handleDisconnect);
+      },
+    );
+
+    // Subscribe native link-state transitions. The actual connected/error
+    // outcome of the RFCOMM connect arrives here, not from [connect]'s future
+    // (which resolves as soon as the request is dispatched).
+    _stateSub = _channel.states.listen(_onStateEvent);
+
+    try {
+      await _channel.connect(_address);
+    } catch (e) {
+      debugPrint('ClassicBtTncTransport connect dispatch failed: $e');
+      _lastErrorMessage = e.toString();
+      _setStatus(ConnectionStatus.error);
+      Future.microtask(_handleDisconnect);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _handleDisconnect();
+  }
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) async {
+    try {
+      await _channel.write(KissFramer.encode(ax25Frame));
+    } catch (e) {
+      debugPrint('ClassicBtTncTransport: sendFrame error — $e');
+      _lastErrorMessage = e.toString();
+      Future.microtask(_handleDisconnect);
+      rethrow;
+    }
+  }
+
+  void _onStateEvent(ClassicBtStateEvent event) {
+    switch (event.state) {
+      case ClassicBtLinkState.connecting:
+        _setStatus(ConnectionStatus.connecting);
+      case ClassicBtLinkState.connected:
+        _setStatus(ConnectionStatus.connected);
+      case ClassicBtLinkState.disconnected:
+        if (!_disconnecting) Future.microtask(_handleDisconnect);
+      case ClassicBtLinkState.error:
+        _lastErrorMessage = event.message;
+        _setStatus(ConnectionStatus.error);
+        if (!_disconnecting) Future.microtask(_handleDisconnect);
+    }
+  }
+
+  /// Idempotent teardown. Safe to call from stream callbacks, [disconnect], or
+  /// error handlers. Closes the active socket but never disposes the shared
+  /// [ClassicBtSppChannel].
+  Future<void> _handleDisconnect() async {
+    if (_disconnecting) return;
+    _disconnecting = true;
+
+    await _rxSub?.cancel();
+    _rxSub = null;
+    await _stateSub?.cancel();
+    _stateSub = null;
+    await _frameSub?.cancel();
+    _frameSub = null;
+    _kissFramer.dispose();
+
+    try {
+      await _channel.disconnect();
+    } catch (e) {
+      // The socket may already be gone after a physical disconnect — swallow.
+      debugPrint('ClassicBtTncTransport channel.disconnect() error: $e');
+    }
+
+    if (_status != ConnectionStatus.error) {
+      _setStatus(ConnectionStatus.disconnected);
+    }
+    _disconnecting = false;
+  }
+
+  /// All already-bonded Classic BT devices (OS-paired). No in-app discovery —
+  /// pairing is owned by Android Bluetooth settings.
+  ///
+  /// Uses a transient channel: [ClassicBtSppChannel.listPaired] is a plain
+  /// method call that never touches the single-sink event stream, so no live
+  /// session is disturbed.
+  static Future<List<ClassicBtPairedDevice>> pairedDevices() =>
+      ClassicBtSppChannel().listPaired();
+
+  void _onAx25Frame(Uint8List frameBytes) {
+    if (!_framesController.isClosed) _framesController.add(frameBytes);
+  }
+
+  void _setStatus(ConnectionStatus status) {
+    _status = status;
+    if (!_stateController.isClosed) _stateController.add(status);
+  }
+}

--- a/lib/core/transport/classic_bt_tnc_transport_stub.dart
+++ b/lib/core/transport/classic_bt_tnc_transport_stub.dart
@@ -1,0 +1,44 @@
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'aprs_transport.dart' show ConnectionStatus;
+import 'classic_bt_spp_channel.dart';
+import 'kiss_tnc_transport.dart';
+
+/// Stub [ClassicBtTncTransport] for platforms without Classic BT SPP (web).
+class ClassicBtTncTransport extends KissTncTransport {
+  // ignore: avoid_unused_constructor_parameters
+  ClassicBtTncTransport(String address, {ClassicBtSppChannel? channel});
+
+  static const _unsupported =
+      'Classic Bluetooth not supported on this platform';
+
+  String? get lastErrorMessage => null;
+
+  @override
+  Stream<Uint8List> get frameStream => throw UnsupportedError(_unsupported);
+
+  @override
+  Stream<ConnectionStatus> get connectionState =>
+      throw UnsupportedError(_unsupported);
+
+  @override
+  ConnectionStatus get currentStatus => ConnectionStatus.disconnected;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  Future<void> connect() => throw UnsupportedError(_unsupported);
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) =>
+      throw UnsupportedError(_unsupported);
+
+  static Future<List<ClassicBtPairedDevice>> pairedDevices() async => const [];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'ui/widgets/in_app_banner_overlay.dart';
 import 'config/app_config.dart';
 import 'core/connection/aprs_is_connection.dart';
 import 'core/connection/ble_connection.dart';
+import 'core/connection/classic_bt_connection.dart';
 import 'core/connection/connection_registry.dart';
 import 'core/connection/serial_connection.dart';
 import 'core/credentials/secure_credential_store.dart';
@@ -144,10 +145,16 @@ Future<void> main() async {
   // Platform-conditional TNC connections.
   BleConnection? bleConn;
   SerialConnection? serialConn;
+  ClassicBtConnection? classicBtConn;
 
   if (!kIsWeb) {
     if (Platform.isAndroid || Platform.isIOS) {
       bleConn = BleConnection();
+    }
+    // Classic Bluetooth SPP is Android-only in v0.21 (ADR-069); iOS restricts
+    // Classic BT to MFi accessories. Phase 3 widens this to desktop.
+    if (Platform.isAndroid) {
+      classicBtConn = ClassicBtConnection();
     }
     if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
       serialConn = SerialConnection();
@@ -157,6 +164,7 @@ Future<void> main() async {
   final registry = ConnectionRegistry();
   registry.register(aprsIsConn);
   if (bleConn != null) registry.register(bleConn);
+  if (classicBtConn != null) registry.register(classicBtConn);
   if (serialConn != null) registry.register(serialConn);
 
   // Load persisted settings (beaconing toggles, serial config) for all

--- a/lib/models/bulletin.dart
+++ b/lib/models/bulletin.dart
@@ -21,6 +21,7 @@ extension BulletinTransportMapping on PacketSource {
     PacketSource.aprsIs => BulletinTransport.aprsIs,
     PacketSource.bleTnc ||
     PacketSource.serialTnc ||
+    PacketSource.classicBtTnc ||
     PacketSource.tnc => BulletinTransport.rf,
   };
 }

--- a/lib/screens/connection_screen.dart
+++ b/lib/screens/connection_screen.dart
@@ -48,6 +48,11 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
   // Packet counters keyed by connection ID.
   final Map<String, int> _packetCountById = {};
 
+  // Drives the page scroll so we can snap back to the top (where the Active
+  // Connections card shows "Connecting…") when a connect is initiated from a
+  // long device list further down.
+  final _scrollController = ScrollController();
+
   StreamSubscription<AprsPacket>? _packetSub;
 
   @override
@@ -87,7 +92,20 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
   @override
   void dispose() {
     _packetSub?.cancel();
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  /// Snap the page back to the top so the just-initiated connection's
+  /// "Connecting…" card is visible — the device lists can be long enough that a
+  /// tap leaves the user scrolled past the status area.
+  void _scrollToTop() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -114,6 +132,7 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Connection')),
       body: SingleChildScrollView(
+        controller: _scrollController,
         padding: const EdgeInsets.only(bottom: 32),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -464,7 +483,10 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
         ),
       );
     }
-    return ClassicBtDeviceList(connection: conn);
+    return ClassicBtDeviceList(
+      connection: conn,
+      onConnectInitiated: _scrollToTop,
+    );
   }
 
   // ── Serial TNC tab ─────────────────────────────────────────────────────────

--- a/lib/screens/connection_screen.dart
+++ b/lib/screens/connection_screen.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 
 import '../core/connection/aprs_is_connection.dart';
 import '../core/connection/ble_connection.dart';
+import '../core/connection/classic_bt_connection.dart';
 import '../core/connection/connection_registry.dart';
 import '../core/connection/serial_connection.dart';
 import '../core/packet/aprs_packet.dart' show AprsPacket, PacketSource;
@@ -18,6 +19,7 @@ import '../services/station_settings_service.dart';
 import '../theme/meridian_colors.dart';
 import '../ui/widgets/battery_optimization_card.dart';
 import '../ui/widgets/ble_scanner_sheet.dart';
+import '../ui/widgets/classic_bt_device_list.dart';
 import '../ui/widgets/meridian_status_pill.dart';
 import '../ui/widgets/serial_connection_form.dart';
 
@@ -36,8 +38,12 @@ class ConnectionScreen extends StatefulWidget {
 }
 
 class _ConnectionScreenState extends State<ConnectionScreen> {
-  // Segmented control selection index into [ConnectionRegistry.available].
+  // Segmented control selection index into the grouped segment list (BLE and
+  // Classic BT are merged into a single "Bluetooth" segment).
   int _tab = 0;
+
+  // Sub-selector within the merged Bluetooth segment: 0 = BLE, 1 = Classic BT.
+  int _btSubTab = 0;
 
   // Packet counters keyed by connection ID.
   final Map<String, int> _packetCountById = {};
@@ -56,6 +62,7 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
         PacketSource.tnc => 'ble_tnc',
         PacketSource.bleTnc => 'ble_tnc',
         PacketSource.serialTnc => 'serial_tnc',
+        PacketSource.classicBtTnc => 'classic_bt_tnc',
         PacketSource.aprsIs => 'aprs_is',
       };
       _packetCountById[key] = (_packetCountById[key] ?? 0) + 1;
@@ -69,6 +76,7 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
           PacketSource.tnc => 'ble_tnc',
           PacketSource.bleTnc => 'ble_tnc',
           PacketSource.serialTnc => 'serial_tnc',
+          PacketSource.classicBtTnc => 'classic_bt_tnc',
           PacketSource.aprsIs => 'aprs_is',
         };
         _packetCountById[key] = (_packetCountById[key] ?? 0) + 1;
@@ -89,11 +97,11 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
   @override
   Widget build(BuildContext context) {
     final registry = context.watch<ConnectionRegistry>();
-    final available = registry.available;
+    final segments = _buildSegments(registry.available);
 
     // Clamp tab index to remain valid if registry changes.
-    if (_tab >= available.length && available.isNotEmpty) {
-      _tab = available.length - 1;
+    if (_tab >= segments.length && segments.isNotEmpty) {
+      _tab = segments.length - 1;
     }
 
     final activeConnections = registry.all.where((c) {
@@ -165,14 +173,16 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
 
             // ── Segmented control + tabs ──────────────────────────────────
             const SizedBox(height: 20),
-            if (available.length > 1)
+            if (segments.length > 1)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: _buildSegmentedControl(available),
+                child: _buildSegmentedControl(segments),
               ),
             const SizedBox(height: 20),
-            if (available.isNotEmpty)
-              _buildTabContent(available[_tab.clamp(0, available.length - 1)]),
+            if (segments.isNotEmpty)
+              _buildSegmentContent(
+                segments[_tab.clamp(0, segments.length - 1)],
+              ),
           ],
         ),
       ),
@@ -180,16 +190,50 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
   }
 
   // ---------------------------------------------------------------------------
+  // Segment grouping
+  // ---------------------------------------------------------------------------
+
+  /// Collapse the available connections into presentational segments. BLE and
+  /// Classic BT merge into a single "Bluetooth" segment (they remain two
+  /// distinct registered connections — the merge is purely at the selector
+  /// layer); every other connection is its own segment. Registry order is
+  /// preserved: APRS-IS, Bluetooth, Serial.
+  List<_ConnSegment> _buildSegments(List<MeridianConnection> available) {
+    final bluetooth = available
+        .where(
+          (c) =>
+              c.type == ConnectionType.bleTnc ||
+              c.type == ConnectionType.classicBtTnc,
+        )
+        .toList();
+
+    final segments = <_ConnSegment>[];
+    var bluetoothAdded = false;
+    for (final conn in available) {
+      if (conn.type == ConnectionType.bleTnc ||
+          conn.type == ConnectionType.classicBtTnc) {
+        if (!bluetoothAdded) {
+          segments.add(_ConnSegment('Bluetooth', bluetooth));
+          bluetoothAdded = true;
+        }
+        continue;
+      }
+      segments.add(_ConnSegment(conn.displayName, [conn]));
+    }
+    return segments;
+  }
+
+  // ---------------------------------------------------------------------------
   // Segmented control
   // ---------------------------------------------------------------------------
 
-  Widget _buildSegmentedControl(List<MeridianConnection> available) {
+  Widget _buildSegmentedControl(List<_ConnSegment> segments) {
     if (!kIsWeb && Platform.isIOS) {
       final children = <int, Widget>{
-        for (var i = 0; i < available.length; i++)
+        for (var i = 0; i < segments.length; i++)
           i: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
-            child: Text(available[i].displayName),
+            child: Text(segments[i].label),
           ),
       };
       return CupertinoSlidingSegmentedControl<int>(
@@ -201,10 +245,10 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
 
     return SegmentedButton<int>(
       segments: [
-        for (var i = 0; i < available.length; i++)
-          ButtonSegment(value: i, label: Text(available[i].displayName)),
+        for (var i = 0; i < segments.length; i++)
+          ButtonSegment(value: i, label: Text(segments[i].label)),
       ],
-      selected: {_tab.clamp(0, available.length - 1)},
+      selected: {_tab.clamp(0, segments.length - 1)},
       onSelectionChanged: (s) => setState(() => _tab = s.first),
     );
   }
@@ -213,14 +257,83 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
   // Tab content dispatch
   // ---------------------------------------------------------------------------
 
-  Widget _buildTabContent(MeridianConnection conn) {
+  Widget _buildSegmentContent(_ConnSegment segment) {
+    if (segment.isBluetooth) return _buildBluetoothTab(segment);
+    final conn = segment.connections.first;
     if (conn is AprsIsConnection) return _buildAprsTab(conn);
-    if (conn is BleConnection) return _buildBleTab(conn);
     if (conn is SerialConnection) return _buildSerialTab(conn);
     // Fallback for test fakes or unknown connection types.
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Text(conn.displayName),
+    );
+  }
+
+  // ── Bluetooth tab (BLE + Classic BT) ─────────────────────────────────────────
+
+  Widget _buildBluetoothTab(_ConnSegment segment) {
+    final bleList = segment.connections.whereType<BleConnection>().toList();
+    final classicList = segment.connections
+        .whereType<ClassicBtConnection>()
+        .toList();
+    final ble = bleList.isEmpty ? null : bleList.first;
+    final classic = classicList.isEmpty ? null : classicList.first;
+    final theme = Theme.of(context);
+
+    // Chip row renders only when both sub-transports are available (Android).
+    // iOS → BLE only (no chips); desktop (Phase 3) → Classic only (no chips).
+    final showChips = ble != null && classic != null;
+
+    final Widget content;
+    if (showChips) {
+      content = _btSubTab == 0
+          ? _buildBleContent(ble)
+          : _buildClassicContent(classic);
+    } else if (ble != null) {
+      content = _buildBleContent(ble);
+    } else if (classic != null) {
+      content = _buildClassicContent(classic);
+    } else {
+      content = const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _SectionLabel('Bluetooth TNC'),
+          ),
+          if (showChips) ...[
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: 8,
+                children: [
+                  ChoiceChip(
+                    label: const Text('BLE'),
+                    selected: _btSubTab == 0,
+                    onSelected: (_) => setState(() => _btSubTab = 0),
+                  ),
+                  ChoiceChip(
+                    label: const Text('Classic'),
+                    selected: _btSubTab == 1,
+                    onSelected: (_) => setState(() => _btSubTab = 1),
+                  ),
+                ],
+              ),
+            ),
+          ],
+          const SizedBox(height: 16),
+          DefaultTextStyle.merge(
+            style: theme.textTheme.bodyMedium,
+            child: content,
+          ),
+        ],
+      ),
     );
   }
 
@@ -300,41 +413,57 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
     );
   }
 
-  // ── BLE TNC tab ────────────────────────────────────────────────────────────
+  // ── BLE sub-content (inside the Bluetooth tab) ───────────────────────────────
 
-  Widget _buildBleTab(BleConnection conn) {
+  Widget _buildBleContent(BleConnection conn) {
     final isSessionActive =
         conn.status == ConnectionStatus.connected ||
         conn.status == ConnectionStatus.reconnecting ||
         conn.status == ConnectionStatus.waitingForDevice;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // Surfaced whenever the user is on the BLE tab — applies equally
-          // before/after a session is established because the prompt is about
-          // keeping the link alive in the background, not about starting one.
-          const BatteryOptimizationCard(),
-          const SizedBox(height: 12),
-          if (isSessionActive)
-            Text(
-              'Connected — disconnect from the card above.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-            )
-          else
-            BleScannerSheet(
-              bleConnection: conn,
-              showDragHandle: false,
-              onBack: () {},
-              showBackButton: false,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Surfaced whenever the user is on the BLE sub-tab — applies equally
+        // before/after a session is established because the prompt is about
+        // keeping the link alive in the background, not about starting one.
+        const BatteryOptimizationCard(),
+        const SizedBox(height: 12),
+        if (isSessionActive)
+          Text(
+            'Connected — disconnect from the card above.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
-        ],
-      ),
+          )
+        else
+          BleScannerSheet(
+            bleConnection: conn,
+            showDragHandle: false,
+            onBack: () {},
+            showBackButton: false,
+          ),
+      ],
     );
+  }
+
+  // ── Classic BT sub-content (inside the Bluetooth tab) ─────────────────────────
+
+  Widget _buildClassicContent(ClassicBtConnection conn) {
+    final isSessionActive =
+        conn.status == ConnectionStatus.connected ||
+        conn.status == ConnectionStatus.reconnecting ||
+        conn.status == ConnectionStatus.waitingForDevice;
+
+    if (isSessionActive) {
+      return Text(
+        'Connected — disconnect from the card above.',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+    return ClassicBtDeviceList(connection: conn);
   }
 
   // ── Serial TNC tab ─────────────────────────────────────────────────────────
@@ -345,6 +474,26 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
       child: SerialConnectionForm(connection: conn),
     );
   }
+}
+
+// =============================================================================
+// Segment model
+// =============================================================================
+
+/// A presentational segment in the connection selector. Most segments wrap a
+/// single connection; the "Bluetooth" segment groups the BLE and Classic BT
+/// connections behind one tab with a [ChoiceChip] sub-selector.
+class _ConnSegment {
+  const _ConnSegment(this.label, this.connections);
+
+  final String label;
+  final List<MeridianConnection> connections;
+
+  bool get isBluetooth => connections.any(
+    (c) =>
+        c.type == ConnectionType.bleTnc ||
+        c.type == ConnectionType.classicBtTnc,
+  );
 }
 
 // =============================================================================
@@ -363,6 +512,7 @@ class _ActiveConnectionCard extends StatelessWidget {
   static IconData _iconFor(ConnectionType type) => switch (type) {
     ConnectionType.aprsIs => Symbols.wifi,
     ConnectionType.bleTnc => Symbols.bluetooth,
+    ConnectionType.classicBtTnc => Symbols.bluetooth,
     ConnectionType.serialTnc => Symbols.usb,
   };
 
@@ -370,6 +520,9 @@ class _ActiveConnectionCard extends StatelessWidget {
     if (conn is AprsIsConnection) return conn.serverDisplay;
     if (conn is SerialConnection) {
       return conn.activeConfig?.port ?? 'Serial TNC';
+    }
+    if (conn is ClassicBtConnection) {
+      return conn.deviceName ?? conn.deviceAddress ?? 'Classic BT';
     }
     if (conn.type == ConnectionType.bleTnc) return 'BLE TNC';
     return conn.displayName;

--- a/lib/screens/connection_screen.dart
+++ b/lib/screens/connection_screen.dart
@@ -106,6 +106,7 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
 
     final activeConnections = registry.all.where((c) {
       return c.status == ConnectionStatus.connected ||
+          c.status == ConnectionStatus.connecting ||
           c.status == ConnectionStatus.reconnecting ||
           c.status == ConnectionStatus.waitingForDevice;
     }).toList();
@@ -558,9 +559,11 @@ class _ActiveConnectionCard extends StatelessWidget {
                 ),
                 MeridianStatusPill(
                   status: displayStatus,
-                  label: status == ConnectionStatus.connected
-                      ? 'Connected'
-                      : 'Reconnecting\u2026',
+                  label: switch (status) {
+                    ConnectionStatus.connected => 'Connected',
+                    ConnectionStatus.connecting => 'Connecting\u2026',
+                    _ => 'Reconnecting\u2026',
+                  },
                 ),
                 if (conn.beaconingEnabled) ...[
                   const SizedBox(width: 8),

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -367,7 +367,10 @@ class _PacketRow extends StatelessWidget {
   static String _transportLabel(AprsPacket p) {
     final transport = switch (p.transportSource) {
       PacketSource.aprsIs => 'Internet',
-      PacketSource.bleTnc || PacketSource.serialTnc || PacketSource.tnc => 'RF',
+      PacketSource.bleTnc ||
+      PacketSource.serialTnc ||
+      PacketSource.classicBtTnc ||
+      PacketSource.tnc => 'RF',
     };
     return p.isOutgoing ? 'Sent · $transport' : transport;
   }

--- a/lib/services/background_service_manager.dart
+++ b/lib/services/background_service_manager.dart
@@ -799,7 +799,9 @@ class BackgroundServiceManager extends ChangeNotifier
     final connected = _registry.connected;
     final hasTnc = connected.any(
       (c) =>
-          c.type == ConnectionType.bleTnc || c.type == ConnectionType.serialTnc,
+          c.type == ConnectionType.bleTnc ||
+          c.type == ConnectionType.serialTnc ||
+          c.type == ConnectionType.classicBtTnc,
     );
     final hasAprsIs = connected.any((c) => c.type == ConnectionType.aprsIs);
     if (hasTnc && hasAprsIs) return 'Meridian — TNC + APRS-IS';

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -378,6 +378,7 @@ class StationService extends ChangeNotifier {
     ConnectionType.aprsIs => PacketSource.aprsIs,
     ConnectionType.bleTnc => PacketSource.bleTnc,
     ConnectionType.serialTnc => PacketSource.serialTnc,
+    ConnectionType.classicBtTnc => PacketSource.classicBtTnc,
   };
 
   Future<void> _handleLine(

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -1,8 +1,8 @@
 /// TX router that fans out outgoing APRS packets across all connected and
 /// beaconing-enabled [MeridianConnection]s.
 ///
-/// Per-message routing follows the unconditional Serial > BLE > APRS-IS
-/// hierarchy (ADR-029). Per-beacon routing honours
+/// Per-message routing follows the unconditional Serial > Classic BT > BLE >
+/// APRS-IS hierarchy (ADR-029, ADR-069). Per-beacon routing honours
 /// [MeridianConnection.beaconingEnabled] on each connection. There is no
 /// per-message transport override.
 library;
@@ -22,10 +22,12 @@ import 'station_settings_service.dart';
 /// Events emitted by [TxService] to drive banner UI.
 sealed class TxEvent {}
 
-/// A TNC (BLE or Serial) disconnected while RF was the active TX path.
+/// A TNC (Serial, Classic BT, or BLE) disconnected while RF was the active TX
+/// path.
 class TxEventTncDisconnected extends TxEvent {}
 
-/// A TNC (BLE or Serial) reconnected — notify the user that RF is live again.
+/// A TNC (Serial, Classic BT, or BLE) reconnected — notify the user that RF is
+/// live again.
 class TxEventTncReconnected extends TxEvent {}
 
 /// A TX attempt was rejected because the user is not marked as a licensed
@@ -107,10 +109,12 @@ class TxService extends ChangeNotifier {
   /// Send [aprsLine] via the resolved effective connection.
   ///
   /// When [forceVia] is provided, the first connected connection of that type
-  /// is used; otherwise the hierarchy (Serial > BLE > APRS-IS) is applied.
+  /// is used; otherwise the hierarchy (Serial > Classic BT > BLE > APRS-IS) is
+  /// applied.
   ///
   /// [digipeaterPath] overrides the default digipeater aliases when the
-  /// effective connection is RF (BLE or Serial). APRS-IS connections ignore
+  /// effective connection is RF (Serial, Classic BT, or BLE). APRS-IS
+  /// connections ignore
   /// this. Used by v0.17 group-message / bulletin send.
   ///
   /// No-op when the user is unlicensed — TX is unconditionally blocked.
@@ -130,11 +134,12 @@ class TxService extends ChangeNotifier {
   }
 
   /// Send a bulletin packet honoring the per-bulletin transport flags. Unlike
-  /// [sendLine], this does *not* use the Serial > BLE > APRS-IS hierarchy —
-  /// bulletins can independently go via RF, APRS-IS, or both, per the user's
-  /// `viaRf` / `viaAprsIs` settings on each `OutgoingBulletin` (ADR-057).
+  /// [sendLine], this does *not* use the Serial > Classic BT > BLE > APRS-IS
+  /// hierarchy — bulletins can independently go via RF, APRS-IS, or both, per
+  /// the user's `viaRf` / `viaAprsIs` settings on each `OutgoingBulletin`
+  /// (ADR-057).
   ///
-  /// When [viaRf] is true, the first live TNC (Serial preferred over BLE)
+  /// When [viaRf] is true, the first live TNC (Serial, Classic BT, or BLE)
   /// receives the line with [rfPath] as the digipeater path. When [viaAprsIs]
   /// is true, the APRS-IS connection receives the line (paths ignored). If
   /// both are true and both are connected, the line goes to both.

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -56,6 +56,7 @@ class TxService extends ChangeNotifier {
     ConnectionType.aprsIs => PacketSource.aprsIs,
     ConnectionType.bleTnc => PacketSource.bleTnc,
     ConnectionType.serialTnc => PacketSource.serialTnc,
+    ConnectionType.classicBtTnc => PacketSource.classicBtTnc,
   };
 
   bool _tncWasConnected = false;
@@ -97,6 +98,7 @@ class TxService extends ChangeNotifier {
     if (conn == null) return 'Auto';
     return switch (conn.type) {
       ConnectionType.serialTnc => 'Auto [Serial]',
+      ConnectionType.classicBtTnc => 'Auto [Classic BT]',
       ConnectionType.bleTnc => 'Auto [BLE]',
       ConnectionType.aprsIs => 'Auto [APRS-IS]',
     };
@@ -164,6 +166,7 @@ class TxService extends ChangeNotifier {
           .where(
             (c) =>
                 (c.type == ConnectionType.serialTnc ||
+                    c.type == ConnectionType.classicBtTnc ||
                     c.type == ConnectionType.bleTnc) &&
                 c.isConnected,
           )
@@ -230,7 +233,8 @@ class TxService extends ChangeNotifier {
   bool get _tncAvailable => _registry.all.any(
     (c) =>
         (c.type == ConnectionType.bleTnc ||
-            c.type == ConnectionType.serialTnc) &&
+            c.type == ConnectionType.serialTnc ||
+            c.type == ConnectionType.classicBtTnc) &&
         c.isConnected,
   );
 
@@ -258,6 +262,7 @@ class TxService extends ChangeNotifier {
     }
     const order = [
       ConnectionType.serialTnc,
+      ConnectionType.classicBtTnc,
       ConnectionType.bleTnc,
       ConnectionType.aprsIs,
     ];

--- a/lib/services/tx_service.dart
+++ b/lib/services/tx_service.dart
@@ -206,7 +206,7 @@ class TxService extends ChangeNotifier {
     }
   }
 
-  /// Send [aprsLine] to the first connected TNC (Serial takes priority over BLE).
+  /// Send [aprsLine] to the first connected TNC (Serial, Classic BT, or BLE).
   ///
   /// Used by [BackgroundServiceManager] to forward background-isolate IPC
   /// beacon/bulletin requests to the live TNC connection. [digipeaterPath]
@@ -219,6 +219,7 @@ class TxService extends ChangeNotifier {
         .where(
           (c) =>
               (c.type == ConnectionType.serialTnc ||
+                  c.type == ConnectionType.classicBtTnc ||
                   c.type == ConnectionType.bleTnc) &&
               c.isConnected,
         )
@@ -229,7 +230,7 @@ class TxService extends ChangeNotifier {
     }
   }
 
-  /// True when any TNC (BLE or Serial) is currently live.
+  /// True when any TNC (Serial, Classic BT, or BLE) is currently live.
   bool get _tncAvailable => _registry.all.any(
     (c) =>
         (c.type == ConnectionType.bleTnc ||

--- a/lib/ui/widgets/classic_bt_device_list.dart
+++ b/lib/ui/widgets/classic_bt_device_list.dart
@@ -15,9 +15,17 @@ import '../../core/transport/classic_bt_spp_channel.dart';
 /// Requests the `BLUETOOTH_CONNECT` runtime permission (Android 12+/API 31+)
 /// before listing; the native bridge also degrades gracefully if it is denied.
 class ClassicBtDeviceList extends StatefulWidget {
-  const ClassicBtDeviceList({super.key, required this.connection});
+  const ClassicBtDeviceList({
+    super.key,
+    required this.connection,
+    this.onConnectInitiated,
+  });
 
   final ClassicBtConnection connection;
+
+  /// Called the moment a device tap kicks off a connect, before the (slow)
+  /// RFCOMM handshake. Lets the host scroll its status area into view.
+  final VoidCallback? onConnectInitiated;
 
   @override
   State<ClassicBtDeviceList> createState() => _ClassicBtDeviceListState();
@@ -60,6 +68,7 @@ class _ClassicBtDeviceListState extends State<ClassicBtDeviceList> {
   }
 
   Future<void> _connect(ClassicBtPairedDevice device) async {
+    widget.onConnectInitiated?.call();
     setState(() => _connectingAddress = device.address);
     try {
       await widget.connection.connectToDevice(

--- a/lib/ui/widgets/classic_bt_device_list.dart
+++ b/lib/ui/widgets/classic_bt_device_list.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../core/connection/classic_bt_connection.dart';
+import '../../core/transport/classic_bt_spp_channel.dart';
+
+/// Paired-device picker for the Classic Bluetooth SPP transport (ADR-069).
+///
+/// Pairing is owned by the OS — this lists only already-bonded devices
+/// (`BluetoothAdapter.bondedDevices`) and connects to the chosen one. There is
+/// deliberately **no scan**: the user pairs the TNC in Android Bluetooth
+/// settings first, then picks it here.
+///
+/// Requests the `BLUETOOTH_CONNECT` runtime permission (Android 12+/API 31+)
+/// before listing; the native bridge also degrades gracefully if it is denied.
+class ClassicBtDeviceList extends StatefulWidget {
+  const ClassicBtDeviceList({super.key, required this.connection});
+
+  final ClassicBtConnection connection;
+
+  @override
+  State<ClassicBtDeviceList> createState() => _ClassicBtDeviceListState();
+}
+
+enum _LoadState { loading, denied, error, ready }
+
+class _ClassicBtDeviceListState extends State<ClassicBtDeviceList> {
+  _LoadState _state = _LoadState.loading;
+  List<ClassicBtPairedDevice> _devices = const [];
+  String? _connectingAddress;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    if (mounted) setState(() => _state = _LoadState.loading);
+
+    // BLUETOOTH_CONNECT is required to read bonded devices and open RFCOMM on
+    // API 31+. On older Android the request resolves granted immediately.
+    final status = await Permission.bluetoothConnect.request();
+    if (!status.isGranted) {
+      if (mounted) setState(() => _state = _LoadState.denied);
+      return;
+    }
+
+    try {
+      final devices = await widget.connection.pairedDevices();
+      if (!mounted) return;
+      setState(() {
+        _devices = devices;
+        _state = _LoadState.ready;
+      });
+    } catch (_) {
+      if (mounted) setState(() => _state = _LoadState.error);
+    }
+  }
+
+  Future<void> _connect(ClassicBtPairedDevice device) async {
+    setState(() => _connectingAddress = device.address);
+    try {
+      await widget.connection.connectToDevice(
+        device.address,
+        name: device.name,
+      );
+    } finally {
+      if (mounted) setState(() => _connectingAddress = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Pair your TNC in Android Bluetooth settings before connecting here.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 12),
+        switch (_state) {
+          _LoadState.loading => const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator.adaptive()),
+          ),
+          _LoadState.denied => _MessageCard(
+            icon: Symbols.bluetooth_disabled,
+            title: 'Bluetooth permission needed',
+            body:
+                'Grant the Nearby devices / Bluetooth permission to list your '
+                'paired TNCs.',
+            actionLabel: 'Open settings',
+            onAction: openAppSettings,
+          ),
+          _LoadState.error => _MessageCard(
+            icon: Symbols.error,
+            title: 'Could not list devices',
+            body: 'Make sure Bluetooth is turned on, then try again.',
+            actionLabel: 'Retry',
+            onAction: _load,
+          ),
+          _LoadState.ready when _devices.isEmpty => _MessageCard(
+            icon: Symbols.bluetooth_searching,
+            title: 'No paired devices',
+            body: 'Pair your TNC in Android Bluetooth settings, then refresh.',
+            actionLabel: 'Refresh',
+            onAction: _load,
+          ),
+          _LoadState.ready => Card(
+            margin: EdgeInsets.zero,
+            child: Column(
+              children: [
+                for (final device in _devices)
+                  ListTile(
+                    leading: const Icon(Symbols.bluetooth),
+                    title: Text(device.name),
+                    subtitle: Text(device.address),
+                    trailing: _connectingAddress == device.address
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator.adaptive(
+                              strokeWidth: 2,
+                            ),
+                          )
+                        : const Icon(Symbols.chevron_right),
+                    enabled: _connectingAddress == null,
+                    onTap: () => _connect(device),
+                  ),
+              ],
+            ),
+          ),
+        },
+        if (_state == _LoadState.ready && _devices.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: _connectingAddress == null ? _load : null,
+              icon: const Icon(Symbols.refresh),
+              label: const Text('Refresh'),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _MessageCard extends StatelessWidget {
+  const _MessageCard({
+    required this.icon,
+    required this.title,
+    required this.body,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+  final String actionLabel;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: theme.colorScheme.primary),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(title, style: theme.textTheme.titleMedium),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(body, style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.tonal(
+                onPressed: onAction,
+                child: Text(actionLabel),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -271,12 +271,14 @@ class PacketDetailSheet extends StatelessWidget {
 bool _isRf(PacketSource src) =>
     src == PacketSource.bleTnc ||
     src == PacketSource.serialTnc ||
+    src == PacketSource.classicBtTnc ||
     src == PacketSource.tnc;
 
 String _transportLabel(PacketSource src) => switch (src) {
   PacketSource.aprsIs => 'Internet (APRS-IS)',
   PacketSource.bleTnc => 'RF (BLE TNC)',
   PacketSource.serialTnc => 'RF (Serial TNC)',
+  PacketSource.classicBtTnc => 'RF (Classic BT)',
   PacketSource.tnc => 'RF (TNC)',
 };
 

--- a/test/core/connection/classic_bt_connection_test.dart
+++ b/test/core/connection/classic_bt_connection_test.dart
@@ -1,0 +1,184 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/core/connection/classic_bt_connection_impl.dart';
+import 'package:meridian_aprs/core/connection/meridian_connection.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/fake_classic_bt_tnc_transport.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testAddress = '00:11:22:33:44:55';
+const _testName = 'TH-D75';
+
+// Build raw AX.25 payload bytes (no KISS wrapper — matches frameStream output).
+Uint8List _buildRawAx25(String src, String dst, String aprsInfo) {
+  List<int> encodeAddr(String call, int ssid, {bool last = false}) {
+    final bytes = List<int>.filled(7, 0);
+    final padded = call.padRight(6);
+    for (int i = 0; i < 6; i++) {
+      bytes[i] = padded.codeUnitAt(i) << 1;
+    }
+    bytes[6] = ((ssid & 0x0F) << 1) | (last ? 0x01 : 0x00);
+    return bytes;
+  }
+
+  final addr = <int>[...encodeAddr(dst, 0), ...encodeAddr(src, 0, last: true)];
+  return Uint8List.fromList([...addr, 0x03, 0xF0, ...aprsInfo.codeUnits]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late ClassicBtConnection conn;
+  late FakeClassicBtTncTransport fakeTransport;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    fakeTransport = FakeClassicBtTncTransport();
+    conn = ClassicBtConnection();
+    conn.transportFactory = (_) => fakeTransport;
+  });
+
+  tearDown(() async {
+    await conn.dispose();
+    await fakeTransport.close();
+  });
+
+  test('id, displayName, type are correct', () {
+    expect(conn.id, 'classic_bt_tnc');
+    expect(conn.displayName, 'Classic BT');
+    expect(conn.type, ConnectionType.classicBtTnc);
+  });
+
+  test('initial state is disconnected', () {
+    expect(conn.status, ConnectionStatus.disconnected);
+    expect(conn.isConnected, isFalse);
+  });
+
+  test('connectToDevice transitions to connected', () async {
+    await conn.connectToDevice(_testAddress, name: _testName);
+    expect(conn.isConnected, isTrue);
+    expect(conn.status, ConnectionStatus.connected);
+    expect(conn.deviceAddress, _testAddress);
+    expect(conn.deviceName, _testName);
+  });
+
+  test('disconnect transitions to disconnected', () async {
+    await conn.connectToDevice(_testAddress);
+    await conn.disconnect();
+    expect(conn.isConnected, isFalse);
+    expect(conn.status, ConnectionStatus.disconnected);
+  });
+
+  test('connectionState stream emits status transitions', () async {
+    final states = <ConnectionStatus>[];
+    conn.connectionState.listen(states.add);
+
+    await conn.connectToDevice(_testAddress);
+    await conn.disconnect();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(states, containsAll([ConnectionStatus.connected]));
+  });
+
+  test('lines stream emits APRS text from AX.25 frames', () async {
+    final received = <String>[];
+    conn.lines.listen(received.add);
+
+    await conn.connectToDevice(_testAddress);
+
+    final rawAx25 = _buildRawAx25(
+      'W1AW',
+      'APMDN0',
+      '!4903.50N/07201.75W>Test comment',
+    );
+    fakeTransport.simulateFrame(rawAx25);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(received, hasLength(1));
+    expect(received.first, contains('W1AW'));
+  });
+
+  test('sendLine encodes to AX.25 and calls sendFrame', () async {
+    await conn.connectToDevice(_testAddress);
+    await conn.sendLine('W1AW-9>APMDN0,TCPIP*:!4903.50N/07201.75W>Hello');
+    expect(fakeTransport.sentFrames, hasLength(1));
+  });
+
+  test('connect() throws when no device is set', () async {
+    await expectLater(conn.connect(), throwsStateError);
+  });
+
+  test('connect() failure sets error status and lastErrorMessage', () async {
+    fakeTransport.connectThrows = true;
+    await conn.connectToDevice(_testAddress, name: _testName);
+    expect(conn.status, ConnectionStatus.error);
+    expect(conn.lastErrorMessage, isNotNull);
+    expect(conn.lastErrorMessage, contains(_testName));
+  });
+
+  test('beaconingEnabled defaults to true', () {
+    expect(conn.beaconingEnabled, isTrue);
+  });
+
+  test('setBeaconingEnabled persists to SharedPreferences', () async {
+    await conn.setBeaconingEnabled(false);
+    expect(conn.beaconingEnabled, isFalse);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('beacon_enabled_classic_bt_tnc'), isFalse);
+  });
+
+  test('connectToDevice persists address and name', () async {
+    await conn.connectToDevice(_testAddress, name: _testName);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('classic_bt_address'), _testAddress);
+    expect(prefs.getString('classic_bt_name'), _testName);
+  });
+
+  test('loadPersistedSettings restores beaconing and device', () async {
+    SharedPreferences.setMockInitialValues({
+      'beacon_enabled_classic_bt_tnc': false,
+      'classic_bt_address': 'AA:BB:CC:DD:EE:FF',
+      'classic_bt_name': 'Mobilinkd',
+    });
+    final conn2 = ClassicBtConnection();
+    conn2.transportFactory = (_) => FakeClassicBtTncTransport();
+    await conn2.loadPersistedSettings();
+    expect(conn2.beaconingEnabled, isFalse);
+    expect(conn2.deviceAddress, 'AA:BB:CC:DD:EE:FF');
+    expect(conn2.deviceName, 'Mobilinkd');
+    await conn2.dispose();
+  });
+
+  test(
+    'no reconnect on initial connect failure (session never connected)',
+    () async {
+      fakeTransport.connectThrows = true;
+      await conn.connectToDevice(_testAddress);
+      expect(conn.status, ConnectionStatus.error);
+      expect(conn.hasScheduledRetry, isFalse);
+    },
+  );
+
+  test('auto-reconnects after mid-session error', () async {
+    await conn.connectToDevice(_testAddress);
+    expect(conn.status, ConnectionStatus.connected);
+
+    // Simulate a transport-level error (e.g. RFCOMM link drop).
+    fakeTransport.simulateUnexpectedDisconnect();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(conn.status, ConnectionStatus.reconnecting);
+    expect(conn.hasScheduledRetry, isTrue);
+
+    await conn.disconnect();
+    expect(conn.status, ConnectionStatus.disconnected);
+    expect(conn.hasScheduledRetry, isFalse);
+  });
+}

--- a/test/helpers/fake_classic_bt_tnc_transport.dart
+++ b/test/helpers/fake_classic_bt_tnc_transport.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:meridian_aprs/core/transport/aprs_transport.dart'
+    show ConnectionStatus;
+import 'package:meridian_aprs/core/transport/kiss_tnc_transport.dart';
+
+/// Fully controllable [KissTncTransport] for use in Classic BT connection
+/// tests. Mirrors [FakeSerialKissTransport]; the real Classic transport is
+/// stream-driven and async, so the synchronous `connect → connected` modelled
+/// here is only validated end-to-end on hardware.
+class FakeClassicBtTncTransport extends KissTncTransport {
+  // sync: true so events fire synchronously in tests without extra awaits.
+  final _frameController = StreamController<Uint8List>.broadcast(sync: true);
+  final _stateController = StreamController<ConnectionStatus>.broadcast(
+    sync: true,
+  );
+
+  ConnectionStatus _status = ConnectionStatus.disconnected;
+  bool disconnectCalled = false;
+  bool connectThrows = false;
+  final List<Uint8List> sentFrames = [];
+
+  @override
+  Stream<Uint8List> get frameStream => _frameController.stream;
+
+  @override
+  Stream<ConnectionStatus> get connectionState => _stateController.stream;
+
+  @override
+  ConnectionStatus get currentStatus => _status;
+
+  @override
+  bool get isConnected => _status == ConnectionStatus.connected;
+
+  @override
+  Future<void> connect() async {
+    _setStatus(ConnectionStatus.connecting);
+    if (connectThrows) {
+      _setStatus(ConnectionStatus.error);
+      throw Exception('FakeClassicBtTncTransport: connect failed');
+    }
+    _setStatus(ConnectionStatus.connected);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalled = true;
+    _setStatus(ConnectionStatus.disconnected);
+  }
+
+  @override
+  Future<void> sendFrame(Uint8List ax25Frame) async {
+    if (!isConnected) {
+      throw StateError('FakeClassicBtTncTransport: not connected');
+    }
+    sentFrames.add(ax25Frame);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  void simulateFrame(Uint8List frame) => _frameController.add(frame);
+
+  void simulateUnexpectedDisconnect() => _setStatus(ConnectionStatus.error);
+
+  void _setStatus(ConnectionStatus s) {
+    _status = s;
+    if (!_stateController.isClosed) _stateController.add(s);
+  }
+
+  Future<void> close() async {
+    await _frameController.close();
+    await _stateController.close();
+  }
+}

--- a/test/services/tx_service_routing_test.dart
+++ b/test/services/tx_service_routing_test.dart
@@ -1,8 +1,9 @@
 /// Tests that [TxService] routes outgoing TX correctly when licensed.
 ///
-/// `sendLine` follows the unconditional Serial > BLE > APRS-IS hierarchy
-/// (ADR-029) with an optional `forceVia` per-message override. `sendBeacon`
-/// fans out to every connected connection where `beaconingEnabled` is true.
+/// `sendLine` follows the unconditional Serial > Classic > BLE > APRS-IS
+/// hierarchy (ADR-029, ADR-069) with an optional `forceVia` per-message
+/// override. `sendBeacon` fans out to every connected connection where
+/// `beaconingEnabled` is true.
 library;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/test/services/tx_service_routing_test.dart
+++ b/test/services/tx_service_routing_test.dart
@@ -97,6 +97,39 @@ void main() {
       expect(aprsIs.lastSentLine, isNull);
     });
 
+    test('Classic BT + APRS-IS → Classic wins', () async {
+      final classic = makeConn(
+        id: 'classic',
+        type: ConnectionType.classicBtTnc,
+      );
+      final aprsIs = makeConn(id: 'aprs_is', type: ConnectionType.aprsIs);
+      await tx.sendLine('LINE');
+      expect(classic.lastSentLine, 'LINE');
+      expect(aprsIs.lastSentLine, isNull);
+    });
+
+    test('Classic BT beats BLE (Serial > Classic > BLE)', () async {
+      final classic = makeConn(
+        id: 'classic',
+        type: ConnectionType.classicBtTnc,
+      );
+      final ble = makeConn(id: 'ble', type: ConnectionType.bleTnc);
+      await tx.sendLine('LINE');
+      expect(classic.lastSentLine, 'LINE');
+      expect(ble.lastSentLine, isNull);
+    });
+
+    test('Serial beats Classic BT (Serial > Classic)', () async {
+      final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
+      final classic = makeConn(
+        id: 'classic',
+        type: ConnectionType.classicBtTnc,
+      );
+      await tx.sendLine('LINE');
+      expect(serial.lastSentLine, 'LINE');
+      expect(classic.lastSentLine, isNull);
+    });
+
     test('forceVia: ConnectionType.aprsIs overrides hierarchy', () async {
       final serial = makeConn(id: 'serial', type: ConnectionType.serialTnc);
       final ble = makeConn(id: 'ble', type: ConnectionType.bleTnc);


### PR DESCRIPTION
## Summary

Adds **Classic Bluetooth SPP (RFCOMM)** as Meridian's 4th transport, shipped on **Android** (ADR-069). SPP is the **serial twin** of `SerialConnection` — a raw bidirectional byte stream through the shared, transport-agnostic `KissFramer`, not the BLE/GATT model. Unlocks installed-base hardware reachable only over Classic BT: APRS HTs/mobiles with built-in or add-on Classic Bluetooth, and pre-BLE Bluetooth TNCs.

Approach (per ADR-069): a thin **native Kotlin platform channel** (`meridian/classic_bt` + RX `EventChannel`) opening an RFCOMM socket over the standard SPP UUID — not a Flutter plugin (no maintained GPL-compatible Classic-SPP plugin exists, and a native channel is the only desktop path anyway).

## What's included

**Transport + connection**
- `ClassicBtTncTransport implements KissTncTransport` over a shared, single-sink `ClassicBtSppChannel`
- `ClassicBtConnection extends MeridianConnection with ReconnectableMixin` (active-polling reconnect, like Serial). Owns **one** long-lived channel for its lifetime — the native RX `EventChannel` is single-sink, so sharing it across per-connect transports avoids the listener race that would drop the sink on reconnect.
- Conditional-export trio (impl/shim/stub) so the symbols compile on every platform; instantiation gated to Android.

**Enums + completeness sweep** (append-only)
- `ConnectionType.classicBtTnc` + `PacketSource.classicBtTnc`
- Every exhaustive switch updated; non-exhaustive `||` groupings handled manually. TX hierarchy is now **Serial > Classic > BLE > APRS-IS**.

**Platform + UI**
- Registered under the Android gate in `main.dart`.
- Merged **"Bluetooth"** segment in the Connection screen with a `[BLE | Classic]` `ChoiceChip` sub-selector (chips only when both available → iOS shows BLE only). New `ClassicBtDeviceList` paired-device picker (no in-app scan — OS owns pairing).
- Runtime `BLUETOOTH_CONNECT` request + legacy `BLUETOOTH` (`maxSdkVersion=30`) for API ≤30 RFCOMM.
- "Connecting…" indicator: the Active Connections card now appears during the connecting phase.

**iOS** is excluded by platform restriction (Classic BT requires MFi/ExternalAccessory) — documented, not surfaced as an error.

## Hardware validation (Kenwood TH-D75)

- ✅ RX decoded packets in the packet log
- ✅ TX beacon keys the radio — confirmed on aprs.fi
- ✅ Background reconnect + background RX after screen lock
- Secure RFCOMM socket was sufficient (no insecure-socket fallback needed)

> **Radio setup requirement** (documented in CAPABILITIES/ROADMAP): the TH-D75's built-in TNC only forwards KISS to the host in **KISS 12 mode with its own beaconing (BCON) off**. With BCON on, the radio keeps the data path for its internal APRS engine and the link stays silent both ways.

## Test coverage

- `test/helpers/fake_classic_bt_tnc_transport.dart` + `test/core/connection/classic_bt_connection_test.dart` (mirror Serial: identity, connect→connected, RX line decode, beaconing pref round-trip, persistence, reconnect-on-error)
- Classic BT TX routing-order tests in `tx_service_routing_test.dart`
- `flutter analyze` clean · **818 tests pass** · `dart format` · `flutter build linux --debug` (stub path) + `flutter build apk --debug` (impl + Kotlin + merged manifest) green

## Scope note

Desktop Classic BT (Linux BlueZ → Windows/macOS) and desktop-BLE enablement are **deferred** to a future effort (tracked in `docs/FUTURE_FEATURES.md`); plan-mode required before that native work.

## Docs

ADR-069 (status → Accepted & shipped), ROADMAP (v0.21 Android shipped), CAPABILITIES (transport row, matrix, setup note), CLAUDE.md (→ v0.22 next), FUTURE_FEATURES (desktop entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android: Classic Bluetooth SPP (RFCOMM) support added — device picker UI, permission prompt, connect/disconnect, TX routing, and active-connection UI integration; last-device and beacon settings persist.

* **Documentation**
  * Roadmap, capabilities, decisions, and docs updated; v0.21 marked shipped on Android and ADR added for Classic BT SPP.

* **Tests**
  * Added unit tests and test helpers covering Classic BT connection, persistence, reconnect, and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->