### PR TITLE
feat(parser): decode third-party, telemetry, positioned weather, queries, capabilities + Kenwood TH-D75

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -46,9 +46,12 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 - **ObjectPacket** — APRS objects with live/killed flag
 - **ItemPacket** — APRS items
 - **StatusPacket** — text status reports
-- **WeatherPacket** — weather report fields parsed and surfaced on station detail
+- **WeatherPacket** — standalone (`_`) reports **and** weather embedded in an uncompressed position report (`_` symbol code: wind dir/speed from the course/speed slot + wx fields), binned as weather with position so it lands on the map
 - **TelemetryPacket** — `T#` data reports (sequence, up to five analog channels, digital bits); definition messages (PARM/UNIT/EQNS/BITS) tracked for a follow-up
+- **QueryPacket** — general queries (DTI `?`, e.g. `?APRS?`); decoded for visibility, no auto-response
+- **CapabilitiesPacket** — station capabilities (DTI `<`, e.g. `IGATE,MSG_CNT,LOC_CNT`)
 - **Third-party traffic (`}`)** — unwrapped and re-parsed to the inner packet, attributed to the inner source with the relaying gateway recorded (`thirdPartyVia`, shown as "Relayed via" in the detail sheet)
+- **Mic-E vendor IDs** — Kenwood legacy prefix/suffix incl. TH-D75 (`>`+`&`); Yaesu / Anytone / Byonics suffixes
 
 ### Parsed but minimally surfaced
 - Capability flags (e.g., messaging-capable indicator on station sheet)
@@ -63,7 +66,10 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 ### Explicit non-support
 - Object / Item *creation* — display only (creation tracked in `FUTURE_FEATURES.md`)
 - Telemetry *definitions* (PARM/UNIT/EQNS/BITS) — data reports decode now; labelled/scaled channels via a definition store are a planned follow-up
-- DX-cluster packets, NMEA passthrough, raw GPS sentences
+- Weather embedded in *compressed* positions and in object/item/Mic-E reports — only uncompressed position weather is promoted today (follow-up)
+- Position data extensions PHG / RNG / DFS — left in the comment, not separately decoded
+- Query auto-response — queries are decoded for visibility only
+- DX-cluster packets, NMEA passthrough, raw GPS sentences (`$`), Peet Bros (`#`/`*`), Agrelo (`%`), Maidenhead grid beacons (`[`), user-defined (`{`) — fall back to `UnknownPacket`
 
 ### AX.25 Layer
 - Pure-Dart UI-frame decoder; sealed `Ax25ParseResult` (`Ax25Ok` / `Ax25Err`); never throws

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -47,6 +47,8 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 - **ItemPacket** — APRS items
 - **StatusPacket** — text status reports
 - **WeatherPacket** — weather report fields parsed and surfaced on station detail
+- **TelemetryPacket** — `T#` data reports (sequence, up to five analog channels, digital bits); definition messages (PARM/UNIT/EQNS/BITS) tracked for a follow-up
+- **Third-party traffic (`}`)** — unwrapped and re-parsed to the inner packet, attributed to the inner source with the relaying gateway recorded (`thirdPartyVia`, shown as "Relayed via" in the detail sheet)
 
 ### Parsed but minimally surfaced
 - Capability flags (e.g., messaging-capable indicator on station sheet)
@@ -60,7 +62,7 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 
 ### Explicit non-support
 - Object / Item *creation* — display only (creation tracked in `FUTURE_FEATURES.md`)
-- Telemetry packets (`T#`) — parsed as `UnknownPacket` today
+- Telemetry *definitions* (PARM/UNIT/EQNS/BITS) — data reports decode now; labelled/scaled channels via a definition store are a planned follow-up
 - DX-cluster packets, NMEA passthrough, raw GPS sentences
 
 ### AX.25 Layer

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -37,6 +37,13 @@ sealed class AprsPacket {
   /// because the parser is unaware of TX direction.
   bool isOutgoing;
 
+  /// When this packet arrived wrapped in third-party traffic (DTI `}`), the
+  /// callsign of the gateway/station that re-injected it. Null for packets
+  /// received directly. Set after construction by the parser (like
+  /// [isOutgoing]); because the parser keeps [rawLine] as the full outer line,
+  /// this reconstructs deterministically on re-parse and is never persisted.
+  String? thirdPartyVia;
+
   AprsPacket({
     required this.rawLine,
     required this.source,
@@ -361,6 +368,47 @@ class MicEPacket extends AprsPacket {
     required this.comment,
     required this.micEMessage,
     this.device,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry
+// ---------------------------------------------------------------------------
+
+/// An APRS telemetry data report (DTI: T).
+///
+/// Carries up to five analog channel values and a digital (binary) field,
+/// tagged by a sequence identifier. Channel labels, units, and scaling
+/// equations arrive separately as telemetry *definition* messages
+/// (PARM/UNIT/EQNS/BITS) and are correlated at the service layer — this packet
+/// holds the raw transmitted values only.
+class TelemetryPacket extends AprsPacket {
+  /// Sequence identifier from the `T#` field, e.g. "014". Stored as text
+  /// because the non-numeric literal "MIC" is also valid per APRS spec.
+  final String sequence;
+
+  /// Analog channel values in transmission order (up to five). A null entry
+  /// marks a field that was blank or could not be parsed.
+  final List<double?> analog;
+
+  /// Digital bits as transmitted (conventionally eight, MSB first). Senders
+  /// occasionally truncate; the list reflects exactly what was sent.
+  final List<bool> digital;
+
+  /// Free-text comment following the digital field, if any.
+  final String? comment;
+
+  TelemetryPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    super.transportSource,
+    required this.sequence,
+    required this.analog,
+    required this.digital,
+    this.comment,
   });
 }
 

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -147,6 +147,10 @@ class WeatherPacket extends AprsPacket {
   /// Rainfall since midnight, in hundredths of an inch (APRS field `P`).
   final double? rainSinceMidnight;
 
+  /// Timestamp encoded in the info field (positioned weather reports with a
+  /// `/` or `@` DTI carry one); null for positionless reports.
+  final DateTime? timestamp;
+
   WeatherPacket({
     required super.rawLine,
     required super.source,
@@ -167,6 +171,7 @@ class WeatherPacket extends AprsPacket {
     this.rainfall1h,
     this.rainfall24h,
     this.rainSinceMidnight,
+    this.timestamp,
   });
 }
 
@@ -368,6 +373,53 @@ class MicEPacket extends AprsPacket {
     required this.comment,
     required this.micEMessage,
     this.device,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+/// An APRS query packet (DTI: ?).
+///
+/// General queries broadcast to the network, e.g. `?APRS?`, `?WX?`, `?IGATE?`.
+/// Decoded for visibility only — Meridian does not auto-respond. (Directed
+/// queries sent inside a message keep DTI `:` and decode as [MessagePacket].)
+class QueryPacket extends AprsPacket {
+  /// The query keyword without the surrounding `?`, e.g. `APRS`, `WX`.
+  final String query;
+
+  QueryPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    super.transportSource,
+    required this.query,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Station capabilities
+// ---------------------------------------------------------------------------
+
+/// An APRS station-capabilities packet (DTI: <).
+///
+/// Carries a comma-separated list of capability tokens a station advertises,
+/// e.g. `IGATE,MSG_CNT=2,LOC_CNT=18`. Decoded for visibility only.
+class CapabilitiesPacket extends AprsPacket {
+  /// Raw capabilities text after the `<` DTI.
+  final String capabilities;
+
+  CapabilitiesPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    super.transportSource,
+    required this.capabilities,
   });
 }
 

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1384,7 +1384,9 @@ class AprsParser {
         // 'P' field: rainfall since midnight, in hundredths of an inch.
         f.rainSinceMidnight = double.tryParse(m.group(7)!);
       } else if (m.group(8) != null) {
-        f.humidity = int.tryParse(m.group(8)!);
+        // APRS 1.0.1 §12: humidity is hNN with h00 meaning 100%.
+        final h = int.tryParse(m.group(8)!);
+        if (h != null) f.humidity = h == 0 ? 100 : h;
       } else if (m.group(9) != null) {
         final raw = int.tryParse(m.group(9)!);
         if (raw != null) f.pressure = raw / 10.0; // tenths of mb → mb

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1603,10 +1603,11 @@ class AprsParser {
     // Strip device-indicator trailing byte from the comment.
     if (micEPrefix != null) {
       // Legacy Kenwood: at most a single trailing byte (`=` for D710/D72A,
-      // `^` for D74, `v` reserved). If it's not one of those, it's user text
-      // and must be left intact.
+      // `^` for D74, `&` for TH-D75, `v` reserved). If it's not one of those,
+      // it's user text and must be left intact.
       if (comment.endsWith('=') ||
           comment.endsWith('^') ||
+          comment.endsWith('&') ||
           comment.endsWith('v')) {
         comment = comment.substring(0, comment.length - 1);
       }

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -42,10 +42,39 @@ class AprsParser {
     required DateTime receivedAt,
     PacketSource transportSource = PacketSource.aprsIs,
   }) {
+    return _parseInternal(
+      line: line,
+      rawLine: line,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      depth: 0,
+    );
+  }
+
+  /// Maximum third-party (`}`) unwrapping depth. One level covers all real
+  /// traffic (an igate re-injecting a heard packet); the small cap is a guard
+  /// against pathological/looped nesting so [parse] keeps its never-throws,
+  /// always-terminates contract.
+  static const int _kMaxThirdPartyDepth = 2;
+
+  /// Core parse used by [parse] and by third-party unwrapping.
+  ///
+  /// [line] is the packet text actually being decoded — for a third-party
+  /// payload this is the *inner* packet. [rawLine] is the original outer line
+  /// stamped onto every produced packet so the Raw Packet display and the
+  /// re-parse-from-DB path both see the complete frame. [depth] tracks
+  /// third-party nesting.
+  AprsPacket _parseInternal({
+    required String line,
+    required String rawLine,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+    required int depth,
+  }) {
     // Ignore blank lines and server comment lines.
     if (line.isEmpty || line.startsWith('#')) {
       return _unknown(
-        line,
+        rawLine,
         '',
         '',
         [],
@@ -59,7 +88,7 @@ class AprsParser {
     final colonIdx = line.indexOf(':');
     if (colonIdx < 0 || colonIdx + 1 > line.length) {
       return _unknown(
-        line,
+        rawLine,
         '',
         '',
         [],
@@ -76,7 +105,7 @@ class AprsParser {
     final gtIdx = header.indexOf('>');
     if (gtIdx <= 0) {
       return _unknown(
-        line,
+        rawLine,
         '',
         '',
         [],
@@ -93,7 +122,7 @@ class AprsParser {
 
     if (info.isEmpty) {
       return _unknown(
-        line,
+        rawLine,
         source,
         destination,
         path,
@@ -109,17 +138,18 @@ class AprsParser {
       return _dispatch(
         dti: dti,
         info: info,
-        rawLine: line,
+        rawLine: rawLine,
         source: source,
         destination: destination,
         path: path,
         receivedAt: receivedAt,
         transportSource: transportSource,
+        depth: depth,
       );
     } catch (_) {
       // Belt-and-suspenders: never propagate exceptions.
       return UnknownPacket(
-        rawLine: line,
+        rawLine: rawLine,
         source: source,
         destination: destination,
         path: path,
@@ -180,6 +210,7 @@ class AprsParser {
     required List<String> path,
     required DateTime receivedAt,
     required PacketSource transportSource,
+    required int depth,
   }) {
     switch (dti) {
       // Position without timestamp — no messaging (!) or messaging (=)
@@ -280,17 +311,30 @@ class AprsParser {
           transportSource: transportSource,
         );
 
-      // Telemetry — parsed as Unknown for now (v0.2 scope)
+      // Telemetry data report.
       case 'T':
-        return UnknownPacket(
+        return _parseTelemetry(
+          info: info,
           rawLine: rawLine,
           source: source,
           destination: destination,
           path: path,
           receivedAt: receivedAt,
           transportSource: transportSource,
-          reason: 'Telemetry not yet implemented',
-          rawInfo: info,
+        );
+
+      // Third-party traffic: an igate/gateway re-injecting a packet it heard.
+      // The info field after the `}` indicator is a complete inner packet.
+      case '}':
+        return _parseThirdParty(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          transportSource: transportSource,
+          depth: depth,
         );
 
       default:
@@ -305,6 +349,136 @@ class AprsParser {
           transportSource: transportSource,
         );
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Third-party traffic  (DTI: })
+  // ---------------------------------------------------------------------------
+
+  /// Decode third-party traffic by unwrapping the embedded inner packet.
+  ///
+  /// Format: `}` immediately followed by a complete APRS packet
+  /// (`SOURCE>DEST,PATH:INFO`). The inner packet is re-parsed and returned as
+  /// its own typed packet — attributed to the *inner* source — with
+  /// [AprsPacket.thirdPartyVia] stamped to the relaying gateway (the outer
+  /// [source]). [rawLine] stays the full outer line so the re-parse-from-DB
+  /// path stays deterministic and the Raw Packet display shows the whole frame.
+  AprsPacket _parseThirdParty({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+    required int depth,
+  }) {
+    if (depth >= _kMaxThirdPartyDepth) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Third-party nesting too deep',
+        rawInfo: info,
+        receivedAt: receivedAt,
+        transportSource: transportSource,
+      );
+    }
+
+    final inner = info.substring(1); // strip the leading '}'
+    if (inner.isEmpty) {
+      return _unknown(
+        rawLine,
+        source,
+        destination,
+        path,
+        'Empty third-party payload',
+        rawInfo: info,
+        receivedAt: receivedAt,
+        transportSource: transportSource,
+      );
+    }
+
+    final innerPacket = _parseInternal(
+      line: inner,
+      rawLine: rawLine,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      depth: depth + 1,
+    );
+    // Attribute the relay to the gateway that re-injected this packet.
+    innerPacket.thirdPartyVia = source;
+    return innerPacket;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Telemetry parsing  (DTI: T)
+  // ---------------------------------------------------------------------------
+
+  // Splits a digital-bits token into the leading run of 0/1 bits and any
+  // trailing comment text (some senders append free text after the bit field).
+  static final _telemetryBitsRe = RegExp(r'^([01]+)(.*)$', dotAll: true);
+
+  /// Decode a telemetry data report: `T#sss,a1,a2,a3,a4,a5,bbbbbbbb[comment]`.
+  ///
+  /// The leading `#` is conventional but some encoders omit it; the sequence
+  /// id may be numeric ("014") or the literal "MIC". Up to five analog
+  /// channels precede an eight-bit digital field. Missing or unparseable
+  /// fields decode to null/false rather than failing the whole packet — `T` is
+  /// telemetry-only per APRS spec, so we always return a [TelemetryPacket].
+  AprsPacket _parseTelemetry({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+  }) {
+    var payload = info.substring(1); // drop the 'T' DTI
+    if (payload.startsWith('#')) payload = payload.substring(1);
+
+    final tokens = payload.split(',');
+    final sequence = tokens.isNotEmpty ? tokens.first.trim() : '';
+
+    final analog = <double?>[];
+    for (var i = 1; i <= 5 && i < tokens.length; i++) {
+      analog.add(double.tryParse(tokens[i].trim()));
+    }
+
+    var digital = const <bool>[];
+    String? comment;
+    if (tokens.length > 6) {
+      final bitsToken = tokens[6];
+      final m = _telemetryBitsRe.firstMatch(bitsToken);
+      if (m != null) {
+        digital = [for (final c in m.group(1)!.split('')) c == '1'];
+        final rest = m.group(2)!;
+        if (rest.isNotEmpty) comment = rest;
+      } else if (bitsToken.isNotEmpty) {
+        comment = bitsToken;
+      }
+    }
+    // Any tokens past the digital field belong to the comment verbatim
+    // (a comment may itself contain commas).
+    if (tokens.length > 7) {
+      final tail = tokens.sublist(7).join(',');
+      comment = (comment == null || comment.isEmpty) ? tail : '$comment,$tail';
+    }
+
+    return TelemetryPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      sequence: sequence,
+      analog: analog,
+      digital: digital,
+      comment: comment,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -18,6 +18,20 @@ class _CsT {
   final String comment;
 }
 
+/// Mutable scratch holder for the scalar fields scanned out of a weather-data
+/// string. Used by both standalone (`_`) and positioned weather parsing.
+class _WxFields {
+  int? windDir;
+  double? windSpeed;
+  double? windGust;
+  double? temperature;
+  int? humidity;
+  double? pressure;
+  double? rainfall1h;
+  double? rainfall24h;
+  double? rainSinceMidnight;
+}
+
 /// Full APRS packet parser.
 ///
 /// [parse] accepts an APRS-IS text line and returns a typed [AprsPacket].
@@ -289,6 +303,31 @@ class AprsParser {
 
       case '>':
         return _parseStatus(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          transportSource: transportSource,
+        );
+
+      // General query (e.g. ?APRS?). Directed queries arrive inside a message
+      // (DTI ':') and are handled there.
+      case '?':
+        return _parseQuery(
+          info: info,
+          rawLine: rawLine,
+          source: source,
+          destination: destination,
+          path: path,
+          receivedAt: receivedAt,
+          transportSource: transportSource,
+        );
+
+      // Station capabilities (e.g. <IGATE,MSG_CNT=2,LOC_CNT=18).
+      case '<':
+        return _parseCapabilities(
           info: info,
           rawLine: rawLine,
           source: source,
@@ -649,6 +688,30 @@ class AprsParser {
     final symbolTable = m.group(3)!;
     final symbolCode = m.group(6)!;
     var comment = m.group(7)!;
+
+    // Weather station: a `_` symbol code means this position carries a weather
+    // report — the `ddd/sss` in the course/speed slot is wind direction/speed
+    // and the remainder holds the wx fields. Bin as a WeatherPacket WITH the
+    // position. The symbol is the only reliable discriminator: a moving station
+    // with course/speed has an identical `ddd/sss` but a non-`_` symbol and
+    // must stay a PositionPacket. (Compressed `_` weather and object/item/Mic-E
+    // weather are not yet promoted — tracked as a follow-up.)
+    if (symbolCode == '_') {
+      return _buildPositionedWeather(
+        comment: comment,
+        rawLine: rawLine,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: receivedAt,
+        transportSource: transportSource,
+        lat: lat,
+        lon: lon,
+        symbolTable: symbolTable,
+        symbolCode: symbolCode,
+        timestamp: packetTimestamp,
+      );
+    }
 
     // Extract course/speed from beginning of comment.
     int? course;
@@ -1211,6 +1274,10 @@ class AprsParser {
     r'c(\d{3})|s(\d{3})|g(\d{3})|t(-?\d{3})|r(\d{3})|p(\d{3})|P(\d{3})|h(\d{2})|b(\d{5})',
   );
 
+  // Wind in a positioned weather report uses the course/speed slot:
+  // `ddd/sss` = wind direction (degrees) / wind speed (mph).
+  static final _windRe = RegExp(r'^(\d{3})/(\d{3})');
+
   AprsPacket _parseWeather({
     required String info,
     required String rawLine,
@@ -1223,40 +1290,7 @@ class AprsParser {
     // Skip DTI and 8-char timestamp (MMDDhhmm).
     // Some implementations omit the timestamp; handle both.
     final weatherData = info.length > 9 ? info.substring(9) : info.substring(1);
-
-    int? windDir;
-    double? windSpeed;
-    double? windGust;
-    double? temperature;
-    int? humidity;
-    double? pressure;
-    double? rainfall1h;
-    double? rainfall24h;
-    double? rainSinceMidnight;
-
-    for (final m in _weatherFieldRe.allMatches(weatherData)) {
-      if (m.group(1) != null) {
-        windDir = int.tryParse(m.group(1)!);
-      } else if (m.group(2) != null) {
-        windSpeed = double.tryParse(m.group(2)!);
-      } else if (m.group(3) != null) {
-        windGust = double.tryParse(m.group(3)!);
-      } else if (m.group(4) != null) {
-        temperature = double.tryParse(m.group(4)!);
-      } else if (m.group(5) != null) {
-        rainfall1h = double.tryParse(m.group(5)!);
-      } else if (m.group(6) != null) {
-        rainfall24h = double.tryParse(m.group(6)!);
-      } else if (m.group(7) != null) {
-        // 'P' field: rainfall since midnight, in hundredths of an inch.
-        rainSinceMidnight = double.tryParse(m.group(7)!);
-      } else if (m.group(8) != null) {
-        humidity = int.tryParse(m.group(8)!);
-      } else if (m.group(9) != null) {
-        final raw = int.tryParse(m.group(9)!);
-        if (raw != null) pressure = raw / 10.0; // tenths of mb → mb
-      }
-    }
+    final f = _scanWeatherFields(weatherData);
 
     return WeatherPacket(
       rawLine: rawLine,
@@ -1265,15 +1299,144 @@ class AprsParser {
       path: path,
       receivedAt: receivedAt,
       transportSource: transportSource,
-      temperature: temperature,
-      humidity: humidity,
-      pressure: pressure,
-      windSpeed: windSpeed,
-      windDirection: windDir,
-      windGust: windGust,
-      rainfall1h: rainfall1h,
-      rainfall24h: rainfall24h,
-      rainSinceMidnight: rainSinceMidnight,
+      temperature: f.temperature,
+      humidity: f.humidity,
+      pressure: f.pressure,
+      windSpeed: f.windSpeed,
+      windDirection: f.windDir,
+      windGust: f.windGust,
+      rainfall1h: f.rainfall1h,
+      rainfall24h: f.rainfall24h,
+      rainSinceMidnight: f.rainSinceMidnight,
+    );
+  }
+
+  /// Build a [WeatherPacket] from a positioned weather report (a `_`-symbol
+  /// position). [comment] is the text after the symbol code: an optional
+  /// leading `ddd/sss` wind direction/speed, then the wx fields.
+  AprsPacket _buildPositionedWeather({
+    required String comment,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+    required double lat,
+    required double lon,
+    required String symbolTable,
+    required String symbolCode,
+    required DateTime? timestamp,
+  }) {
+    int? windDir;
+    double? windSpeed;
+    var data = comment;
+    final wm = _windRe.firstMatch(comment);
+    if (wm != null) {
+      windDir = int.tryParse(wm.group(1)!);
+      windSpeed = double.tryParse(wm.group(2)!); // mph (APRS weather wind)
+      data = comment.substring(wm.end);
+    }
+    final f = _scanWeatherFields(data);
+
+    return WeatherPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      lat: lat,
+      lon: lon,
+      symbolTable: symbolTable,
+      symbolCode: symbolCode,
+      temperature: f.temperature,
+      humidity: f.humidity,
+      pressure: f.pressure,
+      windSpeed: windSpeed ?? f.windSpeed,
+      windDirection: windDir ?? f.windDir,
+      windGust: f.windGust,
+      rainfall1h: f.rainfall1h,
+      rainfall24h: f.rainfall24h,
+      rainSinceMidnight: f.rainSinceMidnight,
+      timestamp: timestamp,
+    );
+  }
+
+  /// Scan a weather-data string for the standard letter-prefixed wx fields
+  /// (`c/s/g/t/r/p/P/h/b`). Shared by standalone (`_`) and positioned weather.
+  _WxFields _scanWeatherFields(String data) {
+    final f = _WxFields();
+    for (final m in _weatherFieldRe.allMatches(data)) {
+      if (m.group(1) != null) {
+        f.windDir = int.tryParse(m.group(1)!);
+      } else if (m.group(2) != null) {
+        f.windSpeed = double.tryParse(m.group(2)!);
+      } else if (m.group(3) != null) {
+        f.windGust = double.tryParse(m.group(3)!);
+      } else if (m.group(4) != null) {
+        f.temperature = double.tryParse(m.group(4)!);
+      } else if (m.group(5) != null) {
+        f.rainfall1h = double.tryParse(m.group(5)!);
+      } else if (m.group(6) != null) {
+        f.rainfall24h = double.tryParse(m.group(6)!);
+      } else if (m.group(7) != null) {
+        // 'P' field: rainfall since midnight, in hundredths of an inch.
+        f.rainSinceMidnight = double.tryParse(m.group(7)!);
+      } else if (m.group(8) != null) {
+        f.humidity = int.tryParse(m.group(8)!);
+      } else if (m.group(9) != null) {
+        final raw = int.tryParse(m.group(9)!);
+        if (raw != null) f.pressure = raw / 10.0; // tenths of mb → mb
+      }
+    }
+    return f;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Query  (DTI: ?)  and  Station capabilities  (DTI: <)
+  // ---------------------------------------------------------------------------
+
+  AprsPacket _parseQuery({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+  }) {
+    // Strip the leading '?' and any trailing '?' (e.g. '?APRS?' → 'APRS').
+    var q = info.substring(1);
+    if (q.endsWith('?')) q = q.substring(0, q.length - 1);
+    return QueryPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      query: q,
+    );
+  }
+
+  AprsPacket _parseCapabilities({
+    required String info,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+  }) {
+    return CapabilitiesPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      capabilities: info.substring(1), // drop the '<' DTI
     );
   }
 

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1278,6 +1278,10 @@ class AprsParser {
   // `ddd/sss` = wind direction (degrees) / wind speed (mph).
   static final _windRe = RegExp(r'^(\d{3})/(\d{3})');
 
+  // Detects the 8-digit MDHM timestamp that follows the `_` DTI in a
+  // positionless weather report (when present).
+  static final _eightDigitsRe = RegExp(r'^\d{8}$');
+
   AprsPacket _parseWeather({
     required String info,
     required String rawLine,
@@ -1287,9 +1291,12 @@ class AprsParser {
     required DateTime receivedAt,
     required PacketSource transportSource,
   }) {
-    // Skip DTI and 8-char timestamp (MMDDhhmm).
-    // Some implementations omit the timestamp; handle both.
-    final weatherData = info.length > 9 ? info.substring(9) : info.substring(1);
+    // Skip the DTI and, when present, the 8-char timestamp (MMDDhhmm). Some
+    // implementations omit it, so only strip a leading run that actually looks
+    // like an 8-digit timestamp — otherwise the first wx chars get dropped.
+    final hasTimestamp =
+        info.length > 9 && _eightDigitsRe.hasMatch(info.substring(1, 9));
+    final weatherData = hasTimestamp ? info.substring(9) : info.substring(1);
     final f = _scanWeatherFields(weatherData);
 
     return WeatherPacket(

--- a/lib/core/packet/device_resolver.dart
+++ b/lib/core/packet/device_resolver.dart
@@ -199,6 +199,7 @@ class DeviceResolver {
     if (prefix == '>') {
       if (comment.endsWith('=')) return 'Kenwood TH-D72A';
       if (comment.endsWith('^')) return 'Kenwood TH-D74';
+      if (comment.endsWith('&')) return 'Kenwood TH-D75';
       return 'Kenwood TH-D7A';
     }
     if (prefix == ']') {

--- a/lib/database/tables/packets.dart
+++ b/lib/database/tables/packets.dart
@@ -13,6 +13,8 @@ enum PacketTypeTag {
   status,
   micE,
   telemetry,
+  query,
+  capabilities,
   unknown,
 }
 

--- a/lib/database/tables/packets.dart
+++ b/lib/database/tables/packets.dart
@@ -12,6 +12,7 @@ enum PacketTypeTag {
   item,
   status,
   micE,
+  telemetry,
   unknown,
 }
 

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -16,7 +16,8 @@ enum _PacketFilter {
   obj('OBJ'),
   item('ITEM'),
   status('STATUS'),
-  micE('MIC-E');
+  micE('MIC-E'),
+  tel('TEL');
 
   const _PacketFilter(this.label);
   final String label;
@@ -192,6 +193,7 @@ class _PacketListState extends State<_PacketList> {
       _PacketFilter.item => p is ItemPacket,
       _PacketFilter.status => p is StatusPacket,
       _PacketFilter.micE => p is MicEPacket,
+      _PacketFilter.tel => p is TelemetryPacket,
     };
   }
 
@@ -236,7 +238,7 @@ class _FilterBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Eager inflation is intentional: the chip set is a fixed, small enum
-    // (8 items). Rebuild scope is the concern here, not lazy inflation — and
+    // (9 items). Rebuild scope is the concern here, not lazy inflation — and
     // that is handled by isolating this bar from the packet list (#58).
     return SizedBox(
       height: 48,
@@ -384,6 +386,7 @@ class _PacketRow extends StatelessWidget {
       ItemPacket() => 'ITEM',
       StatusPacket() => 'STATUS',
       MicEPacket() => 'MIC-E',
+      TelemetryPacket() => 'TEL',
       UnknownPacket() => '???',
     };
   }
@@ -399,6 +402,7 @@ class _PacketRow extends StatelessWidget {
       StatusPacket() => p.status,
       MicEPacket() =>
         '${_latStr(p.lat)}, ${_lonStr(p.lon)} \u2022 ${p.micEMessage}',
+      TelemetryPacket() => _telSummary(p),
       UnknownPacket() =>
         p.rawLine.length > 40
             ? '${p.rawLine.substring(0, 40)}\u2026'
@@ -430,7 +434,18 @@ class _PacketRow extends StatelessWidget {
     }
     return parts.isEmpty ? 'Weather' : parts.join(' / ');
   }
+
+  static String _telSummary(TelemetryPacket p) {
+    final vals = p.analog.map((v) => v == null ? '—' : _trimNum(v)).join(', ');
+    final seq = p.sequence.isEmpty ? '' : '#${p.sequence} ';
+    return vals.isEmpty ? '${seq}telemetry'.trim() : '$seq• $vals';
+  }
 }
+
+/// Formats a telemetry value as an integer when it has no fractional part,
+/// otherwise with its natural decimal representation.
+String _trimNum(double v) =>
+    v == v.roundToDouble() ? v.toInt().toString() : v.toString();
 
 // ---------------------------------------------------------------------------
 // Type badge — color-coded per packet type, theme-aware
@@ -475,6 +490,7 @@ class _TypeBadge extends StatelessWidget {
     'ITEM' => Colors.amber,
     'STATUS' => Colors.green,
     'MIC-E' => Colors.indigo,
+    'TEL' => Colors.teal,
     _ => Colors.blueGrey,
   };
 }

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -387,6 +387,8 @@ class _PacketRow extends StatelessWidget {
       StatusPacket() => 'STATUS',
       MicEPacket() => 'MIC-E',
       TelemetryPacket() => 'TEL',
+      QueryPacket() => 'QUERY',
+      CapabilitiesPacket() => 'CAP',
       UnknownPacket() => '???',
     };
   }
@@ -403,6 +405,8 @@ class _PacketRow extends StatelessWidget {
       MicEPacket() =>
         '${_latStr(p.lat)}, ${_lonStr(p.lon)} \u2022 ${p.micEMessage}',
       TelemetryPacket() => _telSummary(p),
+      QueryPacket() => '? ${p.query}',
+      CapabilitiesPacket() => p.capabilities,
       UnknownPacket() =>
         p.rawLine.length > 40
             ? '${p.rawLine.substring(0, 40)}\u2026'
@@ -491,6 +495,8 @@ class _TypeBadge extends StatelessWidget {
     'STATUS' => Colors.green,
     'MIC-E' => Colors.indigo,
     'TEL' => Colors.teal,
+    'QUERY' => Colors.pink,
+    'CAP' => Colors.brown,
     _ => Colors.blueGrey,
   };
 }

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -442,7 +442,8 @@ class _PacketRow extends StatelessWidget {
   static String _telSummary(TelemetryPacket p) {
     final vals = p.analog.map((v) => v == null ? '—' : _trimNum(v)).join(', ');
     final seq = p.sequence.isEmpty ? '' : '#${p.sequence} ';
-    return vals.isEmpty ? '${seq}telemetry'.trim() : '$seq• $vals';
+    if (seq.isEmpty) return vals.isEmpty ? 'telemetry' : vals;
+    return vals.isEmpty ? '${seq}telemetry' : '$seq• $vals';
   }
 }
 

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -620,6 +620,8 @@ class StationService extends ChangeNotifier {
     if (p is StatusPacket) return PacketTypeTag.status;
     if (p is MicEPacket) return PacketTypeTag.micE;
     if (p is TelemetryPacket) return PacketTypeTag.telemetry;
+    if (p is QueryPacket) return PacketTypeTag.query;
+    if (p is CapabilitiesPacket) return PacketTypeTag.capabilities;
     return PacketTypeTag.unknown;
   }
 

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -619,6 +619,7 @@ class StationService extends ChangeNotifier {
     if (p is ItemPacket) return PacketTypeTag.item;
     if (p is StatusPacket) return PacketTypeTag.status;
     if (p is MicEPacket) return PacketTypeTag.micE;
+    if (p is TelemetryPacket) return PacketTypeTag.telemetry;
     return PacketTypeTag.unknown;
   }
 

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -710,7 +710,23 @@ class StationService extends ChangeNotifier {
     lastHeard: p.receivedAt,
     symbolTable: p.symbolTable,
     symbolCode: p.symbolCode,
-    comment: p.rawLine,
+    // A concise human summary — not the raw frame (which lives in rawPacket
+    // and the packet detail sheet). Empty when no fields decoded.
+    comment: _weatherSummary(p),
     type: StationType.weather,
   );
+
+  static String _weatherSummary(WeatherPacket p) {
+    final parts = <String>[];
+    if (p.temperature != null) {
+      parts.add('${p.temperature!.toStringAsFixed(0)}°F');
+    }
+    if (p.windDirection != null && p.windSpeed != null) {
+      parts.add(
+        'wind ${p.windDirection}°/${p.windSpeed!.toStringAsFixed(0)} mph',
+      );
+    }
+    if (p.humidity != null) parts.add('${p.humidity}% RH');
+    return parts.join(' · ');
+  }
 }

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -710,23 +710,42 @@ class StationService extends ChangeNotifier {
     lastHeard: p.receivedAt,
     symbolTable: p.symbolTable,
     symbolCode: p.symbolCode,
-    // A concise human summary — not the raw frame (which lives in rawPacket
-    // and the packet detail sheet). Empty when no fields decoded.
-    comment: _weatherSummary(p),
+    // Canonical APRS wx tokens (c/s/g/t/r/p/P/h/b) reconstructed from the
+    // decoded fields. The map weather overlay and the station sheet both
+    // re-parse this via WxData.parse(comment) — it must carry parseable wx
+    // tokens, not a human-formatted summary or the raw frame.
+    comment: _weatherComment(p),
     type: StationType.weather,
   );
 
-  static String _weatherSummary(WeatherPacket p) {
-    final parts = <String>[];
-    if (p.temperature != null) {
-      parts.add('${p.temperature!.toStringAsFixed(0)}°F');
+  /// Rebuild a `WxData`-parseable token string from a decoded [WeatherPacket].
+  static String _weatherComment(WeatherPacket p) {
+    final b = StringBuffer();
+    // Letter-prefixed field; magnitude zero-padded to [width] digits, with a
+    // leading '-' for negatives (matches WxData's `(-?\d{N})` patterns).
+    void f(String code, num? v, int width) {
+      if (v == null) return;
+      final n = v.round();
+      final mag = n.abs().toString().padLeft(width, '0');
+      b.write(n < 0 ? '$code-$mag' : '$code$mag');
     }
-    if (p.windDirection != null && p.windSpeed != null) {
-      parts.add(
-        'wind ${p.windDirection}°/${p.windSpeed!.toStringAsFixed(0)} mph',
-      );
+
+    f('c', p.windDirection, 3); // wind direction (deg)
+    f('s', p.windSpeed, 3); // sustained wind (mph)
+    f('g', p.windGust, 3); // gust (mph)
+    f('t', p.temperature, 3); // temperature (°F)
+    f('r', p.rainfall1h, 3);
+    f('p', p.rainfall24h, 3);
+    f('P', p.rainSinceMidnight, 3);
+    if (p.humidity != null) {
+      // APRS §12: h00 encodes 100%.
+      final h = p.humidity! >= 100 ? 0 : p.humidity!;
+      b.write('h${h.toString().padLeft(2, '0')}');
     }
-    if (p.humidity != null) parts.add('${p.humidity}% RH');
-    return parts.join(' · ');
+    if (p.pressure != null) {
+      // b is tenths of a millibar (hPa × 10), 5 digits.
+      b.write('b${(p.pressure! * 10).round().toString().padLeft(5, '0')}');
+    }
+    return b.toString();
   }
 }

--- a/lib/ui/utils/wx_data.dart
+++ b/lib/ui/utils/wx_data.dart
@@ -38,7 +38,9 @@ class WxData {
       } else if (m.group(7) != null) {
         wx.rainSinceMidnight = double.tryParse(m.group(7)!);
       } else if (m.group(8) != null) {
-        wx.humidity = int.tryParse(m.group(8)!);
+        // APRS §12: humidity hNN with h00 meaning 100%.
+        final h = int.tryParse(m.group(8)!);
+        if (h != null) wx.humidity = h == 0 ? 100 : h;
       } else if (m.group(9) != null) {
         wx._pressureRaw = double.tryParse(m.group(9)!);
       } else if (m.group(10) != null) {

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -158,6 +158,9 @@ class PacketDetailSheet extends StatelessWidget {
     } else if (p.path.isNotEmpty) {
       m['Path'] = p.path.join(', ');
     }
+    if (p.thirdPartyVia != null) {
+      m['Relayed via'] = p.thirdPartyVia!;
+    }
     m['Received'] = p.receivedAt
         .toUtc()
         .toString()
@@ -258,6 +261,20 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
 
+      case TelemetryPacket():
+        m['Type'] = 'Telemetry';
+        if (p.sequence.isNotEmpty) m['Sequence'] = p.sequence;
+        for (var i = 0; i < p.analog.length; i++) {
+          final v = p.analog[i];
+          m['Analog ${i + 1}'] = v == null ? '—' : _trimNum(v);
+        }
+        if (p.digital.isNotEmpty) {
+          m['Digital bits'] = p.digital.map((b) => b ? '1' : '0').join();
+        }
+        if (p.comment != null && p.comment!.isNotEmpty) {
+          m['Comment'] = p.comment!;
+        }
+
       case UnknownPacket():
         m['Type'] = 'Unknown';
         m['Reason'] = p.reason;
@@ -291,6 +308,10 @@ String _formatLon(double lon) {
   final dir = lon >= 0 ? 'E' : 'W';
   return '${lon.abs().toStringAsFixed(6)}\u00b0 $dir';
 }
+
+/// Formats a telemetry value as an integer when it has no fractional part.
+String _trimNum(double v) =>
+    v == v.roundToDouble() ? v.toInt().toString() : v.toString();
 
 class _SectionLabel extends StatelessWidget {
   const _SectionLabel({required this.label, required this.colorScheme});

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -218,6 +218,7 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.rainfall24h != null) {
           m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
         }
+        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
 
       case ObjectPacket():
         m['Type'] = 'Object';
@@ -274,6 +275,14 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.comment != null && p.comment!.isNotEmpty) {
           m['Comment'] = p.comment!;
         }
+
+      case QueryPacket():
+        m['Type'] = 'Query';
+        if (p.query.isNotEmpty) m['Query'] = p.query;
+
+      case CapabilitiesPacket():
+        m['Type'] = 'Capabilities';
+        if (p.capabilities.isNotEmpty) m['Capabilities'] = p.capabilities;
 
       case UnknownPacket():
         m['Type'] = 'Unknown';

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -924,6 +924,36 @@ void main() {
       },
     );
 
+    // Real Kenwood TH-D75 signature: leading `>` prefix, trailing `&` suffix
+    // (per aprs-deviceid; D7A=`>`, D72=`>=`, D74=`>^`, D75=`>&`). Modelled on a
+    // real TH-D75 capture: without this, the `&` device byte leaked into the
+    // comment and the radio was misidentified as a TH-D7A.
+    test(
+      'TH-D75 (`>` prefix + `&` suffix): suffix stripped, device detected',
+      () {
+        final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>\x224\x22}hello&';
+        final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
+        expect(packet, isA<MicEPacket>());
+        if (packet is MicEPacket) {
+          expect(packet.comment, equals('hello'));
+          expect(packet.device, equals('Kenwood TH-D75'));
+          expect(packet.altitude, closeTo(11.0, 1.0));
+        }
+      },
+    );
+
+    // An empty TH-D75 comment is just the bare `&` device byte — it must strip
+    // to an empty comment, not surface a lone '&'.
+    test('TH-D75 with no user comment strips the bare `&` to empty', () {
+      final rawLine = 'N0CALL-9>SX5E0A,WIDE1-1:\x60i<N Ol>/>&';
+      final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
+      expect(packet, isA<MicEPacket>());
+      if (packet is MicEPacket) {
+        expect(packet.comment, isEmpty);
+        expect(packet.device, equals('Kenwood TH-D75'));
+      }
+    });
+
     // Real-world capture from KM4TJO-9 (user-owned TM-D710): the radio sent
     // an empty user comment, so the extension is just the prefix + altitude
     // + suffix. Earlier the parser surfaced "]\"4\"}=" as the comment.

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1865,4 +1865,76 @@ void main() {
       expect(p.analog[2], isNull);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Weather embedded in a position report (`_` symbol code)
+  // -------------------------------------------------------------------------
+  group('positioned weather (`_` symbol)', () {
+    test('timestamped position with `_` symbol decodes to WeatherPacket', () {
+      final p = expectPacketType<WeatherPacket>(
+        'N0CALL>APRS:@092345z4903.50N/07201.75W_220/004g005t077r000p000'
+        'P000h50b09900wRSW',
+      );
+      expect(p.lat, closeTo(49.0583, 0.001));
+      expect(p.lon, closeTo(-72.0292, 0.001));
+      expect(p.symbolCode, equals('_'));
+      expect(p.windDirection, equals(220));
+      expect(p.windSpeed, equals(4)); // mph, from the ddd/sss slot
+      expect(p.windGust, equals(5));
+      expect(p.temperature, equals(77));
+      expect(p.humidity, equals(50));
+      expect(p.pressure, closeTo(990.0, 0.1));
+      expect(p.timestamp, isNotNull);
+    });
+
+    test('non-timestamped position with `_` symbol also decodes weather', () {
+      final p = expectPacketType<WeatherPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W_180/010t068',
+      );
+      expect(p.windDirection, equals(180));
+      expect(p.windSpeed, equals(10));
+      expect(p.temperature, equals(68));
+    });
+
+    // Critical regression: a *moving* station sends an identical-looking
+    // `ddd/sss` course/speed but a non-`_` symbol — it must stay a Position.
+    test('moving station with course/speed is NOT mis-binned as weather', () {
+      final p = expectPacketType<PositionPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W>088/036Mobile',
+      );
+      expect(p.course, equals(88));
+      expect(p.speed, equals(36)); // knots — course/speed, not wind
+      expect(p.symbolCode, equals('>'));
+      expect(p.comment, equals('Mobile'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Query (DTI ?) and station capabilities (DTI <)
+  // -------------------------------------------------------------------------
+  group('query and capabilities', () {
+    test('general query `?APRS?` decodes to QueryPacket', () {
+      final p = expectPacketType<QueryPacket>('N0CALL>APRS:?APRS?');
+      expect(p.query, equals('APRS'));
+    });
+
+    test('query without trailing `?` decodes', () {
+      final p = expectPacketType<QueryPacket>('N0CALL>APRS:?WX');
+      expect(p.query, equals('WX'));
+    });
+
+    test('station capabilities `<` decodes to CapabilitiesPacket', () {
+      final p = expectPacketType<CapabilitiesPacket>(
+        'N0CALL>APRS:<IGATE,MSG_CNT=2,LOC_CNT=18',
+      );
+      expect(p.capabilities, equals('IGATE,MSG_CNT=2,LOC_CNT=18'));
+    });
+
+    // A directed query carried inside a message keeps DTI ':' and must stay a
+    // MessagePacket — the `?` parser must not intercept it.
+    test('directed query inside a message stays a MessagePacket', () {
+      final p = expectPacketType<MessagePacket>('N0CALL>APRS::N0CALL   :?WX?');
+      expect(p.message, equals('?WX?'));
+    });
+  });
 }

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -685,13 +685,15 @@ void main() {
       );
     });
 
-    test('telemetry packet (T) returns UnknownPacket', () {
+    test('telemetry packet (T) decodes to TelemetryPacket', () {
+      // Previously stubbed to UnknownPacket; telemetry data reports are now
+      // decoded (see the dedicated TelemetryPacket group below).
       expect(
         parser.parse(
           'N0CALL>APRS:T#001,100,200,050,000,255,00000001',
           receivedAt: kTestReceivedAt,
         ),
-        isA<UnknownPacket>(),
+        isA<TelemetryPacket>(),
       );
     });
 
@@ -1714,6 +1716,123 @@ void main() {
           equals('Object uncompressed position regex did not match'),
         );
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Third-party traffic (DTI: })
+  // -------------------------------------------------------------------------
+  group('third-party traffic (DTI })', () {
+    test('unwraps an inner message and attributes the relaying gateway', () {
+      // Modelled on a real LoRa-igate relay: gateway re-injecting a heard
+      // message addressed to a third station. Callsigns anonymised.
+      final p = expectPacketType<MessagePacket>(
+        'N0CALL-1>APRS,N0DIGI-5,WIDE2:}N0AAA-7>APRS,TCPIP,N0CALL-1*'
+        '::N0BBB-1  :N:HOTG Happy #APRSThursday from LoRa Tracker 73!',
+      );
+      // Attributed to the inner source, not the gateway.
+      expect(p.source, equals('N0AAA-7'));
+      expect(p.destination, equals('APRS'));
+      expect(p.addressee, equals('N0BBB-1'));
+      // The relaying gateway is recorded.
+      expect(p.thirdPartyVia, equals('N0CALL-1'));
+      // rawLine stays the full outer frame for display / DB re-parse.
+      expect(p.rawLine, startsWith('N0CALL-1>APRS'));
+    });
+
+    test('unwraps an inner warning-service message', () {
+      // Modelled on a relayed weather-warning message. Callsigns anonymised.
+      final p = expectPacketType<MessagePacket>(
+        'N0CALL-1>APRS,N0DIGI-5,WIDE2:}N0WX>APRS,TCPIP,N0CALL-1*'
+        '::WXALERT  :280215z,SVR_STORM,VAC025,VAC053,VAC111,VAC135{Z10AA',
+      );
+      expect(p.source, equals('N0WX'));
+      expect(p.addressee, equals('WXALERT'));
+      expect(p.thirdPartyVia, equals('N0CALL-1'));
+    });
+
+    test('unwraps an inner object packet', () {
+      // Modelled on a relayed severe-storm warning object (DTI ;).
+      // Callsigns / object name anonymised.
+      final p = expectPacketType<ObjectPacket>(
+        'N0CALL-1>APRS,N0DIGI-5,WIDE2:}N0WX>APRS,TCPIP,N0CALL-1*'
+        ':;N0WXOBJ01*280130z3708.40N\\07815.00WT111/037SVR_STORM '
+        '}d0]MPPNNHKJMP{Y10AA',
+      );
+      expect(p.source, equals('N0WX'));
+      expect(p.objectName, equals('N0WXOBJ01'));
+      expect(p.thirdPartyVia, equals('N0CALL-1'));
+      expect(p.lat, closeTo(37.14, 0.01));
+      expect(p.lon, closeTo(-78.25, 0.01));
+    });
+
+    test('inner packet that is itself unknown still records the relay', () {
+      final packet = parser.parse(
+        'GATE>APRS:}BADCALL>APRS:%bogus',
+        receivedAt: kTestReceivedAt,
+      );
+      expect(packet, isA<UnknownPacket>());
+      expect(packet.source, equals('BADCALL'));
+      expect(packet.thirdPartyVia, equals('GATE'));
+    });
+
+    test('empty third-party payload is reported, never throws', () {
+      final p = expectPacketType<UnknownPacket>('GATE>APRS:}');
+      expect(p.reason, equals('Empty third-party payload'));
+    });
+
+    test('deeply nested third-party is capped (terminates)', () {
+      // Three '}' levels exceed the cap (the guard fires when a '}' is
+      // dispatched at the max depth); the parser must not recurse unboundedly
+      // and must still return a packet.
+      final p = expectPacketType<UnknownPacket>(
+        'A>APRS:}B>APRS:}C>APRS:}D>APRS:!1234.56N/12345.67W>',
+      );
+      expect(p.reason, equals('Third-party nesting too deep'));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Telemetry data reports (DTI: T)
+  // -------------------------------------------------------------------------
+  group('TelemetryPacket (DTI T)', () {
+    test('decodes a standard T# data report', () {
+      // Modelled on a real T# telemetry beacon; callsigns anonymised.
+      final p = expectPacketType<TelemetryPacket>(
+        'N0CALL>APRS,N0DIGI-5,WIDE1,WIDE2-2:T#014,123,162,255,093,065,00000011',
+      );
+      expect(p.sequence, equals('014'));
+      expect(p.analog, equals(<double>[123, 162, 255, 93, 65]));
+      expect(
+        p.digital,
+        equals(<bool>[false, false, false, false, false, false, true, true]),
+      );
+      expect(p.comment, isNull);
+    });
+
+    test('accepts a non-numeric MIC sequence id', () {
+      final p = expectPacketType<TelemetryPacket>(
+        'N0CALL>APRS:T#MIC,001,002,003,004,005,10101010',
+      );
+      expect(p.sequence, equals('MIC'));
+      expect(p.analog.length, equals(5));
+      expect(p.digital.first, isTrue);
+    });
+
+    test('preserves a trailing comment after the digital field', () {
+      final p = expectPacketType<TelemetryPacket>(
+        'N0CALL>APRS:T#007,10,20,30,40,50,00000000Solar',
+      );
+      expect(p.comment, equals('Solar'));
+    });
+
+    test('tolerates blank analog fields without failing the packet', () {
+      final p = expectPacketType<TelemetryPacket>(
+        'N0CALL>APRS:T#008,,20,,40,,00000000',
+      );
+      expect(p.analog[0], isNull);
+      expect(p.analog[1], equals(20));
+      expect(p.analog[2], isNull);
     });
   });
 }

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1896,6 +1896,13 @@ void main() {
       expect(p.temperature, equals(68));
     });
 
+    test('humidity h00 decodes as 100% (APRS §12)', () {
+      final p = expectPacketType<WeatherPacket>(
+        'N0CALL>APRS:!4903.50N/07201.75W_000/000t070h00',
+      );
+      expect(p.humidity, equals(100));
+    });
+
     // Critical regression: a *moving* station sends an identical-looking
     // `ddd/sss` course/speed but a non-`_` symbol — it must stay a Position.
     test('moving station with course/speed is NOT mis-binned as weather', () {

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -418,6 +418,18 @@ void main() {
       );
       expect(p.rainfall1h, equals(0.0));
     });
+
+    // Regression: a positionless report that omits the 8-char timestamp must
+    // not have its leading wx fields stripped as if a timestamp were present.
+    test('parses standalone weather without a timestamp', () {
+      final p = expectPacketType<WeatherPacket>(
+        'WX4XYZ>APRS:_c220s004g008t060h68',
+      );
+      expect(p.windDirection, equals(220));
+      expect(p.windSpeed, equals(4.0));
+      expect(p.temperature, equals(60.0));
+      expect(p.humidity, equals(68));
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/core/packet/device_resolver_test.dart
+++ b/test/core/packet/device_resolver_test.dart
@@ -81,6 +81,13 @@ void main() {
       );
     });
 
+    test('prefix `>` + suffix `&` → TH-D75', () {
+      expect(
+        DeviceResolver.resolve(micEPrefix: '>', micECommentSuffix: 'hi&'),
+        equals('Kenwood TH-D75'),
+      );
+    });
+
     test('prefix `]` alone → TM-D700', () {
       expect(
         DeviceResolver.resolve(micEPrefix: ']', micECommentSuffix: 'hi'),

--- a/test/services/station_service_test.dart
+++ b/test/services/station_service_test.dart
@@ -6,6 +6,7 @@ import 'package:meridian_aprs/core/packet/aprs_packet.dart';
 import 'package:meridian_aprs/core/packet/station.dart';
 import 'package:meridian_aprs/database/meridian_database.dart';
 import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/ui/utils/wx_data.dart';
 
 import '../helpers/fake_meridian_connection.dart';
 import '../helpers/test_database.dart';
@@ -120,6 +121,26 @@ void main() {
       );
       expect(service.currentStations['W1AW']?.type, StationType.weather);
     });
+
+    // Regression: the weather-overlay chip and station sheet both re-parse the
+    // station comment via WxData.parse, so a weather station's comment must
+    // carry parseable wx tokens (not a human summary or the raw frame).
+    test(
+      'weather station comment is WxData-parseable for the overlay',
+      () async {
+        await service.ingestLine(
+          'W1AW>APMDN0,TCPIP*:!4903.50N/07201.75W_220/004g005t077h50',
+        );
+        final s = service.currentStations['W1AW'];
+        expect(s, isNotNull);
+        final wx = WxData.parse(s!.comment);
+        expect(wx, isNotNull);
+        expect(wx!.tempF, equals(77));
+        expect(wx.windDir, equals(220));
+        expect(wx.windSpeed, equals(4));
+        expect(wx.humidity, equals(50));
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes several APRS packet-decoding gaps surfaced while reviewing real-world "Unknown Type" packets (and one Kenwood TH-D75 issue) during on-device testing. Everything here is **receive/decode** work — the parser already never throws; this promotes packets that previously fell back to `UnknownPacket` (or were mis-binned) into proper typed decoding.

### What now decodes

- **Third-party traffic (`}`)** — unwrapped and re-parsed to the inner packet, attributed to the **inner source**, with the relaying gateway recorded (`AprsPacket.thirdPartyVia`, shown as "Relayed via …" in the detail sheet). Depth-guarded; `rawLine` stays the full outer frame so DB re-parse is deterministic.
- **Telemetry data (`T#`)** — new `TelemetryPacket` (sequence, up to five analog channels, digital bits, comment). *Definition* messages (PARM/UNIT/EQNS/BITS) are a planned follow-up (drift-backed `TelemetryService`).
- **Kenwood TH-D75 Mic-E** — recognises the `>`+`&` device suffix (per aprs-deviceid: D7A=`>`, D72=`>=`, D74=`>^`, D75=`>&`). Previously the `&` leaked into the comment (empty status → lone `&`) and the radio was mislabelled TH-D7A.
- **Weather embedded in an uncompressed position (`_` symbol)** — now binned as a `WeatherPacket` *with* position (wind dir/speed from the course/speed slot as mph + the `g/t/r/p/P/h/b` fields), so weather stations render on the map. Binning keys **only** on the `_` symbol — a moving station with an identical-looking `ddd/sss` course/speed stays a `PositionPacket` (explicit regression test).
- **General queries (`?`)** → `QueryPacket`; **station capabilities (`<`)** → `CapabilitiesPacket` — classify-only (no auto-response). Directed queries inside messages keep DTI `:` and stay `MessagePacket`.

Also: `h00` humidity now decodes as 100 % per APRS §12 (parser + `WxData`).

### Deferred (documented in `CAPABILITIES.md`)
Compressed / object / item / Mic-E embedded weather; PHG/RNG/DFS extensions; query auto-response; and the rare/legacy DTIs (`$` NMEA, `#`/`*` Peet Bros, `%` Agrelo, `[` Maidenhead, `{` user-defined) — all still fall back safely to `UnknownPacket`.

## New packet types

`TelemetryPacket`, `QueryPacket`, `CapabilitiesPacket` added to the sealed `AprsPacket` hierarchy; wired through `PacketTypeTag` (name-stored — no DB migration), station tagging, the packet-log filter/label/colour, and the detail sheet. `WeatherPacket` gains a `timestamp`.

## Test coverage

- Parser tests for every example packet (third-party message/object/NWS, telemetry `T#`, TH-D75 `>`+`&`, positioned weather timestamped/non-timestamped, `?`/`<`) plus edge cases: nested/empty/too-deep third-party, MIC sequence ids, blank analog fields, the **moving-station-not-weather** regression, `h00`=100 %, and a directed-query-stays-a-message guard.
- `DeviceResolver` unit case for TH-D75.
- Station-level regression: a positioned-weather ingest produces a station whose comment is `WxData.parse`-able (guards the map weather overlay).
- **840 tests pass**; `flutter analyze` clean; `dart format` applied.

## Notes for review
- The map weather overlay reads weather via `WxData.parse(station.comment)`, so `_stationFromWeather` stores canonical wx tokens reconstructed from the decoded fields (not a human summary or the raw frame). This also makes wind appear in the overlay, which the old PositionPacket path dropped.
- All test fixtures use placeholder callsigns. A separate `infra/scrub-real-callsigns` branch anonymises pre-existing real callsigns elsewhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full support and display for telemetry (T#), query (?), and capabilities (<) packets
  * Third‑party (relayed) packets now show the relaying gateway and attribute inner messages
  * Positioned uncompressed weather is treated as weather and weather reports appear on the map
  * Packet log/filter UI and packet detail view updated to surface new packet types and telemetry fields

* **Bug Fixes**
  * Humidity token h00 correctly parsed as 100%
  * Mic‑E legacy vendor suffix handling improved for Kenwood models

* **Documentation**
  * Capabilities doc updated to reflect expanded decoding and clarified non‑support items

* **Tests**
  * Expanded parsing and regression tests covering new packet types, third‑party unwrapping, telemetry, and weather edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->