### PR TITLE
test: anonymise third-party operators' real callsigns in fixtures

### DIFF
--- a/lib/screens/settings/category/messaging_screen.dart
+++ b/lib/screens/settings/category/messaging_screen.dart
@@ -753,7 +753,7 @@ Future<void> _showAddMutedSource(
         textCapitalization: TextCapitalization.characters,
         decoration: const InputDecoration(
           labelText: 'Callsign (with or without SSID)',
-          hintText: 'e.g. K5WX-15',
+          hintText: 'e.g. N0BBB-15',
         ),
       ),
       actions: [

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -971,7 +971,7 @@ void main() {
     // + suffix. Earlier the parser surfaced "]\"4\"}=" as the comment.
     test('TM-D710 with empty user comment renders as empty comment', () {
       final rawLine =
-          'KM4TJO-9>S6TW3Q,KE4KDY-5,WIDE1,WIDE2-1:\x60h_} *p>/]\x224\x22}=';
+          'KM4TJO-9>S6TW3Q,N0DIGI-5,WIDE1,WIDE2-1:\x60h_} *p>/]\x224\x22}=';
       final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
@@ -987,7 +987,7 @@ void main() {
     // does not over-eat the user's text.
     test('TM-D710 with frequency-object comment preserves user text', () {
       final rawLine =
-          "KM4TJO-9>S6TV7S,KE4KDY-5,WIDE1,WIDE2-1:\x60h]nmJ\x14>/]\x223r}146.520MHz Toff Eric's D710G=";
+          "KM4TJO-9>S6TV7S,N0DIGI-5,WIDE1,WIDE2-1:\x60h]nmJ\x14>/]\x223r}146.520MHz Toff Eric's D710G=";
       final packet = parser.parse(rawLine, receivedAt: kTestReceivedAt);
       expect(packet, isA<MicEPacket>());
       if (packet is MicEPacket) {
@@ -1676,11 +1676,11 @@ void main() {
       // tenth-of-minute ambiguity (APRS 1.0.1 §6).
       test('Winlink WLNK-1 ambiguous Object decodes to ObjectPacket', () {
         final p = expectPacketType<ObjectPacket>(
-          'WINLINK>APWL2K,TCPIP*,qAS,WLNK-1:;N4CEC-10 *251245z3646.  N'
+          'WINLINK>APWL2K,TCPIP*,qAS,WLNK-1:;N0DDD-10 *251245z3646.  N'
           'W07617.  Wa440.450MHz Winlink VARA FM Wide Gateway',
         );
         expect(p.positionAmbiguity, equals(2));
-        expect(p.objectName, equals('N4CEC-10'));
+        expect(p.objectName, equals('N0DDD-10'));
         expect(p.isAlive, isTrue);
         expect(p.lat, closeTo(36.776, 0.001));
         expect(p.lon, closeTo(-76.2925, 0.001));

--- a/test/database/bulletin_dao_test.dart
+++ b/test/database/bulletin_dao_test.dart
@@ -30,8 +30,8 @@ void main() {
   );
 
   test('upsertIncoming replaces on (source, addressee) conflict', () async {
-    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0', body: 'v1'));
-    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0', body: 'v2'));
+    await db.bulletinDao.upsertIncoming(incoming('N0BBB', 'BLN0', body: 'v1'));
+    await db.bulletinDao.upsertIncoming(incoming('N0BBB', 'BLN0', body: 'v2'));
     final rows = await db.bulletinDao.getAllIncoming();
     expect(rows, hasLength(1));
     expect(rows.single.body, 'v2');
@@ -40,7 +40,7 @@ void main() {
   test('transports converter round-trips a set', () async {
     await db.bulletinDao.upsertIncoming(
       incoming(
-        'K5WX',
+        'N0BBB',
         'BLN0',
         transports: {BulletinTransport.rf, BulletinTransport.aprsIs},
       ),
@@ -62,11 +62,11 @@ void main() {
   });
 
   test('markIncomingRead + deleteIncoming target the right row', () async {
-    await db.bulletinDao.upsertIncoming(incoming('K5WX', 'BLN0'));
-    await db.bulletinDao.markIncomingRead('K5WX', 'BLN0');
+    await db.bulletinDao.upsertIncoming(incoming('N0BBB', 'BLN0'));
+    await db.bulletinDao.markIncomingRead('N0BBB', 'BLN0');
     expect((await db.bulletinDao.getAllIncoming()).single.isRead, isTrue);
 
-    await db.bulletinDao.deleteIncoming('K5WX', 'BLN0');
+    await db.bulletinDao.deleteIncoming('N0BBB', 'BLN0');
     expect(await db.bulletinDao.getAllIncoming(), isEmpty);
   });
 

--- a/test/services/bulletin_service_test.dart
+++ b/test/services/bulletin_service_test.dart
@@ -53,7 +53,7 @@ void main() {
       final (svc, _) = await makeServices();
       final outcome = svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Severe weather alert',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -72,14 +72,14 @@ void main() {
         final (svc, _) = await makeServices();
         svc.ingest(
           info: generalInfo('0'),
-          sourceCallsign: 'K5WX-15',
+          sourceCallsign: 'N0BBB-15',
           body: 'Alert',
           transport: PacketSource.aprsIs,
           receivedAt: DateTime(2026, 4, 23, 12, 0),
         );
         final outcome = svc.ingest(
           info: generalInfo('0'),
-          sourceCallsign: 'K5WX-15',
+          sourceCallsign: 'N0BBB-15',
           body: 'Alert',
           transport: PacketSource.serialTnc,
           receivedAt: DateTime(2026, 4, 23, 12, 5),
@@ -97,7 +97,7 @@ void main() {
       final (svc, _) = await makeServices();
       svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Old text',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -107,7 +107,7 @@ void main() {
 
       svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'New text',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 10),
@@ -120,7 +120,7 @@ void main() {
       final (svc, _) = await makeServices();
       svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Same',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -128,7 +128,7 @@ void main() {
       await svc.markRead(svc.bulletins.first.id);
       svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Same',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 5),
@@ -142,7 +142,7 @@ void main() {
       final (svc, _) = await makeServices();
       final outcome = svc.ingest(
         info: namedInfo('1', 'WX'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Radar update',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -155,7 +155,7 @@ void main() {
       final (svc, _) = await makeServices(subscribedGroups: ['WX']);
       final outcome = svc.ingest(
         info: namedInfo('1', 'WX'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Radar update',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -234,7 +234,7 @@ void main() {
 
       first.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Alert',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -258,14 +258,14 @@ void main() {
       final fresh = DateTime.now().subtract(const Duration(hours: 2));
       svc.ingest(
         info: generalInfo('0'),
-        sourceCallsign: 'K5WX-1',
+        sourceCallsign: 'N0BBB-1',
         body: 'Old',
         transport: PacketSource.aprsIs,
         receivedAt: old,
       );
       svc.ingest(
         info: generalInfo('1'),
-        sourceCallsign: 'K5WX-2',
+        sourceCallsign: 'N0BBB-2',
         body: 'Fresh',
         transport: PacketSource.aprsIs,
         receivedAt: fresh,
@@ -292,7 +292,7 @@ void main() {
         // Sender ~4000 km away (Miami-ish).
         final outcome = svc.ingest(
           info: generalInfo('0'),
-          sourceCallsign: 'K4MIA',
+          sourceCallsign: 'N0CCC',
           body: 'Severe wx',
           transport: PacketSource.aprsIs,
           receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -314,7 +314,7 @@ void main() {
         // ~230 km away (Portland-ish).
         final outcome = svc.ingest(
           info: generalInfo('1'),
-          sourceCallsign: 'K7PDX',
+          sourceCallsign: 'N0EEE',
           body: 'Local nets',
           transport: PacketSource.aprsIs,
           receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -335,7 +335,7 @@ void main() {
 
         final outcome = svc.ingest(
           info: generalInfo('2'),
-          sourceCallsign: 'K4MIA',
+          sourceCallsign: 'N0CCC',
           body: 'No lat/lon',
           transport: PacketSource.aprsIs,
           receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -351,7 +351,7 @@ void main() {
 
       final outcome = svc.ingest(
         info: generalInfo('3'),
-        sourceCallsign: 'K4MIA',
+        sourceCallsign: 'N0CCC',
         body: 'Far away',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -391,7 +391,7 @@ void main() {
 
         final outcome = svc.ingest(
           info: namedInfo('0', 'WX'),
-          sourceCallsign: 'K4MIA',
+          sourceCallsign: 'N0CCC',
           body: 'Severe weather',
           transport: PacketSource.aprsIs,
           receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -409,7 +409,7 @@ void main() {
 
       final outcome = svc.ingest(
         info: generalInfo('5'),
-        sourceCallsign: 'K4MIA',
+        sourceCallsign: 'N0CCC',
         body: 'Global pass-through',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),

--- a/test/services/message_service_classification_test.dart
+++ b/test/services/message_service_classification_test.dart
@@ -166,19 +166,19 @@ void main() {
       'general bulletin (BLN0) lands in BulletinService, not Conversation',
       () async {
         final f = await _Fixture.create();
-        _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN0     :Severe wx alert');
+        _ingestLine(f, 'N0BBB-15>APMDN0,TCPIP*::BLN0     :Severe wx alert');
         await Future<void>.delayed(Duration.zero);
 
         expect(f.bulletins.bulletins, hasLength(1));
         final b = f.bulletins.bulletins.first;
-        expect(b.sourceCallsign, 'K5WX-15');
+        expect(b.sourceCallsign, 'N0BBB-15');
         expect(b.addressee, 'BLN0');
         expect(b.body, 'Severe wx alert');
         expect(b.heardCount, 1);
 
         // No conversation thread was created.
         expect(
-          f.service.allConversations.any((c) => c.peerCallsign == 'K5WX-15'),
+          f.service.allConversations.any((c) => c.peerCallsign == 'N0BBB-15'),
           isFalse,
         );
         // No ACK (bulletins are never ACKed).
@@ -188,7 +188,7 @@ void main() {
 
     test('named bulletin with no subscription is dropped', () async {
       final f = await _Fixture.create();
-      _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN1WX   :Radar');
+      _ingestLine(f, 'N0BBB-15>APMDN0,TCPIP*::BLN1WX   :Radar');
       await Future<void>.delayed(Duration.zero);
       expect(f.bulletins.bulletins, isEmpty);
     });
@@ -196,7 +196,7 @@ void main() {
     test('named bulletin with matching subscription is kept', () async {
       final f = await _Fixture.create();
       await f.bulletinSubscriptions.add(groupName: 'WX', notify: false);
-      _ingestLine(f, 'K5WX-15>APMDN0,TCPIP*::BLN1WX   :Radar');
+      _ingestLine(f, 'N0BBB-15>APMDN0,TCPIP*::BLN1WX   :Radar');
       await Future<void>.delayed(Duration.zero);
       expect(f.bulletins.bulletins, hasLength(1));
       expect(f.bulletins.bulletins.first.groupName, 'WX');

--- a/test/services/messaging_settings_service_test.dart
+++ b/test/services/messaging_settings_service_test.dart
@@ -79,14 +79,14 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final svc = MessagingSettingsService(prefs: prefs);
       await svc.load();
-      await svc.addMutedBulletinSource('k5wx-15');
-      expect(svc.mutedBulletinSources, contains('K5WX-15'));
+      await svc.addMutedBulletinSource('n0bbb-15');
+      expect(svc.mutedBulletinSources, contains('N0BBB-15'));
 
       // Add again — should be idempotent.
-      await svc.addMutedBulletinSource('K5WX-15');
+      await svc.addMutedBulletinSource('N0BBB-15');
       expect(svc.mutedBulletinSources.length, 1);
 
-      await svc.removeMutedBulletinSource('K5WX-15');
+      await svc.removeMutedBulletinSource('N0BBB-15');
       expect(svc.mutedBulletinSources, isEmpty);
     });
 

--- a/test/widget/map_rebuild_hygiene_test.dart
+++ b/test/widget/map_rebuild_hygiene_test.dart
@@ -137,7 +137,7 @@ void main() {
       // Feed several more packets from distinct, widely-separated callsigns so
       // they do not cluster into a single marker at the initial zoom.
       await service.ingestLine('W2XY>APMDN0:!3234.00N/08901.00W>two');
-      await service.ingestLine('W3ZZ>APMDN0:!4012.00N/10001.00W>three');
+      await service.ingestLine('N0FFF>APMDN0:!4012.00N/10001.00W>three');
       await tester.pump(const Duration(milliseconds: 350));
 
       final mapAfter = currentMap();

--- a/test/widget/messages/messages_screen_test.dart
+++ b/test/widget/messages/messages_screen_test.dart
@@ -301,7 +301,7 @@ void main() {
           lineNumber: '0',
           category: BulletinCategory.general,
         ),
-        sourceCallsign: 'K5WX-15',
+        sourceCallsign: 'N0BBB-15',
         body: 'Severe weather alert',
         transport: PacketSource.aprsIs,
         receivedAt: DateTime(2026, 4, 23, 12, 0),
@@ -315,7 +315,7 @@ void main() {
 
       expect(find.text('BLN0'), findsWidgets);
       expect(find.text('Severe weather alert'), findsOneWidget);
-      expect(find.text('From K5WX-15'), findsOneWidget);
+      expect(find.text('From N0BBB-15'), findsOneWidget);
       expect(find.text('Total receipts'), findsOneWidget);
 
       // Critical: bulletin detail is read-only — no TextField should exist.


### PR DESCRIPTION
## Summary

Replaces real amateur-radio callsigns belonging to **other operators** — captured from live traffic and embedded in test/sample data — with `N0`-prefixed placeholders, so no third party's callsign ships in the public repo. Behaviour-preserving: each fixture input and its assertion are renamed together; no production logic changes.

| Real call | Placeholder |
|---|---|
| `KE4KDY` | `N0DIGI` |
| `K5WX` | `N0BBB` |
| `K4MIA` | `N0CCC` |
| `N4CEC` | `N0DDD` |
| `K7PDX` | `N0EEE` |
| `W3ZZ` | `N0FFF` |

Only illustrative test fixtures and one UI hint string (`messaging_screen.dart`) are touched.

## Deliberately kept

- **`KM4TJO`** — the project owner's own callsign and the factual `APMDN` tocall-registry record (`DECISIONS.md`) + About-screen credit. No third-party-complaint risk.
- **`OH7LZB`** — CC BY-SA attribution for the aprs-deviceid DB / aprs.fi symbols and the tocall allocation record (license-required).
- **`WB4IHY` ("WB4IHY TNC")**, **`CA2RXU` (LoRa tracker)** — device/product names, not example data.
- **`W1AW` / `WB4APR`** — universal APRS example callsigns.
- **`assets/aprs-deviceid/tocalls.dense.json`** — vendored upstream community dataset (~150 calls); editing it would break device resolution and diverge from upstream.

## Scope

Current files only — no rewrite of historical commits (real calls remain reachable in old history; a `git filter-repo` purge was considered and declined as too disruptive for a public repo). Rebased onto `main` after #131.

## Validation

`flutter analyze` clean; **841 tests pass**; `dart format` applied. 41 insertions / 41 deletions (symmetric rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated example callsign text in the "Mute bulletin source" dialog hint.

* **Tests**
  * Updated test fixtures and data across messaging, bulletin, and service tests with new callsign values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->