### PR TITLE
feat(telemetry): definitions (PARM/UNIT/EQNS/BITS) — labelled, scaled channels (ADR-070)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -47,7 +47,8 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 - **ItemPacket** — APRS items
 - **StatusPacket** — text status reports
 - **WeatherPacket** — standalone (`_`) reports **and** weather embedded in an uncompressed position report (`_` symbol code: wind dir/speed from the course/speed slot + wx fields), binned as weather with position so it lands on the map
-- **TelemetryPacket** — `T#` data reports (sequence, up to five analog channels, digital bits); definition messages (PARM/UNIT/EQNS/BITS) tracked for a follow-up
+- **TelemetryPacket** — `T#` data reports (sequence, up to five analog channels, digital bits)
+- **TelemetryDefinitionPacket** — PARM/UNIT/EQNS/BITS definition messages, decoded as a distinct type (kept out of the message/conversation pipeline). Accumulated per station by `TelemetryService` (drift-backed) and correlated to data reports by `addressee` ↔ `source` (SSID-specific), so the detail sheet shows **labelled, EQNS-scaled, unit-tagged** channels — falling back to raw numbers when no definition has been heard
 - **QueryPacket** — general queries (DTI `?`, e.g. `?APRS?`); decoded for visibility, no auto-response
 - **CapabilitiesPacket** — station capabilities (DTI `<`, e.g. `IGATE,MSG_CNT,LOC_CNT`)
 - **Third-party traffic (`}`)** — unwrapped and re-parsed to the inner packet, attributed to the inner source with the relaying gateway recorded (`thirdPartyVia`, shown as "Relayed via" in the detail sheet)
@@ -65,7 +66,6 @@ Pure-Dart parser dispatching on the APRS Data Type Identifier byte. Sealed `Aprs
 
 ### Explicit non-support
 - Object / Item *creation* — display only (creation tracked in `FUTURE_FEATURES.md`)
-- Telemetry *definitions* (PARM/UNIT/EQNS/BITS) — data reports decode now; labelled/scaled channels via a definition store are a planned follow-up
 - Weather embedded in *compressed* positions and in object/item/Mic-E reports — only uncompressed position weather is promoted today (follow-up)
 - Position data extensions PHG / RNG / DFS — left in the comment, not separately decoded
 - Query auto-response — queries are decoded for visibility only

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -4,7 +4,7 @@ A consolidated reference of what Meridian can do today, organized by user-facing
 
 > **Maintenance:** This document is generated and maintained by Claude Code as part of milestone close-out. When a milestone changes user-visible capabilities or platform behavior, update this file alongside `ROADMAP.md` and `DECISIONS.md`. Source of truth is the codebase, not aspiration — partially implemented or untested capabilities are flagged explicitly.
 
-**Last updated:** 2026-05-30 (v0.21 Classic Bluetooth SPP shipped on Android — native RFCOMM channel, ADR-069, hardware-validated on a TH-D75; desktop deferred)
+**Last updated:** 2026-05-31 (telemetry definitions shipped — PARM/UNIT/EQNS/BITS decoded into `TelemetryDefinitionPacket`, accumulated per station by the drift-backed `TelemetryService`, ADR-070; labelled/scaled `T#` channels in the detail sheet)
 
 ---
 
@@ -315,7 +315,7 @@ Y = supported, P = partial / pending validation, — = not supported.
 ## 15. Reference Inventory
 
 - **Architecture overview:** `docs/ARCHITECTURE.md`
-- **Decisions:** `docs/DECISIONS.md` (ADR-001 through ADR-069)
+- **Decisions:** `docs/DECISIONS.md` (ADR-001 through ADR-070)
 - **Roadmap:** `docs/ROADMAP.md`
 - **Future features:** `docs/FUTURE_FEATURES.md`
 - **Theming strategy:** `docs/THEME_PLATFORM_STRATEGY.md`

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1914,3 +1914,81 @@ directions. This is a radio configuration requirement, not an app defect; it is 
 - `docs/ROADMAP.md` — v0.21 Classic Bluetooth SPP milestone (platform matrix, iOS caveat)
 - Android RFCOMM: `BluetoothDevice.createRfcommSocketToServiceRecord` / `BluetoothAdapter.bondedDevices`
 
+---
+
+## ADR-070: Telemetry definitions — distinct packet type, drift-backed `TelemetryService`, first schema migration
+
+**Date:** 2026-05-31
+**Status:** Accepted
+**Milestone:** Telemetry (Unit 2 — definitions)
+**Related:** ADR-067 (drift persistence), ADR-057/058/062 (BulletinService pattern this mirrors), ADR-055 (addressee classification precedence)
+
+### Context
+
+Meridian already decodes APRS telemetry **data** reports (`T#`, → `TelemetryPacket`) but shows them as
+raw channel numbers. The labels, units, and scaling that make telemetry legible arrive separately as
+the four **definition** components — `PARM` (channel names), `UNIT` (units), `EQNS` (scaling
+coefficients), `BITS` (binary sense mask + project title), APRS 1.0.1 §13. Three facts shape the
+design:
+
+1. **A definition is four independent messages.** PARM/UNIT/EQNS/BITS arrive as separate packets,
+   often minutes apart, and any subset may be missing. Partial definitions are the normal case.
+2. **They ride the `:` message DTI but are not user messages.** On the wire a definition is
+   `:ADDRESSEE :PARM.…`, addressed to the station it describes — frequently the sender itself (a
+   Kenwood TH-D75 sends its telemetry definitions to its own callsign), but a base station may also
+   define parameters for a remote tracker.
+3. **The correlation key is the definition's `addressee`, matched to a data report's `source`** —
+   SSID preserved, because telemetry is SSID-specific (`N0CALL-9` ≠ `N0CALL-1`).
+
+> **Interop tradeoff (SSID-strict).** Because correlation keeps the SSID, a station that *sends*
+> `T#` data under one SSID but *addresses* its definitions to a different one (e.g. data from `-7`,
+> defs to the bare base call) will not correlate — its channels render as raw numbers. This is the
+> spec-correct behaviour (definitions are per-SSID) and the fallback is graceful (raw values, no
+> error), but it is the most likely real-world "why aren't my labels showing?" case and should be
+> verified against live hardware.
+
+### Decision
+
+- **Parse definitions into a distinct sealed subtype, `TelemetryDefinitionPacket`** (carrying a
+  `kind {parm,unit,eqns,bits}` + that one component's payload), branched in `_parseMessage` on the
+  body prefix *before* any ACK/REJ or message-ID handling. Because `MessageService._onPacket` opens
+  with `if (packet is! MessagePacket) return;`, a distinct type keeps definitions out of the
+  conversation/ACK pipeline for free — **no phantom thread, and no auto-ACK even when a `{NNN` id is
+  present** (definitions are never ACKed). A new append-safe `PacketTypeTag.telemetryDefinition` tags
+  them for persistence; in the packet log they fold under the existing **TEL** filter chip.
+- **Accumulate per station in a new drift-backed `TelemetryService`** (ChangeNotifier), mirroring
+  `BulletinService`: an in-memory cache written through to drift, with a synchronous
+  `definitionFor(callsign)` lookup for the UI. Each incoming component merges into a per-station
+  `TelemetryDefinition` aggregate. EQNS scaling is `value = a·v² + b·v + c` per analog channel, with
+  identity defaults (a=0, b=1, c=0) for absent coefficients and tolerance for truncated/garbled
+  fields.
+- **Persist (not in-memory or SharedPreferences).** The packet log is retention-pruned; definitions
+  are slowly-changing and must outlive that window so channels stay labelled across restarts and
+  immediately on launch (rather than waiting hours for the next PARM). Drift keeps consistency with
+  `BulletinService` and avoids hand-rolling serialization of a keyed, growing collection.
+
+### First schema migration (v1 → v2)
+
+This adds the app's **first-ever** schema migration. Until now `schemaVersion` was 1 with `onCreate`
+only — no `onUpgrade` had ever run, and installs carry real packet/message/station data. The change
+is therefore deliberately minimal and **strictly additive**: bump to 2, add a single
+`telemetry_definitions` table (keyed by station), and an `onUpgrade` that does only
+`if (from < 2) m.createTable(telemetryDefinitions)` — no existing data is read or rewritten. A
+migration test pins both paths (fresh `onCreate` at v2, and a forced `user_version = 1` upgrade that
+round-trips a row), because every future migration builds on this precedent.
+
+### Rejected alternatives
+
+- **Keep definitions as `MessagePacket` and intercept in `MessageService`** (the way bulletins are
+  handled): bulletins are *addressee*-detected, but telemetry definitions are *body*-detected, so this
+  would push telemetry knowledge into the message layer and risks the phantom-thread/auto-ACK
+  regression. The distinct subtype is the cleaner seam.
+- **In-memory only / SharedPreferences:** rejected for the retention and consistency reasons above.
+
+### References
+
+- APRS 1.0.1 §13 — telemetry data and definition messages
+- ADR-067 — drift persistence; ADR-057/058/062 — the BulletinService pattern mirrored here
+- `lib/services/telemetry_service.dart`, `lib/models/telemetry_definition.dart`,
+  `lib/database/tables/telemetry_definitions.dart`
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -230,6 +230,15 @@ Deferred to the desktop follow-on phase (was Phase 3):
 
 ---
 
+### Telemetry (interstitial, between v0.21 and v0.22)
+
+Not a numbered milestone — a focused protocol-decoding effort delivered in two units.
+
+- **Unit 1 — decode (shipped, #131/#132):** `T#` telemetry data reports, third-party traffic (`}`) unwrapping, positioned weather (`_` symbol), queries (`?`), capabilities (`<`), and Kenwood TH-D75 Mic-E device ID. Test fixtures anonymised to `N0CALL`-style placeholders.
+- **Unit 2 — definitions (shipped, ADR-070):** PARM/UNIT/EQNS/BITS parsed into a distinct `TelemetryDefinitionPacket` (kept out of the message/conversation pipeline), accumulated per station by a drift-backed `TelemetryService`, and correlated to data reports (`addressee` ↔ `source`, SSID-specific). The packet detail sheet now renders labelled, EQNS-scaled, unit-tagged channels with a raw-number fallback. Introduced the app's first schema migration (v1 → v2, additive `telemetry_definitions` table).
+
+---
+
 ### v0.22 — Polish & A11y
 
 Pre-launch polish. The same surfaces being touched for accessibility and adaptive-widget cleanup are the ones that need pinning widget tests, so this milestone co-locates all three.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -300,4 +300,4 @@ Items that were filed as issues but deferred without scheduling. Each is tracked
 
 ---
 
-*Last updated: 2026-05-30*
+*Last updated: 2026-05-31*

--- a/lib/core/packet/aprs_packet.dart
+++ b/lib/core/packet/aprs_packet.dart
@@ -465,6 +465,71 @@ class TelemetryPacket extends AprsPacket {
 }
 
 // ---------------------------------------------------------------------------
+// Telemetry definition (PARM / UNIT / EQNS / BITS)
+// ---------------------------------------------------------------------------
+
+/// Which of the four telemetry-definition components this packet carries.
+///
+/// Per APRS 1.0.1 §13 a complete definition is delivered as four *separate*
+/// messages — they arrive independently (often minutes apart) and any subset
+/// may be missing. Each [TelemetryDefinitionPacket] carries exactly one
+/// component; the service layer accumulates them per station.
+enum TelemetryDefinitionKind { parm, unit, eqns, bits }
+
+/// An APRS telemetry-definition packet.
+///
+/// On the wire these are DTI `:` messages whose body begins with `PARM.`,
+/// `UNIT.`, `EQNS.`, or `BITS.`, addressed to the station whose telemetry they
+/// describe (frequently the sender itself, but a base station may define
+/// parameters for a remote tracker). They are deliberately a distinct subtype
+/// — NOT [MessagePacket] — so they never enter the conversation/ACK pipeline
+/// (no phantom threads, no auto-ACK), even when a `{NNN` id is present.
+///
+/// Only the field(s) relevant to [kind] are populated; the others are empty.
+/// The correlation key to a [TelemetryPacket] data report is this packet's
+/// [addressee] matched against the data packet's `source` (SSID preserved).
+class TelemetryDefinitionPacket extends AprsPacket {
+  /// The station this definition describes (correlation target). Trimmed; SSID
+  /// preserved because telemetry is SSID-specific.
+  final String addressee;
+
+  /// Which component this packet carries.
+  final TelemetryDefinitionKind kind;
+
+  /// PARM / UNIT labels in transmission order (up to 13: 5 analog + 8 binary).
+  /// Empty for [TelemetryDefinitionKind.eqns] / [TelemetryDefinitionKind.bits].
+  final List<String> labels;
+
+  /// EQNS coefficients in transmission order (conventionally 5 channels × 3:
+  /// a, b, c with `value = a·v² + b·v + c`). Kept as a flat list — the service
+  /// applies per-channel defaults (a=0, b=1, c=0) and tolerates truncation. A
+  /// null entry marks a field that could not be parsed. Empty for other kinds.
+  final List<double?> coefficients;
+
+  /// BITS 8-bit sense mask (MSB first). Empty for other kinds.
+  final List<bool> bitSense;
+
+  /// Optional project title following the BITS sense mask (`BITS.mask,Title`);
+  /// kept verbatim (a title may itself contain commas). Null for other kinds.
+  final String? projectTitle;
+
+  TelemetryDefinitionPacket({
+    required super.rawLine,
+    required super.source,
+    required super.destination,
+    required super.path,
+    required super.receivedAt,
+    super.transportSource,
+    required this.addressee,
+    required this.kind,
+    this.labels = const [],
+    this.coefficients = const [],
+    this.bitSense = const [],
+    this.projectTitle,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Unknown / catch-all
 // ---------------------------------------------------------------------------
 

--- a/lib/core/packet/aprs_parser.dart
+++ b/lib/core/packet/aprs_parser.dart
@@ -1208,6 +1208,25 @@ class AprsParser {
     final addressee = info.substring(1, 10).trim();
     var messageText = info.substring(11);
 
+    // Telemetry definitions (PARM/UNIT/EQNS/BITS) ride on the `:` message DTI
+    // but are metadata, not user messages. Branch to a distinct subtype before
+    // any ACK/REJ or message-ID handling so they never reach the conversation
+    // pipeline. Detection is on the body prefix; the keyword includes the dot.
+    final defKind = _telemetryDefinitionKind(messageText);
+    if (defKind != null) {
+      return _parseTelemetryDefinition(
+        kind: defKind,
+        body: messageText,
+        addressee: addressee,
+        rawLine: rawLine,
+        source: source,
+        destination: destination,
+        path: path,
+        receivedAt: receivedAt,
+        transportSource: transportSource,
+      );
+    }
+
     // Extract optional message ID: '{NNN' suffix (no closing brace per spec).
     String? messageId;
     final idIdx = messageText.lastIndexOf('{');
@@ -1260,6 +1279,83 @@ class AprsParser {
       addressee: addressee,
       message: messageText,
       messageId: messageId?.isEmpty == true ? null : messageId,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Telemetry definitions  (PARM. / UNIT. / EQNS. / BITS. on the `:` DTI)
+  // ---------------------------------------------------------------------------
+
+  /// Returns the definition kind if [body] begins with a telemetry-definition
+  /// keyword (`PARM.`, `UNIT.`, `EQNS.`, `BITS.`), or null otherwise.
+  static TelemetryDefinitionKind? _telemetryDefinitionKind(String body) {
+    if (body.startsWith('PARM.')) return TelemetryDefinitionKind.parm;
+    if (body.startsWith('UNIT.')) return TelemetryDefinitionKind.unit;
+    if (body.startsWith('EQNS.')) return TelemetryDefinitionKind.eqns;
+    if (body.startsWith('BITS.')) return TelemetryDefinitionKind.bits;
+    return null;
+  }
+
+  AprsPacket _parseTelemetryDefinition({
+    required TelemetryDefinitionKind kind,
+    required String body,
+    required String addressee,
+    required String rawLine,
+    required String source,
+    required String destination,
+    required List<String> path,
+    required DateTime receivedAt,
+    required PacketSource transportSource,
+  }) {
+    // Drop the 5-char keyword (e.g. "PARM."). A trailing `{NNN` message id is
+    // rare on definitions but legal; strip it so it never pollutes the payload.
+    var payload = body.substring(5);
+    final idIdx = payload.lastIndexOf('{');
+    if (idIdx >= 0) payload = payload.substring(0, idIdx);
+
+    var labels = const <String>[];
+    var coefficients = const <double?>[];
+    var bitSense = const <bool>[];
+    String? projectTitle;
+
+    switch (kind) {
+      case TelemetryDefinitionKind.parm:
+      case TelemetryDefinitionKind.unit:
+        // Up to 13 comma-separated labels (5 analog + 8 binary). Blanks kept.
+        labels = [for (final t in payload.split(',').take(13)) t.trim()];
+      case TelemetryDefinitionKind.eqns:
+        // Flat list of coefficients (conventionally 5×3). Tolerate truncation
+        // and unparseable fields (null); the service applies per-channel
+        // defaults and chunks into triples.
+        coefficients = [
+          for (final t in payload.split(',')) double.tryParse(t.trim()),
+        ];
+      case TelemetryDefinitionKind.bits:
+        // `mask,Project Title` — the sense mask is the run of bit chars before
+        // the first comma; everything after it is the title (may contain
+        // commas, so split only once).
+        final comma = payload.indexOf(',');
+        final mask = comma >= 0 ? payload.substring(0, comma) : payload;
+        bitSense = [for (final c in mask.split('')) c == '1'];
+        if (comma >= 0) {
+          final title = payload.substring(comma + 1).trim();
+          if (title.isNotEmpty) projectTitle = title;
+        }
+    }
+
+    return TelemetryDefinitionPacket(
+      rawLine: rawLine,
+      source: source,
+      destination: destination,
+      path: path,
+      receivedAt: receivedAt,
+      transportSource: transportSource,
+      addressee: addressee,
+      kind: kind,
+      labels: labels,
+      coefficients: coefficients,
+      bitSense: bitSense,
+      projectTitle: projectTitle,
     );
   }
 

--- a/lib/database/daos/telemetry_definition_dao.dart
+++ b/lib/database/daos/telemetry_definition_dao.dart
@@ -1,0 +1,23 @@
+import 'package:drift/drift.dart';
+
+import '../meridian_database.dart';
+import '../tables/telemetry_definitions.dart';
+
+part 'telemetry_definition_dao.g.dart';
+
+@DriftAccessor(tables: [TelemetryDefinitions])
+class TelemetryDefinitionDao extends DatabaseAccessor<MeridianDatabase>
+    with _$TelemetryDefinitionDaoMixin {
+  TelemetryDefinitionDao(super.db);
+
+  /// Upsert keyed by `station` — a new component for a known station updates
+  /// the existing row rather than appending.
+  Future<void> upsert(TelemetryDefinitionsCompanion def) =>
+      into(telemetryDefinitions).insertOnConflictUpdate(def);
+
+  /// One-shot read of every stored definition. Used by [load] at startup.
+  Future<List<TelemetryDefinitionRow>> getAll() =>
+      select(telemetryDefinitions).get();
+
+  Future<void> clearAll() => delete(telemetryDefinitions).go();
+}

--- a/lib/database/daos/telemetry_definition_dao.g.dart
+++ b/lib/database/daos/telemetry_definition_dao.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'telemetry_definition_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$TelemetryDefinitionDaoMixin on DatabaseAccessor<MeridianDatabase> {
+  $TelemetryDefinitionsTable get telemetryDefinitions =>
+      attachedDatabase.telemetryDefinitions;
+  TelemetryDefinitionDaoManager get managers =>
+      TelemetryDefinitionDaoManager(this);
+}
+
+class TelemetryDefinitionDaoManager {
+  final _$TelemetryDefinitionDaoMixin _db;
+  TelemetryDefinitionDaoManager(this._db);
+  $$TelemetryDefinitionsTableTableManager get telemetryDefinitions =>
+      $$TelemetryDefinitionsTableTableManager(
+        _db.attachedDatabase,
+        _db.telemetryDefinitions,
+      );
+}

--- a/lib/database/meridian_database.dart
+++ b/lib/database/meridian_database.dart
@@ -10,6 +10,7 @@ import 'daos/bulletin_dao.dart';
 import 'daos/message_dao.dart';
 import 'daos/packet_dao.dart';
 import 'daos/station_dao.dart';
+import 'daos/telemetry_definition_dao.dart';
 import 'tables/bulletins.dart';
 import 'tables/conversations.dart';
 import 'tables/group_message_entries.dart';
@@ -18,6 +19,7 @@ import 'tables/outgoing_bulletins.dart';
 import 'tables/packets.dart';
 import 'tables/position_history.dart';
 import 'tables/stations.dart';
+import 'tables/telemetry_definitions.dart';
 
 part 'meridian_database.g.dart';
 
@@ -31,16 +33,26 @@ part 'meridian_database.g.dart';
     GroupMessageEntries,
     Bulletins,
     OutgoingBulletins,
+    TelemetryDefinitions,
   ],
-  daos: [StationDao, PacketDao, MessageDao, BulletinDao],
+  daos: [
+    StationDao,
+    PacketDao,
+    MessageDao,
+    BulletinDao,
+    TelemetryDefinitionDao,
+  ],
 )
 class MeridianDatabase extends _$MeridianDatabase {
   MeridianDatabase(super.executor);
 
   MeridianDatabase.connect(DatabaseConnection super.connection) : super();
 
+  // v1 → v2 (Unit 2, ADR-070): added the telemetry_definitions table. This is
+  // the app's first schema migration — it must be strictly additive and
+  // non-destructive (existing installs carry real packet/message/station data).
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -68,6 +80,12 @@ class MeridianDatabase extends _$MeridianDatabase {
       await customStatement(
         'CREATE INDEX bulletins_last_heard_at ON bulletins(last_heard_at)',
       );
+    },
+    onUpgrade: (m, from, to) async {
+      // v1 → v2: telemetry_definitions table (additive; no data touched).
+      if (from < 2) {
+        await m.createTable(telemetryDefinitions);
+      }
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');

--- a/lib/database/meridian_database.g.dart
+++ b/lib/database/meridian_database.g.dart
@@ -4466,6 +4466,502 @@ class OutgoingBulletinsCompanion extends UpdateCompanion<OutgoingBulletinRow> {
   }
 }
 
+class $TelemetryDefinitionsTable extends TelemetryDefinitions
+    with TableInfo<$TelemetryDefinitionsTable, TelemetryDefinitionRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TelemetryDefinitionsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _stationMeta = const VerificationMeta(
+    'station',
+  );
+  @override
+  late final GeneratedColumn<String> station = GeneratedColumn<String>(
+    'station',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _parameterNamesMeta = const VerificationMeta(
+    'parameterNames',
+  );
+  @override
+  late final GeneratedColumn<String> parameterNames = GeneratedColumn<String>(
+    'parameter_names',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _unitsMeta = const VerificationMeta('units');
+  @override
+  late final GeneratedColumn<String> units = GeneratedColumn<String>(
+    'units',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _equationsMeta = const VerificationMeta(
+    'equations',
+  );
+  @override
+  late final GeneratedColumn<String> equations = GeneratedColumn<String>(
+    'equations',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _bitSenseMeta = const VerificationMeta(
+    'bitSense',
+  );
+  @override
+  late final GeneratedColumn<String> bitSense = GeneratedColumn<String>(
+    'bit_sense',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _projectTitleMeta = const VerificationMeta(
+    'projectTitle',
+  );
+  @override
+  late final GeneratedColumn<String> projectTitle = GeneratedColumn<String>(
+    'project_title',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    station,
+    parameterNames,
+    units,
+    equations,
+    bitSense,
+    projectTitle,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'telemetry_definitions';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<TelemetryDefinitionRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('station')) {
+      context.handle(
+        _stationMeta,
+        station.isAcceptableOrUnknown(data['station']!, _stationMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_stationMeta);
+    }
+    if (data.containsKey('parameter_names')) {
+      context.handle(
+        _parameterNamesMeta,
+        parameterNames.isAcceptableOrUnknown(
+          data['parameter_names']!,
+          _parameterNamesMeta,
+        ),
+      );
+    }
+    if (data.containsKey('units')) {
+      context.handle(
+        _unitsMeta,
+        units.isAcceptableOrUnknown(data['units']!, _unitsMeta),
+      );
+    }
+    if (data.containsKey('equations')) {
+      context.handle(
+        _equationsMeta,
+        equations.isAcceptableOrUnknown(data['equations']!, _equationsMeta),
+      );
+    }
+    if (data.containsKey('bit_sense')) {
+      context.handle(
+        _bitSenseMeta,
+        bitSense.isAcceptableOrUnknown(data['bit_sense']!, _bitSenseMeta),
+      );
+    }
+    if (data.containsKey('project_title')) {
+      context.handle(
+        _projectTitleMeta,
+        projectTitle.isAcceptableOrUnknown(
+          data['project_title']!,
+          _projectTitleMeta,
+        ),
+      );
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {station};
+  @override
+  TelemetryDefinitionRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TelemetryDefinitionRow(
+      station: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}station'],
+      )!,
+      parameterNames: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}parameter_names'],
+      ),
+      units: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}units'],
+      ),
+      equations: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}equations'],
+      ),
+      bitSense: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}bit_sense'],
+      ),
+      projectTitle: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}project_title'],
+      ),
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $TelemetryDefinitionsTable createAlias(String alias) {
+    return $TelemetryDefinitionsTable(attachedDatabase, alias);
+  }
+}
+
+class TelemetryDefinitionRow extends DataClass
+    implements Insertable<TelemetryDefinitionRow> {
+  final String station;
+
+  /// PARM labels, comma-joined (`Battery,Temp,...`).
+  final String? parameterNames;
+
+  /// UNIT labels, comma-joined.
+  final String? units;
+
+  /// EQNS coefficients, comma-joined (`0,0.075,0,...`).
+  final String? equations;
+
+  /// BITS sense mask as transmitted (`10110000`).
+  final String? bitSense;
+
+  /// BITS project title, verbatim.
+  final String? projectTitle;
+  final int updatedAt;
+  const TelemetryDefinitionRow({
+    required this.station,
+    this.parameterNames,
+    this.units,
+    this.equations,
+    this.bitSense,
+    this.projectTitle,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['station'] = Variable<String>(station);
+    if (!nullToAbsent || parameterNames != null) {
+      map['parameter_names'] = Variable<String>(parameterNames);
+    }
+    if (!nullToAbsent || units != null) {
+      map['units'] = Variable<String>(units);
+    }
+    if (!nullToAbsent || equations != null) {
+      map['equations'] = Variable<String>(equations);
+    }
+    if (!nullToAbsent || bitSense != null) {
+      map['bit_sense'] = Variable<String>(bitSense);
+    }
+    if (!nullToAbsent || projectTitle != null) {
+      map['project_title'] = Variable<String>(projectTitle);
+    }
+    map['updated_at'] = Variable<int>(updatedAt);
+    return map;
+  }
+
+  TelemetryDefinitionsCompanion toCompanion(bool nullToAbsent) {
+    return TelemetryDefinitionsCompanion(
+      station: Value(station),
+      parameterNames: parameterNames == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parameterNames),
+      units: units == null && nullToAbsent
+          ? const Value.absent()
+          : Value(units),
+      equations: equations == null && nullToAbsent
+          ? const Value.absent()
+          : Value(equations),
+      bitSense: bitSense == null && nullToAbsent
+          ? const Value.absent()
+          : Value(bitSense),
+      projectTitle: projectTitle == null && nullToAbsent
+          ? const Value.absent()
+          : Value(projectTitle),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory TelemetryDefinitionRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return TelemetryDefinitionRow(
+      station: serializer.fromJson<String>(json['station']),
+      parameterNames: serializer.fromJson<String?>(json['parameterNames']),
+      units: serializer.fromJson<String?>(json['units']),
+      equations: serializer.fromJson<String?>(json['equations']),
+      bitSense: serializer.fromJson<String?>(json['bitSense']),
+      projectTitle: serializer.fromJson<String?>(json['projectTitle']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'station': serializer.toJson<String>(station),
+      'parameterNames': serializer.toJson<String?>(parameterNames),
+      'units': serializer.toJson<String?>(units),
+      'equations': serializer.toJson<String?>(equations),
+      'bitSense': serializer.toJson<String?>(bitSense),
+      'projectTitle': serializer.toJson<String?>(projectTitle),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+    };
+  }
+
+  TelemetryDefinitionRow copyWith({
+    String? station,
+    Value<String?> parameterNames = const Value.absent(),
+    Value<String?> units = const Value.absent(),
+    Value<String?> equations = const Value.absent(),
+    Value<String?> bitSense = const Value.absent(),
+    Value<String?> projectTitle = const Value.absent(),
+    int? updatedAt,
+  }) => TelemetryDefinitionRow(
+    station: station ?? this.station,
+    parameterNames: parameterNames.present
+        ? parameterNames.value
+        : this.parameterNames,
+    units: units.present ? units.value : this.units,
+    equations: equations.present ? equations.value : this.equations,
+    bitSense: bitSense.present ? bitSense.value : this.bitSense,
+    projectTitle: projectTitle.present ? projectTitle.value : this.projectTitle,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  TelemetryDefinitionRow copyWithCompanion(TelemetryDefinitionsCompanion data) {
+    return TelemetryDefinitionRow(
+      station: data.station.present ? data.station.value : this.station,
+      parameterNames: data.parameterNames.present
+          ? data.parameterNames.value
+          : this.parameterNames,
+      units: data.units.present ? data.units.value : this.units,
+      equations: data.equations.present ? data.equations.value : this.equations,
+      bitSense: data.bitSense.present ? data.bitSense.value : this.bitSense,
+      projectTitle: data.projectTitle.present
+          ? data.projectTitle.value
+          : this.projectTitle,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TelemetryDefinitionRow(')
+          ..write('station: $station, ')
+          ..write('parameterNames: $parameterNames, ')
+          ..write('units: $units, ')
+          ..write('equations: $equations, ')
+          ..write('bitSense: $bitSense, ')
+          ..write('projectTitle: $projectTitle, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    station,
+    parameterNames,
+    units,
+    equations,
+    bitSense,
+    projectTitle,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TelemetryDefinitionRow &&
+          other.station == this.station &&
+          other.parameterNames == this.parameterNames &&
+          other.units == this.units &&
+          other.equations == this.equations &&
+          other.bitSense == this.bitSense &&
+          other.projectTitle == this.projectTitle &&
+          other.updatedAt == this.updatedAt);
+}
+
+class TelemetryDefinitionsCompanion
+    extends UpdateCompanion<TelemetryDefinitionRow> {
+  final Value<String> station;
+  final Value<String?> parameterNames;
+  final Value<String?> units;
+  final Value<String?> equations;
+  final Value<String?> bitSense;
+  final Value<String?> projectTitle;
+  final Value<int> updatedAt;
+  final Value<int> rowid;
+  const TelemetryDefinitionsCompanion({
+    this.station = const Value.absent(),
+    this.parameterNames = const Value.absent(),
+    this.units = const Value.absent(),
+    this.equations = const Value.absent(),
+    this.bitSense = const Value.absent(),
+    this.projectTitle = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  TelemetryDefinitionsCompanion.insert({
+    required String station,
+    this.parameterNames = const Value.absent(),
+    this.units = const Value.absent(),
+    this.equations = const Value.absent(),
+    this.bitSense = const Value.absent(),
+    this.projectTitle = const Value.absent(),
+    required int updatedAt,
+    this.rowid = const Value.absent(),
+  }) : station = Value(station),
+       updatedAt = Value(updatedAt);
+  static Insertable<TelemetryDefinitionRow> custom({
+    Expression<String>? station,
+    Expression<String>? parameterNames,
+    Expression<String>? units,
+    Expression<String>? equations,
+    Expression<String>? bitSense,
+    Expression<String>? projectTitle,
+    Expression<int>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (station != null) 'station': station,
+      if (parameterNames != null) 'parameter_names': parameterNames,
+      if (units != null) 'units': units,
+      if (equations != null) 'equations': equations,
+      if (bitSense != null) 'bit_sense': bitSense,
+      if (projectTitle != null) 'project_title': projectTitle,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  TelemetryDefinitionsCompanion copyWith({
+    Value<String>? station,
+    Value<String?>? parameterNames,
+    Value<String?>? units,
+    Value<String?>? equations,
+    Value<String?>? bitSense,
+    Value<String?>? projectTitle,
+    Value<int>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return TelemetryDefinitionsCompanion(
+      station: station ?? this.station,
+      parameterNames: parameterNames ?? this.parameterNames,
+      units: units ?? this.units,
+      equations: equations ?? this.equations,
+      bitSense: bitSense ?? this.bitSense,
+      projectTitle: projectTitle ?? this.projectTitle,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (station.present) {
+      map['station'] = Variable<String>(station.value);
+    }
+    if (parameterNames.present) {
+      map['parameter_names'] = Variable<String>(parameterNames.value);
+    }
+    if (units.present) {
+      map['units'] = Variable<String>(units.value);
+    }
+    if (equations.present) {
+      map['equations'] = Variable<String>(equations.value);
+    }
+    if (bitSense.present) {
+      map['bit_sense'] = Variable<String>(bitSense.value);
+    }
+    if (projectTitle.present) {
+      map['project_title'] = Variable<String>(projectTitle.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TelemetryDefinitionsCompanion(')
+          ..write('station: $station, ')
+          ..write('parameterNames: $parameterNames, ')
+          ..write('units: $units, ')
+          ..write('equations: $equations, ')
+          ..write('bitSense: $bitSense, ')
+          ..write('projectTitle: $projectTitle, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$MeridianDatabase extends GeneratedDatabase {
   _$MeridianDatabase(QueryExecutor e) : super(e);
   $MeridianDatabaseManager get managers => $MeridianDatabaseManager(this);
@@ -4481,10 +4977,14 @@ abstract class _$MeridianDatabase extends GeneratedDatabase {
   late final $BulletinsTable bulletins = $BulletinsTable(this);
   late final $OutgoingBulletinsTable outgoingBulletins =
       $OutgoingBulletinsTable(this);
+  late final $TelemetryDefinitionsTable telemetryDefinitions =
+      $TelemetryDefinitionsTable(this);
   late final StationDao stationDao = StationDao(this as MeridianDatabase);
   late final PacketDao packetDao = PacketDao(this as MeridianDatabase);
   late final MessageDao messageDao = MessageDao(this as MeridianDatabase);
   late final BulletinDao bulletinDao = BulletinDao(this as MeridianDatabase);
+  late final TelemetryDefinitionDao telemetryDefinitionDao =
+      TelemetryDefinitionDao(this as MeridianDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -4498,6 +4998,7 @@ abstract class _$MeridianDatabase extends GeneratedDatabase {
     groupMessageEntries,
     bulletins,
     outgoingBulletins,
+    telemetryDefinitions,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -7252,6 +7753,264 @@ typedef $$OutgoingBulletinsTableProcessedTableManager =
       OutgoingBulletinRow,
       PrefetchHooks Function()
     >;
+typedef $$TelemetryDefinitionsTableCreateCompanionBuilder =
+    TelemetryDefinitionsCompanion Function({
+      required String station,
+      Value<String?> parameterNames,
+      Value<String?> units,
+      Value<String?> equations,
+      Value<String?> bitSense,
+      Value<String?> projectTitle,
+      required int updatedAt,
+      Value<int> rowid,
+    });
+typedef $$TelemetryDefinitionsTableUpdateCompanionBuilder =
+    TelemetryDefinitionsCompanion Function({
+      Value<String> station,
+      Value<String?> parameterNames,
+      Value<String?> units,
+      Value<String?> equations,
+      Value<String?> bitSense,
+      Value<String?> projectTitle,
+      Value<int> updatedAt,
+      Value<int> rowid,
+    });
+
+class $$TelemetryDefinitionsTableFilterComposer
+    extends Composer<_$MeridianDatabase, $TelemetryDefinitionsTable> {
+  $$TelemetryDefinitionsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get station => $composableBuilder(
+    column: $table.station,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get parameterNames => $composableBuilder(
+    column: $table.parameterNames,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get units => $composableBuilder(
+    column: $table.units,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get equations => $composableBuilder(
+    column: $table.equations,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get bitSense => $composableBuilder(
+    column: $table.bitSense,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get projectTitle => $composableBuilder(
+    column: $table.projectTitle,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$TelemetryDefinitionsTableOrderingComposer
+    extends Composer<_$MeridianDatabase, $TelemetryDefinitionsTable> {
+  $$TelemetryDefinitionsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get station => $composableBuilder(
+    column: $table.station,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get parameterNames => $composableBuilder(
+    column: $table.parameterNames,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get units => $composableBuilder(
+    column: $table.units,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get equations => $composableBuilder(
+    column: $table.equations,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get bitSense => $composableBuilder(
+    column: $table.bitSense,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get projectTitle => $composableBuilder(
+    column: $table.projectTitle,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$TelemetryDefinitionsTableAnnotationComposer
+    extends Composer<_$MeridianDatabase, $TelemetryDefinitionsTable> {
+  $$TelemetryDefinitionsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get station =>
+      $composableBuilder(column: $table.station, builder: (column) => column);
+
+  GeneratedColumn<String> get parameterNames => $composableBuilder(
+    column: $table.parameterNames,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get units =>
+      $composableBuilder(column: $table.units, builder: (column) => column);
+
+  GeneratedColumn<String> get equations =>
+      $composableBuilder(column: $table.equations, builder: (column) => column);
+
+  GeneratedColumn<String> get bitSense =>
+      $composableBuilder(column: $table.bitSense, builder: (column) => column);
+
+  GeneratedColumn<String> get projectTitle => $composableBuilder(
+    column: $table.projectTitle,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$TelemetryDefinitionsTableTableManager
+    extends
+        RootTableManager<
+          _$MeridianDatabase,
+          $TelemetryDefinitionsTable,
+          TelemetryDefinitionRow,
+          $$TelemetryDefinitionsTableFilterComposer,
+          $$TelemetryDefinitionsTableOrderingComposer,
+          $$TelemetryDefinitionsTableAnnotationComposer,
+          $$TelemetryDefinitionsTableCreateCompanionBuilder,
+          $$TelemetryDefinitionsTableUpdateCompanionBuilder,
+          (
+            TelemetryDefinitionRow,
+            BaseReferences<
+              _$MeridianDatabase,
+              $TelemetryDefinitionsTable,
+              TelemetryDefinitionRow
+            >,
+          ),
+          TelemetryDefinitionRow,
+          PrefetchHooks Function()
+        > {
+  $$TelemetryDefinitionsTableTableManager(
+    _$MeridianDatabase db,
+    $TelemetryDefinitionsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$TelemetryDefinitionsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$TelemetryDefinitionsTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$TelemetryDefinitionsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> station = const Value.absent(),
+                Value<String?> parameterNames = const Value.absent(),
+                Value<String?> units = const Value.absent(),
+                Value<String?> equations = const Value.absent(),
+                Value<String?> bitSense = const Value.absent(),
+                Value<String?> projectTitle = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => TelemetryDefinitionsCompanion(
+                station: station,
+                parameterNames: parameterNames,
+                units: units,
+                equations: equations,
+                bitSense: bitSense,
+                projectTitle: projectTitle,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String station,
+                Value<String?> parameterNames = const Value.absent(),
+                Value<String?> units = const Value.absent(),
+                Value<String?> equations = const Value.absent(),
+                Value<String?> bitSense = const Value.absent(),
+                Value<String?> projectTitle = const Value.absent(),
+                required int updatedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => TelemetryDefinitionsCompanion.insert(
+                station: station,
+                parameterNames: parameterNames,
+                units: units,
+                equations: equations,
+                bitSense: bitSense,
+                projectTitle: projectTitle,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$TelemetryDefinitionsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$MeridianDatabase,
+      $TelemetryDefinitionsTable,
+      TelemetryDefinitionRow,
+      $$TelemetryDefinitionsTableFilterComposer,
+      $$TelemetryDefinitionsTableOrderingComposer,
+      $$TelemetryDefinitionsTableAnnotationComposer,
+      $$TelemetryDefinitionsTableCreateCompanionBuilder,
+      $$TelemetryDefinitionsTableUpdateCompanionBuilder,
+      (
+        TelemetryDefinitionRow,
+        BaseReferences<
+          _$MeridianDatabase,
+          $TelemetryDefinitionsTable,
+          TelemetryDefinitionRow
+        >,
+      ),
+      TelemetryDefinitionRow,
+      PrefetchHooks Function()
+    >;
 
 class $MeridianDatabaseManager {
   final _$MeridianDatabase _db;
@@ -7272,4 +8031,6 @@ class $MeridianDatabaseManager {
       $$BulletinsTableTableManager(_db, _db.bulletins);
   $$OutgoingBulletinsTableTableManager get outgoingBulletins =>
       $$OutgoingBulletinsTableTableManager(_db, _db.outgoingBulletins);
+  $$TelemetryDefinitionsTableTableManager get telemetryDefinitions =>
+      $$TelemetryDefinitionsTableTableManager(_db, _db.telemetryDefinitions);
 }

--- a/lib/database/tables/packets.dart
+++ b/lib/database/tables/packets.dart
@@ -13,6 +13,7 @@ enum PacketTypeTag {
   status,
   micE,
   telemetry,
+  telemetryDefinition,
   query,
   capabilities,
   unknown,

--- a/lib/database/tables/telemetry_definitions.dart
+++ b/lib/database/tables/telemetry_definitions.dart
@@ -1,0 +1,38 @@
+import 'package:drift/drift.dart';
+
+/// Accumulated telemetry definitions, one row per described station.
+///
+/// PARM/UNIT/EQNS/BITS components arrive as separate messages and are merged
+/// into a single row (keyed by [station] — the definition addressee, trimmed +
+/// upper-cased, SSID preserved). Components are stored as their raw wire
+/// payload strings (the part after the keyword) so round-tripping needs no
+/// converter: comma-joined for PARM/UNIT/EQNS, the bit-mask run for BITS.
+/// A null column means that component has not been heard yet.
+///
+/// Unlike the packet log, this table is NOT retention-pruned: definitions are
+/// slowly-changing and must outlive the packet window so channels stay
+/// labelled across restarts.
+@DataClassName('TelemetryDefinitionRow')
+class TelemetryDefinitions extends Table {
+  TextColumn get station => text()();
+
+  /// PARM labels, comma-joined (`Battery,Temp,...`).
+  TextColumn get parameterNames => text().named('parameter_names').nullable()();
+
+  /// UNIT labels, comma-joined.
+  TextColumn get units => text().nullable()();
+
+  /// EQNS coefficients, comma-joined (`0,0.075,0,...`).
+  TextColumn get equations => text().nullable()();
+
+  /// BITS sense mask as transmitted (`10110000`).
+  TextColumn get bitSense => text().named('bit_sense').nullable()();
+
+  /// BITS project title, verbatim.
+  TextColumn get projectTitle => text().named('project_title').nullable()();
+
+  IntColumn get updatedAt => integer().named('updated_at')();
+
+  @override
+  Set<Column> get primaryKey => {station};
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'database/daos/bulletin_dao.dart';
 import 'database/daos/message_dao.dart';
 import 'database/daos/packet_dao.dart';
 import 'database/daos/station_dao.dart';
+import 'database/daos/telemetry_definition_dao.dart';
 import 'database/database_provider.dart';
 import 'database/meridian_database.dart';
 import 'map/stadia_tile_provider.dart';
@@ -47,6 +48,7 @@ import 'services/message_service.dart';
 import 'services/messaging_settings_service.dart';
 import 'services/station_service.dart';
 import 'services/station_settings_service.dart';
+import 'services/telemetry_service.dart';
 import 'services/tx_service.dart';
 import 'theme/android_theme.dart';
 import 'theme/desktop_theme.dart';
@@ -262,6 +264,16 @@ Future<void> main() async {
   );
   await messageService.loadHistory();
 
+  // Telemetry definitions (PARM/UNIT/EQNS/BITS) accumulate per station so
+  // telemetry data reports render labelled, scaled channels (ADR-070). Listens
+  // to the same packet stream as MessageService; definition packets are a
+  // distinct type, so they never enter the conversation pipeline.
+  final telemetryService = TelemetryService(
+    stations: service,
+    dao: database.telemetryDefinitionDao,
+  );
+  await telemetryService.load();
+
   final bannerController = InAppBannerController();
   final notificationService = NotificationService(
     messageService: messageService,
@@ -339,6 +351,9 @@ Future<void> main() async {
         Provider<PacketDao>.value(value: database.packetDao),
         Provider<MessageDao>.value(value: database.messageDao),
         Provider<BulletinDao>.value(value: database.bulletinDao),
+        Provider<TelemetryDefinitionDao>.value(
+          value: database.telemetryDefinitionDao,
+        ),
         ChangeNotifierProvider<StationService>.value(value: service),
         ChangeNotifierProvider<ConnectionRegistry>.value(value: registry),
         ChangeNotifierProvider<StationSettingsService>.value(
@@ -360,6 +375,7 @@ Future<void> main() async {
           value: messagingSettings,
         ),
         ChangeNotifierProvider<MessageService>.value(value: messageService),
+        ChangeNotifierProvider<TelemetryService>.value(value: telemetryService),
         ChangeNotifierProvider<BackgroundServiceManager>.value(
           value: bgServiceManager,
         ),

--- a/lib/models/telemetry_definition.dart
+++ b/lib/models/telemetry_definition.dart
@@ -1,0 +1,118 @@
+/// An accumulated APRS telemetry definition for one station.
+///
+/// A complete definition arrives as four independent messages (PARM/UNIT/EQNS/
+/// BITS, APRS 1.0.1 §13), often minutes apart and any subset may be missing.
+/// [TelemetryService] merges each [TelemetryDefinitionPacket] component into
+/// the per-station aggregate held here; partial definitions are the normal
+/// case. Channel indices 0–4 are the analog channels; 5–12 are the eight binary
+/// channels.
+library;
+
+import '../core/packet/aprs_packet.dart';
+
+class TelemetryDefinition {
+  TelemetryDefinition({
+    required this.station,
+    required this.updatedAt,
+    List<String>? parameterNames,
+    List<String>? units,
+    List<double?>? coefficients,
+    List<bool>? bitSense,
+    this.projectTitle,
+  }) : parameterNames = parameterNames ?? const [],
+       units = units ?? const [],
+       coefficients = coefficients ?? const [],
+       bitSense = bitSense ?? const [];
+
+  /// Correlation key: the described station, trimmed + upper-cased with the
+  /// SSID preserved (telemetry is SSID-specific).
+  final String station;
+
+  /// PARM channel names (up to 13: 5 analog + 8 binary). May be empty.
+  List<String> parameterNames;
+
+  /// UNIT labels, parallel to [parameterNames]. May be empty.
+  List<String> units;
+
+  /// EQNS coefficients as a flat list (conventionally 5 channels × `a,b,c`).
+  /// A null entry marks an unparseable field. May be empty.
+  List<double?> coefficients;
+
+  /// BITS 8-bit sense mask (MSB first). May be empty.
+  List<bool> bitSense;
+
+  /// Optional project title from the BITS component.
+  String? projectTitle;
+
+  /// Last time any component of this definition was heard.
+  DateTime updatedAt;
+
+  /// True when nothing useful has been captured yet.
+  bool get isEmpty =>
+      parameterNames.isEmpty &&
+      units.isEmpty &&
+      coefficients.isEmpty &&
+      bitSense.isEmpty &&
+      projectTitle == null;
+
+  /// Channel name at [index] (0-based over all 13 channels), or null if not
+  /// defined / blank.
+  String? nameAt(int index) {
+    if (index < 0 || index >= parameterNames.length) return null;
+    final n = parameterNames[index].trim();
+    return n.isEmpty ? null : n;
+  }
+
+  /// Unit label at [index], or null if not defined / blank.
+  String? unitAt(int index) {
+    if (index < 0 || index >= units.length) return null;
+    final u = units[index].trim();
+    return u.isEmpty ? null : u;
+  }
+
+  /// Applies the EQNS scaling for analog channel [channel] (0–4):
+  /// `value = a·raw² + b·raw + c`. Missing or unparseable coefficients fall
+  /// back to identity (a=0, b=1, c=0), so a channel with no EQNS returns [raw]
+  /// unchanged.
+  double scaleAnalog(int channel, double raw) {
+    final base = channel * 3;
+    final a = _coeff(base) ?? 0.0;
+    final b = _coeff(base + 1) ?? 1.0;
+    final c = _coeff(base + 2) ?? 0.0;
+    return a * raw * raw + b * raw + c;
+  }
+
+  /// True when an EQNS scaling other than the identity is defined for analog
+  /// channel [channel] — i.e. applying [scaleAnalog] would change the raw value
+  /// for some inputs. Used by the UI to decide whether to show "raw → scaled".
+  bool hasScaling(int channel) {
+    final base = channel * 3;
+    final a = _coeff(base);
+    final b = _coeff(base + 1);
+    final c = _coeff(base + 2);
+    if (a != null && a != 0) return true;
+    if (b != null && b != 1) return true;
+    if (c != null && c != 0) return true;
+    return false;
+  }
+
+  double? _coeff(int i) =>
+      (i >= 0 && i < coefficients.length) ? coefficients[i] : null;
+
+  /// Merges one decoded definition component into this aggregate, bumping
+  /// [updatedAt]. Only the field(s) carried by [packet] are replaced.
+  void applyComponent(TelemetryDefinitionPacket packet) {
+    switch (packet.kind) {
+      case TelemetryDefinitionKind.parm:
+        parameterNames = List.of(packet.labels);
+      case TelemetryDefinitionKind.unit:
+        units = List.of(packet.labels);
+      case TelemetryDefinitionKind.eqns:
+        coefficients = List.of(packet.coefficients);
+      case TelemetryDefinitionKind.bits:
+        bitSense = List.of(packet.bitSense);
+        projectTitle = packet.projectTitle;
+    }
+    if (packet.receivedAt.isAfter(updatedAt)) updatedAt = packet.receivedAt;
+  }
+}

--- a/lib/screens/packet_log_screen.dart
+++ b/lib/screens/packet_log_screen.dart
@@ -193,7 +193,8 @@ class _PacketListState extends State<_PacketList> {
       _PacketFilter.item => p is ItemPacket,
       _PacketFilter.status => p is StatusPacket,
       _PacketFilter.micE => p is MicEPacket,
-      _PacketFilter.tel => p is TelemetryPacket,
+      _PacketFilter.tel =>
+        p is TelemetryPacket || p is TelemetryDefinitionPacket,
     };
   }
 
@@ -387,6 +388,7 @@ class _PacketRow extends StatelessWidget {
       StatusPacket() => 'STATUS',
       MicEPacket() => 'MIC-E',
       TelemetryPacket() => 'TEL',
+      TelemetryDefinitionPacket() => 'TEL DEF',
       QueryPacket() => 'QUERY',
       CapabilitiesPacket() => 'CAP',
       UnknownPacket() => '???',
@@ -405,6 +407,7 @@ class _PacketRow extends StatelessWidget {
       MicEPacket() =>
         '${_latStr(p.lat)}, ${_lonStr(p.lon)} \u2022 ${p.micEMessage}',
       TelemetryPacket() => _telSummary(p),
+      TelemetryDefinitionPacket() => _telDefSummary(p),
       QueryPacket() => '? ${p.query}',
       CapabilitiesPacket() => p.capabilities,
       UnknownPacket() =>
@@ -444,6 +447,24 @@ class _PacketRow extends StatelessWidget {
     final seq = p.sequence.isEmpty ? '' : '#${p.sequence} ';
     if (seq.isEmpty) return vals.isEmpty ? 'telemetry' : vals;
     return vals.isEmpty ? '${seq}telemetry' : '$seq• $vals';
+  }
+
+  static String _telDefSummary(TelemetryDefinitionPacket p) {
+    final kind = switch (p.kind) {
+      TelemetryDefinitionKind.parm => 'names',
+      TelemetryDefinitionKind.unit => 'units',
+      TelemetryDefinitionKind.eqns => 'equations',
+      TelemetryDefinitionKind.bits => 'bits',
+    };
+    final detail = switch (p.kind) {
+      TelemetryDefinitionKind.parm || TelemetryDefinitionKind.unit =>
+        p.labels.where((l) => l.isNotEmpty).join(', '),
+      TelemetryDefinitionKind.eqns =>
+        p.coefficients.map((c) => c == null ? '—' : _trimNum(c)).join(', '),
+      TelemetryDefinitionKind.bits => p.projectTitle ?? '',
+    };
+    final defFor = '${p.addressee} $kind';
+    return detail.isEmpty ? defFor : '$defFor • $detail';
   }
 }
 

--- a/lib/services/station_service.dart
+++ b/lib/services/station_service.dart
@@ -620,6 +620,9 @@ class StationService extends ChangeNotifier {
     if (p is StatusPacket) return PacketTypeTag.status;
     if (p is MicEPacket) return PacketTypeTag.micE;
     if (p is TelemetryPacket) return PacketTypeTag.telemetry;
+    if (p is TelemetryDefinitionPacket) {
+      return PacketTypeTag.telemetryDefinition;
+    }
     if (p is QueryPacket) return PacketTypeTag.query;
     if (p is CapabilitiesPacket) return PacketTypeTag.capabilities;
     return PacketTypeTag.unknown;

--- a/lib/services/telemetry_service.dart
+++ b/lib/services/telemetry_service.dart
@@ -1,0 +1,127 @@
+/// Accumulates APRS telemetry definitions (PARM/UNIT/EQNS/BITS) per station so
+/// that telemetry *data* reports can be shown with channel labels, units, and
+/// EQNS scaling (ADR-070).
+///
+/// Definitions arrive as four independent messages, often minutes apart, with
+/// any subset present. The parser yields a [TelemetryDefinitionPacket] per
+/// component (kept out of the message/conversation pipeline). This service
+/// merges them into a per-station [TelemetryDefinition] aggregate, write-through
+/// to drift so labels survive restarts and the packet-log retention window.
+///
+/// Correlation: a definition's `addressee` is the described station; a data
+/// report's `source` is matched against it (both trimmed + upper-cased, SSID
+/// preserved — telemetry is SSID-specific). Mirrors the [BulletinService]
+/// pattern: an in-memory cache written through to drift, with a synchronous
+/// [definitionFor] lookup for the UI.
+library;
+
+import 'dart:async';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/foundation.dart';
+
+import '../core/packet/aprs_packet.dart';
+import '../core/util/clock.dart';
+import '../database/daos/telemetry_definition_dao.dart';
+import '../database/meridian_database.dart'
+    show TelemetryDefinitionRow, TelemetryDefinitionsCompanion;
+import '../models/telemetry_definition.dart';
+import 'station_service.dart';
+
+class TelemetryService extends ChangeNotifier {
+  TelemetryService({
+    required StationService stations,
+    required TelemetryDefinitionDao dao,
+    Clock clock = DateTime.now,
+  }) : _dao = dao,
+       _clock = clock {
+    _sub = stations.packetStream.listen(_onPacket);
+  }
+
+  final TelemetryDefinitionDao _dao;
+  final Clock _clock;
+  StreamSubscription<AprsPacket>? _sub;
+
+  final Map<String, TelemetryDefinition> _defs = {};
+
+  /// Restores persisted definitions into the in-memory cache. Call once at
+  /// startup before the UI reads [definitionFor].
+  Future<void> load() async {
+    final rows = await _dao.getAll();
+    _defs.clear();
+    for (final row in rows) {
+      _defs[row.station] = _fromRow(row);
+    }
+    notifyListeners();
+  }
+
+  /// The accumulated definition for [callsign] (a data report's source), or
+  /// null if none has been heard. Normalizes to match the stored key.
+  TelemetryDefinition? definitionFor(String callsign) =>
+      _defs[_normalize(callsign)];
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  void _onPacket(AprsPacket packet) {
+    if (packet is! TelemetryDefinitionPacket) return;
+    final key = _normalize(packet.addressee);
+    if (key.isEmpty) return;
+
+    final def = _defs[key] ??= TelemetryDefinition(
+      station: key,
+      updatedAt: _clock(),
+    );
+    def.applyComponent(packet);
+    _dao.upsert(_toCompanion(def)); // ignore: unawaited_futures
+    notifyListeners();
+  }
+
+  static String _normalize(String callsign) => callsign.trim().toUpperCase();
+
+  // --- (de)serialization -----------------------------------------------------
+
+  TelemetryDefinitionsCompanion _toCompanion(TelemetryDefinition d) {
+    return TelemetryDefinitionsCompanion(
+      station: Value(d.station),
+      parameterNames: Value(
+        d.parameterNames.isEmpty ? null : d.parameterNames.join(','),
+      ),
+      units: Value(d.units.isEmpty ? null : d.units.join(',')),
+      equations: Value(
+        d.coefficients.isEmpty
+            ? null
+            : d.coefficients.map((c) => c?.toString() ?? '').join(','),
+      ),
+      bitSense: Value(
+        d.bitSense.isEmpty ? null : d.bitSense.map((b) => b ? '1' : '0').join(),
+      ),
+      projectTitle: Value(d.projectTitle),
+      updatedAt: Value(d.updatedAt.millisecondsSinceEpoch),
+    );
+  }
+
+  TelemetryDefinition _fromRow(TelemetryDefinitionRow row) {
+    return TelemetryDefinition(
+      station: row.station,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+      parameterNames: row.parameterNames?.split(','),
+      units: row.units?.split(','),
+      coefficients: row.equations
+          ?.split(',')
+          .map((s) => s.isEmpty ? null : double.tryParse(s))
+          .toList(),
+      bitSense: row.bitSense == null
+          ? null
+          : [for (final c in row.bitSense!.split('')) c == '1'],
+      projectTitle: row.projectTitle,
+    );
+  }
+}

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../core/packet/aprs_packet.dart';
+import '../../models/telemetry_definition.dart';
+import '../../services/telemetry_service.dart';
 import 'aprs_symbol_widget.dart';
 
 /// Shows a modal bottom sheet with the full decoded detail of an [AprsPacket].
@@ -10,17 +13,28 @@ import 'aprs_symbol_widget.dart';
 /// showPacketDetailSheet(context, packet);
 /// ```
 void showPacketDetailSheet(BuildContext context, AprsPacket packet) {
+  // Resolve the telemetry definition here, where the provider is in scope, so
+  // the sheet itself stays a pure presentation widget. Only data reports need
+  // one; the lookup correlates the report's source with a stored definition.
+  TelemetryDefinition? definition;
+  if (packet is TelemetryPacket) {
+    definition = context.read<TelemetryService>().definitionFor(packet.source);
+  }
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
-    builder: (_) => PacketDetailSheet(packet: packet),
+    builder: (_) => PacketDetailSheet(packet: packet, definition: definition),
   );
 }
 
 class PacketDetailSheet extends StatelessWidget {
-  const PacketDetailSheet({super.key, required this.packet});
+  const PacketDetailSheet({super.key, required this.packet, this.definition});
 
   final AprsPacket packet;
+
+  /// Telemetry definition correlated to [packet] (only for [TelemetryPacket]);
+  /// null when none has been heard, in which case channels render raw.
+  final TelemetryDefinition? definition;
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +42,7 @@ class PacketDetailSheet extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;
 
-    final fields = _decodedFields(packet);
+    final fields = decodedFields(packet, definition);
     final symbol = _symbolFor(packet);
 
     return SafeArea(
@@ -135,7 +149,16 @@ class PacketDetailSheet extends StatelessWidget {
   }
 
   /// Builds an ordered map of label → value for all meaningful decoded fields.
-  Map<String, String> _decodedFields(AprsPacket p) {
+  ///
+  /// [definition] is consulted only for [TelemetryPacket]s, to label and scale
+  /// channels; null renders raw values. Exposed for testing so the
+  /// telemetry-labelling logic can be asserted without pumping the lazy
+  /// scroll view.
+  @visibleForTesting
+  static Map<String, String> decodedFields(
+    AprsPacket p,
+    TelemetryDefinition? definition,
+  ) {
     final m = <String, String>{};
 
     // Common header fields
@@ -265,15 +288,62 @@ class PacketDetailSheet extends StatelessWidget {
       case TelemetryPacket():
         m['Type'] = 'Telemetry';
         if (p.sequence.isNotEmpty) m['Sequence'] = p.sequence;
+        final def = definition;
+        if (def?.projectTitle != null) m['Project'] = def!.projectTitle!;
         for (var i = 0; i < p.analog.length; i++) {
           final v = p.analog[i];
-          m['Analog ${i + 1}'] = v == null ? '—' : _trimNum(v);
+          // Prefer the defined channel name; otherwise a generic ordinal.
+          final name = def?.nameAt(i) ?? 'Analog ${i + 1}';
+          final unit = def?.unitAt(i);
+          if (v == null) {
+            m[name] = '—';
+          } else if (def != null && def.hasScaling(i)) {
+            // Show the scaled, unit-tagged value with the raw count alongside.
+            final scaled = _trimNum(def.scaleAnalog(i, v));
+            final tagged = unit == null ? scaled : '$scaled $unit';
+            m[name] = '$tagged (raw ${_trimNum(v)})';
+          } else {
+            final raw = _trimNum(v);
+            m[name] = unit == null ? raw : '$raw $unit';
+          }
         }
         if (p.digital.isNotEmpty) {
           m['Digital bits'] = p.digital.map((b) => b ? '1' : '0').join();
+          // Per-bit names live at definition channels 5–12.
+          for (var i = 0; i < p.digital.length; i++) {
+            final name = def?.nameAt(5 + i);
+            if (name != null) m[name] = p.digital[i] ? 'on' : 'off';
+          }
         }
         if (p.comment != null && p.comment!.isNotEmpty) {
           m['Comment'] = p.comment!;
+        }
+
+      case TelemetryDefinitionPacket():
+        m['Type'] = 'Telemetry definition';
+        m['Defines'] = p.addressee;
+        switch (p.kind) {
+          case TelemetryDefinitionKind.parm:
+            m['Component'] = 'Parameter names';
+            for (var i = 0; i < p.labels.length; i++) {
+              if (p.labels[i].isNotEmpty) m['Channel ${i + 1}'] = p.labels[i];
+            }
+          case TelemetryDefinitionKind.unit:
+            m['Component'] = 'Units';
+            for (var i = 0; i < p.labels.length; i++) {
+              if (p.labels[i].isNotEmpty) m['Channel ${i + 1}'] = p.labels[i];
+            }
+          case TelemetryDefinitionKind.eqns:
+            m['Component'] = 'Equations';
+            m['Coefficients'] = p.coefficients
+                .map((c) => c == null ? '—' : _trimNum(c))
+                .join(', ');
+          case TelemetryDefinitionKind.bits:
+            m['Component'] = 'Bit sense';
+            if (p.bitSense.isNotEmpty) {
+              m['Sense mask'] = p.bitSense.map((b) => b ? '1' : '0').join();
+            }
+            if (p.projectTitle != null) m['Project'] = p.projectTitle!;
         }
 
       case QueryPacket():

--- a/test/core/packet/aprs_parser_test.dart
+++ b/test/core/packet/aprs_parser_test.dart
@@ -1956,4 +1956,85 @@ void main() {
       expect(p.message, equals('?WX?'));
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Telemetry definitions (PARM./UNIT./EQNS./BITS. on the `:` message DTI)
+  // -------------------------------------------------------------------------
+  group('TelemetryDefinitionPacket', () {
+    test('PARM. decodes to parameter-name labels', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :PARM.Battery,Temp,Solar,RxCt,TxCt,Door,Fan',
+      );
+      expect(p.kind, equals(TelemetryDefinitionKind.parm));
+      expect(p.addressee, equals('N0CALL-5')); // SSID preserved
+      expect(
+        p.labels,
+        equals(['Battery', 'Temp', 'Solar', 'RxCt', 'TxCt', 'Door', 'Fan']),
+      );
+    });
+
+    test('UNIT. decodes to unit labels', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :UNIT.Volts,degF,Watts,Pkts,Pkts',
+      );
+      expect(p.kind, equals(TelemetryDefinitionKind.unit));
+      expect(p.labels, equals(['Volts', 'degF', 'Watts', 'Pkts', 'Pkts']));
+    });
+
+    test('EQNS. decodes coefficients as a flat list', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :EQNS.0,0.075,0,0,1,0,0,1,0',
+      );
+      expect(p.kind, equals(TelemetryDefinitionKind.eqns));
+      expect(p.coefficients, equals(<double>[0, 0.075, 0, 0, 1, 0, 0, 1, 0]));
+    });
+
+    test('EQNS. tolerates truncation and unparseable fields', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :EQNS.0,2,,0,1',
+      );
+      expect(p.coefficients, equals(<double?>[0, 2, null, 0, 1]));
+    });
+
+    test('BITS. decodes the sense mask and keeps a comma-bearing title', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :BITS.10110000,Shack Sensors, rev 2',
+      );
+      expect(p.kind, equals(TelemetryDefinitionKind.bits));
+      expect(
+        p.bitSense,
+        equals([true, false, true, true, false, false, false, false]),
+      );
+      expect(p.projectTitle, equals('Shack Sensors, rev 2'));
+    });
+
+    test('definition addressed to another station is still a definition', () {
+      // Definitions are frequently sent BY a base FOR a remote tracker, so the
+      // addressee (the described station) is what matters — not whether it is
+      // addressed to us. Either way it must never become a MessagePacket.
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0BASE>APRS::N0RMOTE-9:PARM.Speed,Volts',
+      );
+      expect(p.addressee, equals('N0RMOTE-9'));
+    });
+
+    test('a trailing {NNN message id is stripped from the payload', () {
+      final p = expectPacketType<TelemetryDefinitionPacket>(
+        'N0CALL>APRS::N0CALL-5 :PARM.Battery,Temp{045',
+      );
+      expect(p.labels, equals(['Battery', 'Temp']));
+    });
+
+    test(
+      'an ordinary message merely mentioning PARM stays a MessagePacket',
+      () {
+        // Detection requires the keyword at the very start with its dot; a user
+        // sentence must not be hijacked.
+        final p = expectPacketType<MessagePacket>(
+          'N0CALL>APRS::N0CALL-5 :the PARM. settings look good',
+        );
+        expect(p.message, equals('the PARM. settings look good'));
+      },
+    );
+  });
 }

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -1,0 +1,56 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/database/meridian_database.dart';
+
+/// First-ever schema migration (v1 → v2, ADR-070): the only change is the
+/// additive `telemetry_definitions` table. These tests pin the behaviour
+/// because every future migration builds on this `onUpgrade` precedent.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'v1 → v2 onUpgrade creates telemetry_definitions and it round-trips',
+    () async {
+      // Present as a v1 database: stamp user_version = 1 BEFORE drift opens, so
+      // drift runs onUpgrade(from: 1, to: 2) — not onCreate. The other v1 tables
+      // are irrelevant to this isolated migration check.
+      final db = MeridianDatabase(
+        NativeDatabase.memory(
+          setup: (raw) => raw.execute('PRAGMA user_version = 1'),
+        ),
+      );
+
+      // Touching the new table forces the migration to run.
+      await db.telemetryDefinitionDao.upsert(
+        TelemetryDefinitionsCompanion(
+          station: const Value('N0CALL-5'),
+          parameterNames: const Value('Batt,Temp'),
+          equations: const Value('0,0.1,0'),
+          updatedAt: const Value(1000),
+        ),
+      );
+
+      final rows = await db.telemetryDefinitionDao.getAll();
+      expect(rows, hasLength(1));
+      expect(rows.first.station, equals('N0CALL-5'));
+      expect(rows.first.parameterNames, equals('Batt,Temp'));
+      expect(rows.first.units, isNull); // unheard component stays null
+
+      await db.close();
+    },
+  );
+
+  test(
+    'fresh onCreate database is at schemaVersion 2 with the table present',
+    () async {
+      final db = MeridianDatabase(NativeDatabase.memory());
+      // A brand-new DB runs onCreate (createAll) — the table must exist.
+      final rows = await db.telemetryDefinitionDao.getAll();
+      expect(rows, isEmpty);
+      expect(db.schemaVersion, equals(2));
+      await db.close();
+    },
+  );
+}

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -688,4 +688,40 @@ void main() {
       },
     );
   });
+
+  // --- Telemetry definitions must bypass the conversation pipeline --------
+
+  group('telemetry definitions are not messages', () {
+    // The Kenwood TH-D75 (and many telemetry stations) address PARM/UNIT/EQNS/
+    // BITS definitions to their own callsign. These ride the `:` message DTI
+    // but are metadata — the parser yields a TelemetryDefinitionPacket, so
+    // MessageService (which only acts on MessagePacket) must ignore them: no
+    // phantom conversation, and no auto-ACK even when a `{NNN` id is present.
+    test(
+      'PARM addressed to our own callsign creates no thread, no ACK',
+      () async {
+        final f = await _Fixture.create(); // we are W1AW-9
+        f.stationService.ingestLine(
+          'W1AW-9>APMDN0::W1AW-9   :PARM.Battery,Temp,Solar{007',
+        );
+        await Future.delayed(const Duration(milliseconds: 50));
+
+        expect(f.service.conversations, isEmpty);
+        expect(f.service.totalUnread, equals(0));
+        expect(f.sentLines, isEmpty);
+      },
+    );
+
+    test('EQNS/UNIT/BITS to our callsign likewise create no threads', () async {
+      final f = await _Fixture.create();
+      f.stationService
+        ..ingestLine('W1AW-9>APMDN0::W1AW-9   :UNIT.Volts,degF')
+        ..ingestLine('W1AW-9>APMDN0::W1AW-9   :EQNS.0,1,0')
+        ..ingestLine('W1AW-9>APMDN0::W1AW-9   :BITS.10000000,Shack');
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(f.service.conversations, isEmpty);
+      expect(f.sentLines, isEmpty);
+    });
+  });
 }

--- a/test/services/message_service_test.dart
+++ b/test/services/message_service_test.dart
@@ -707,6 +707,9 @@ void main() {
         await Future.delayed(const Duration(milliseconds: 50));
 
         expect(f.service.conversations, isEmpty);
+        // Also assert the unfiltered view, so a hidden/cross-SSID thread can't
+        // slip past the filtered getter.
+        expect(f.service.allConversations, isEmpty);
         expect(f.service.totalUnread, equals(0));
         expect(f.sentLines, isEmpty);
       },
@@ -721,6 +724,7 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 50));
 
       expect(f.service.conversations, isEmpty);
+      expect(f.service.allConversations, isEmpty);
       expect(f.sentLines, isEmpty);
     });
   });

--- a/test/services/telemetry_service_test.dart
+++ b/test/services/telemetry_service_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/services/station_service.dart';
+import 'package:meridian_aprs/services/telemetry_service.dart';
+
+import '../helpers/test_database.dart';
+
+/// Drives [TelemetryService] by feeding raw lines through a real
+/// [StationService] (whose parser produces the typed packets), mirroring the
+/// production wiring.
+Future<({StationService stations, TelemetryService telemetry})>
+_buildFixture() async {
+  final db = buildTestDatabase();
+  final stations = StationService(
+    stationDao: db.stationDao,
+    packetDao: db.packetDao,
+  );
+  final telemetry = TelemetryService(
+    stations: stations,
+    dao: db.telemetryDefinitionDao,
+  );
+  await telemetry.load();
+  addTearDown(() async {
+    telemetry.dispose();
+    await stations.stop();
+    await db.close();
+  });
+  return (stations: stations, telemetry: telemetry);
+}
+
+Future<void> _settle() =>
+    Future<void>.delayed(const Duration(milliseconds: 50));
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TelemetryService — accumulation', () {
+    test(
+      'merges PARM/UNIT/EQNS/BITS into one per-station definition',
+      () async {
+        final f = await _buildFixture();
+        f.stations
+          ..ingestLine('N0CALL-5>APRS::N0CALL-5 :PARM.Batt,Temp,Solar')
+          ..ingestLine('N0CALL-5>APRS::N0CALL-5 :UNIT.Volts,degF,Watts')
+          ..ingestLine('N0CALL-5>APRS::N0CALL-5 :EQNS.0,0.1,0,0,1,0')
+          ..ingestLine('N0CALL-5>APRS::N0CALL-5 :BITS.11000000,Shack');
+        await _settle();
+
+        final def = f.telemetry.definitionFor('N0CALL-5');
+        expect(def, isNotNull);
+        expect(def!.nameAt(0), equals('Batt'));
+        expect(def.unitAt(1), equals('degF'));
+        expect(def.projectTitle, equals('Shack'));
+        expect(def.bitSense.first, isTrue);
+      },
+    );
+
+    test(
+      'correlation keeps the SSID (data source matches definition)',
+      () async {
+        final f = await _buildFixture();
+        f.stations.ingestLine('N0CALL-9>APRS::N0CALL-9 :PARM.Speed');
+        await _settle();
+
+        // A different SSID must NOT share the definition.
+        expect(f.telemetry.definitionFor('N0CALL-9'), isNotNull);
+        expect(f.telemetry.definitionFor('N0CALL-1'), isNull);
+        // Lookup is case-insensitive and trims.
+        expect(f.telemetry.definitionFor(' n0call-9 '), isNotNull);
+      },
+    );
+
+    test('a later component updates only its own field', () async {
+      final f = await _buildFixture();
+      f.stations.ingestLine('N0CALL-5>APRS::N0CALL-5 :PARM.A,B,C');
+      await _settle();
+      f.stations.ingestLine('N0CALL-5>APRS::N0CALL-5 :PARM.X,Y,Z');
+      await _settle();
+
+      final def = f.telemetry.definitionFor('N0CALL-5')!;
+      expect(def.parameterNames, equals(['X', 'Y', 'Z']));
+    });
+  });
+
+  group('TelemetryService — EQNS scaling', () {
+    test('applies a·v² + b·v + c per analog channel', () async {
+      final f = await _buildFixture();
+      // ch0: 0,0.075,0 → linear ×0.075 ; ch1: 1,0,0 → square
+      f.stations.ingestLine('N0CALL-5>APRS::N0CALL-5 :EQNS.0,0.075,0,1,0,0');
+      await _settle();
+
+      final def = f.telemetry.definitionFor('N0CALL-5')!;
+      expect(def.scaleAnalog(0, 200), closeTo(15.0, 1e-9));
+      expect(def.scaleAnalog(1, 4), closeTo(16.0, 1e-9));
+      expect(def.hasScaling(0), isTrue);
+    });
+
+    test('channels without coefficients fall back to identity', () async {
+      final f = await _buildFixture();
+      f.stations.ingestLine('N0CALL-5>APRS::N0CALL-5 :EQNS.0,2,0');
+      await _settle();
+
+      final def = f.telemetry.definitionFor('N0CALL-5')!;
+      // ch0 scales ×2; ch3 has no coeffs → returns the raw value unchanged.
+      expect(def.scaleAnalog(0, 5), closeTo(10.0, 1e-9));
+      expect(def.scaleAnalog(3, 42), closeTo(42.0, 1e-9));
+      expect(def.hasScaling(3), isFalse);
+    });
+  });
+
+  group('TelemetryService — persistence', () {
+    test('definitions survive a restart on the same database', () async {
+      final db = buildTestDatabase();
+      final stations = StationService(
+        stationDao: db.stationDao,
+        packetDao: db.packetDao,
+      );
+      final first = TelemetryService(
+        stations: stations,
+        dao: db.telemetryDefinitionDao,
+      );
+      await first.load();
+      stations
+        ..ingestLine('N0CALL-5>APRS::N0CALL-5 :PARM.Batt,Temp')
+        ..ingestLine('N0CALL-5>APRS::N0CALL-5 :EQNS.0,0.1,0');
+      await _settle();
+      first.dispose();
+
+      // New service over the SAME db — load() must restore the definition.
+      final second = TelemetryService(
+        stations: stations,
+        dao: db.telemetryDefinitionDao,
+      );
+      await second.load();
+
+      final def = second.definitionFor('N0CALL-5');
+      expect(def, isNotNull);
+      expect(def!.nameAt(0), equals('Batt'));
+      expect(def.scaleAnalog(0, 100), closeTo(10.0, 1e-9));
+
+      second.dispose();
+      await stations.stop();
+      await db.close();
+    });
+  });
+}

--- a/test/ui/widgets/packet_detail_sheet_test.dart
+++ b/test/ui/widgets/packet_detail_sheet_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:meridian_aprs/core/packet/aprs_packet.dart';
+import 'package:meridian_aprs/models/telemetry_definition.dart';
+import 'package:meridian_aprs/ui/widgets/packet_detail_sheet.dart';
+
+TelemetryPacket _telemetry() => TelemetryPacket(
+  rawLine: 'N0CALL-5>APRS:T#014,200,4,0,0,0,11000000',
+  source: 'N0CALL-5',
+  destination: 'APRS',
+  path: const [],
+  receivedAt: DateTime.utc(2026, 1, 1),
+  sequence: '014',
+  analog: const [200, 4, 0, 0, 0],
+  digital: const [true, true, false, false, false, false, false, false],
+);
+
+void main() {
+  group('PacketDetailSheet.decodedFields — telemetry', () {
+    test('labels and scales channels when a definition is present', () {
+      final def = TelemetryDefinition(
+        station: 'N0CALL-5',
+        updatedAt: DateTime.utc(2026, 1, 1),
+        parameterNames: ['Battery', 'Temp', '', '', '', 'Door'],
+        units: ['Volts', 'degF'],
+        coefficients: [0, 0.075, 0], // ch0 ×0.075 → 200 = 15
+        projectTitle: 'Shack',
+      );
+
+      final m = PacketDetailSheet.decodedFields(_telemetry(), def);
+
+      expect(m['Project'], equals('Shack'));
+      // Named, scaled, unit-tagged, with the raw count alongside.
+      expect(m['Battery'], equals('15 Volts (raw 200)'));
+      // Named-but-unscaled channel keeps its unit only.
+      expect(m['Temp'], equals('4 degF'));
+      // Binary channel name lives at definition index 5.
+      expect(m['Door'], equals('on'));
+      // A blank PARM slot falls back to the ordinal label.
+      expect(m['Analog 3'], equals('0'));
+    });
+
+    test('falls back to raw ordinals when no definition is known', () {
+      final m = PacketDetailSheet.decodedFields(_telemetry(), null);
+
+      expect(m['Analog 1'], equals('200')); // unscaled raw value
+      expect(m['Analog 2'], equals('4'));
+      expect(m.containsKey('Battery'), isFalse);
+      expect(m['Digital bits'], equals('11000000'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the telemetry **definition** side (Unit 2) so `T#` data reports render with channel names, units, and EQNS scaling instead of raw `Analog 1…5` numbers. Hardware-validated on a Kenwood TH-D75 (labelled/scaled channels confirmed in the packet detail sheet).

A definition is **four independent messages** (PARM/UNIT/EQNS/BITS), often minutes apart, any subset missing — so partial definitions are the normal case.

## Changes

**Parser**
- New sealed `TelemetryDefinitionPacket` (`kind {parm,unit,eqns,bits}` + that component's payload), branched in `_parseMessage` on the body prefix **before** ACK/REJ/message-id handling. Because `MessageService` only acts on `MessagePacket`, definitions never enter the conversation pipeline — **no phantom thread, no auto-ACK** even with a `{NNN` id.

**Service / persistence**
- `TelemetryService` (ChangeNotifier, mirrors `BulletinService`): in-memory cache write-through to drift, synchronous `definitionFor(callsign)`.
- Correlation = definition `addressee` ↔ data `source`, **SSID preserved** (telemetry is SSID-specific). Interop tradeoff documented in ADR-070.
- EQNS scaling `a·v² + b·v + c` per analog channel, identity defaults, truncation-tolerant.
- **First-ever schema migration (v1→v2):** additive `telemetry_definitions` table + `onUpgrade` that only creates it — no existing data read or rewritten.

**UI**
- Detail sheet shows labelled, scaled, unit-tagged channels (raw fallback when no definition heard).
- Definition packets fold under the **TEL** filter chip with a `TEL DEF` badge.
- Station sheet **intentionally unchanged** — no existing telemetry surface there; a "latest telemetry" card would be net-new scope (deferred).

## Test coverage

**+20 tests → 861 total**, `flutter analyze` clean, formatted.
- Parser: definition group (PARM/UNIT/EQNS/BITS, SSID preserved, `{NNN` strip, non-hijack of ordinary messages).
- MessageService regression: PARM addressed to our own callsign creates **no thread, no ACK**.
- TelemetryService: accumulation, SSID-strict correlation, EQNS scaling, persistence round-trip.
- Migration: fresh `onCreate`@v2 + forced `user_version=1` upgrade round-trip.
- Detail sheet: labelled/scaled field map + raw fallback.

## Validation done
- ✅ Labelled/scaled channels confirmed on-device (TH-D75).
- ✅ v1→v2 migration verified against existing on-device data.

## Docs
- ADR-070 (distinct packet type · drift-backed service · first migration · SSID interop tradeoff)
- CAPABILITIES.md, ROADMAP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry definition packets (PARM/UNIT/EQNS/BITS) are parsed, accumulated per station, persisted, and used to label/scale telemetry channels in detail views.

* **Database**
  * Schema bumped (v1 → v2) and a telemetry definitions table added with migration support.

* **UI**
  * Packet list/filtering and detail sheet now surface telemetry-definition summaries and apply definitions to telemetry rendering.

* **Documentation**
  * Updated capabilities, ADRs, and roadmap to document telemetry definition handling.

* **Tests**
  * Added tests for parsing, service behavior, migration, and detail-sheet rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->