### PR TITLE
fix(ui): display timestamps in local timezone, not UTC

### DIFF
--- a/lib/screens/bulletin_detail_screen.dart
+++ b/lib/screens/bulletin_detail_screen.dart
@@ -116,7 +116,8 @@ class BulletinDetailScreen extends StatelessWidget {
     );
   }
 
-  String _formatAbsolute(DateTime dt) {
+  String _formatAbsolute(DateTime dtRaw) {
+    final dt = dtRaw.toLocal();
     final y = dt.year.toString().padLeft(4, '0');
     final m = dt.month.toString().padLeft(2, '0');
     final d = dt.day.toString().padLeft(2, '0');

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -32,12 +32,24 @@ final class _DayDividerItem extends _ThreadItem {
   final DateTime date;
 }
 
+/// Local-timezone calendar day for [dt], as a midnight `DateTime`.
+///
+/// Timestamps flow through the app as absolute instants (received packets are
+/// stamped in UTC). Day-divider grouping must reflect the operator's *local*
+/// calendar, so we convert to local time before discarding the clock — without
+/// this, a packet received at 02:48 UTC would land on the next day for an
+/// operator in a behind-UTC timezone.
+DateTime localDayKey(DateTime dt) {
+  final local = dt.toLocal();
+  return DateTime(local.year, local.month, local.day);
+}
+
 List<_ThreadItem> _buildThreadItems(List<MessageEntry> messages) {
   if (messages.isEmpty) return const [];
   final items = <_ThreadItem>[];
   DateTime? lastDate;
   for (final m in messages) {
-    final d = DateTime(m.timestamp.year, m.timestamp.month, m.timestamp.day);
+    final d = localDayKey(m.timestamp);
     if (lastDate == null || d != lastDate) {
       items.add(_DayDividerItem(d));
       lastDate = d;
@@ -442,6 +454,37 @@ class _ComposeBarState extends State<_ComposeBar> {
   }
 }
 
+const _dayDividerMonths = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+const _dayDividerWeekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/// Day-divider label for the local day [date] (a [localDayKey] value),
+/// relative to [now] (defaults to the current local time). Returns "Today",
+/// "Yesterday", or a dated form such as "Mon, Jun 1".
+String dayDividerLabel(DateTime date, {DateTime? now}) {
+  final n = now ?? DateTime.now();
+  final today = DateTime(n.year, n.month, n.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+  if (date == today) return 'Today';
+  if (date == yesterday) return 'Yesterday';
+  final wd = _dayDividerWeekdays[date.weekday - 1];
+  final mo = _dayDividerMonths[date.month - 1];
+  if (date.year == n.year) return '$wd, $mo ${date.day}';
+  return '$wd, $mo ${date.day}, ${date.year}';
+}
+
 /// Centered day marker (e.g. "Today", "Yesterday", "Mon, Apr 20") shown
 /// between message bubbles whenever the calendar date changes.
 class _DayDivider extends StatelessWidget {
@@ -449,33 +492,7 @@ class _DayDivider extends StatelessWidget {
 
   final DateTime date;
 
-  static const _months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  static const _weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-
-  String _label() {
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
-    final yesterday = today.subtract(const Duration(days: 1));
-    if (date == today) return 'Today';
-    if (date == yesterday) return 'Yesterday';
-    final wd = _weekdays[date.weekday - 1];
-    final mo = _months[date.month - 1];
-    if (date.year == now.year) return '$wd, $mo ${date.day}';
-    return '$wd, $mo ${date.day}, ${date.year}';
-  }
+  String _label() => dayDividerLabel(date);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/widgets/packet_detail_sheet.dart
+++ b/lib/ui/widgets/packet_detail_sheet.dart
@@ -185,7 +185,7 @@ class PacketDetailSheet extends StatelessWidget {
       m['Relayed via'] = p.thirdPartyVia!;
     }
     m['Received'] = p.receivedAt
-        .toUtc()
+        .toLocal()
         .toString()
         .replaceFirst('.000', '')
         .replaceAll('T', ' ');
@@ -205,7 +205,9 @@ class PacketDetailSheet extends StatelessWidget {
         m['Messaging'] = p.hasMessaging ? 'Yes' : 'No';
         if (p.device != null) m['Device'] = p.device!;
         if (p.comment.isNotEmpty) m['Comment'] = p.comment;
-        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
+        if (p.timestamp != null) {
+          m['Packet time'] = p.timestamp!.toLocal().toString();
+        }
 
       case MessagePacket():
         m['Type'] = 'Message';
@@ -241,7 +243,9 @@ class PacketDetailSheet extends StatelessWidget {
         if (p.rainfall24h != null) {
           m['Rainfall 24h'] = '${(p.rainfall24h! / 100).toStringAsFixed(2)} in';
         }
-        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
+        if (p.timestamp != null) {
+          m['Packet time'] = p.timestamp!.toLocal().toString();
+        }
 
       case ObjectPacket():
         m['Type'] = 'Object';
@@ -268,7 +272,9 @@ class PacketDetailSheet extends StatelessWidget {
       case StatusPacket():
         m['Type'] = 'Status';
         m['Status'] = p.status;
-        if (p.timestamp != null) m['Packet time'] = p.timestamp.toString();
+        if (p.timestamp != null) {
+          m['Packet time'] = p.timestamp!.toLocal().toString();
+        }
 
       case MicEPacket():
         m['Type'] = 'Mic-E';

--- a/test/screens/message_thread_day_test.dart
+++ b/test/screens/message_thread_day_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meridian_aprs/screens/message_thread_screen.dart';
+
+void main() {
+  group('localDayKey', () {
+    test('strips the clock and returns local midnight', () {
+      final dt = DateTime(2026, 5, 31, 22, 48, 17);
+      expect(localDayKey(dt), DateTime(2026, 5, 31));
+    });
+
+    test('keys off the LOCAL calendar day, not the raw (UTC) fields', () {
+      // The bug was reading .year/.month/.day off a UTC-flagged instant, which
+      // yields the UTC calendar day. localDayKey must convert to local first.
+      final instant = DateTime.utc(2026, 6, 1, 2, 48);
+      final local = instant.toLocal();
+      expect(
+        localDayKey(instant),
+        DateTime(local.year, local.month, local.day),
+      );
+    });
+
+    // Timezone-independent invariant: the same absolute instant, whether held
+    // as a local or a UTC DateTime, must produce one day key. This is exactly
+    // what the reported bug violated — an outgoing send (local) and the reply
+    // (received as a UTC instant) split across two day dividers.
+    test('is invariant across the same instant expressed in either flag', () {
+      final sentLocal = DateTime(2026, 5, 31, 22, 48);
+      expect(localDayKey(sentLocal), localDayKey(sentLocal.toUtc()));
+
+      final receivedUtc = DateTime.utc(2026, 6, 1, 2, 48);
+      expect(localDayKey(receivedUtc), localDayKey(receivedUtc.toLocal()));
+    });
+  });
+
+  group('dayDividerLabel', () {
+    final now = DateTime(2026, 5, 31, 22, 48);
+
+    test('today / yesterday', () {
+      expect(dayDividerLabel(DateTime(2026, 5, 31), now: now), 'Today');
+      expect(dayDividerLabel(DateTime(2026, 5, 30), now: now), 'Yesterday');
+    });
+
+    test('a future/other day in the same year is dated without a year', () {
+      expect(dayDividerLabel(DateTime(2026, 6, 1), now: now), 'Mon, Jun 1');
+    });
+
+    test('a different year includes the year', () {
+      expect(
+        dayDividerLabel(DateTime(2025, 12, 25), now: now),
+        'Thu, Dec 25, 2025',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Chat threads and packet timestamps rendered in **UTC** instead of the operator's local timezone. Near midnight this split a single conversation across day dividers — an outgoing send (stamped local) showed **"Today"** while the reply (a UTC instant) showed the **next day** ("Mon, Jun 1"). Reported live: at 22:48 EDT a self-message reply appeared as June 1.

### Root cause

Timestamps already flow through the app as absolute instants stored in UTC — received packets are stamped via `toUtc()`, and the DB persists epoch millis (timezone-agnostic at rest). The bug was purely on the **display side**: several sites read calendar fields (`.year/.month/.day`) or stringified a `DateTime` **without converting to local first**, so a UTC-flagged instant rendered its UTC wall clock.

The relative-time labels (`6m`, `3m`) looked correct throughout because they use `.difference()`, which is offset-independent — that's what masked the bug.

The correct pattern already existed at `packet_log_screen.dart:289` (`packet.receivedAt.toLocal()`); every affected site simply deviated from it.

## Fix

Convert to local at every affected display site (store UTC → display local):

- **`message_thread_screen.dart`** — extracted pure, testable `localDayKey()` / `dayDividerLabel()` helpers that convert to local before grouping. (The thread in the report.)
- **`packet_detail_sheet.dart`** — "Received" `toUtc()` → `toLocal()`; the three "Packet time" rows (parsed as `DateTime.utc`) → `toLocal()`.
- **`bulletin_detail_screen.dart`** — `_formatAbsolute` converts to local first.

Storage and reload paths are **left untouched** — UTC-at-rest is already the model, and `toLocal()` is correct regardless of a `DateTime`'s `isUtc` flag, so partially normalizing the `fromMillisecondsSinceEpoch` sites would only deepen inconsistency for zero functional gain. All relative-time formatters (`_formatTime`, `_relativeTime`, `_formatAge`, `_formatLastHeard`) were audited and are correct.

## Test coverage

- **New** `test/screens/message_thread_day_test.dart` — locks the midnight boundary (the case the relative labels hid) using timezone-independent invariants, since Dart can't inject a local timezone in tests.
- `flutter analyze` clean · **867 tests pass** · `dart format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps throughout the application now display in local timezone instead of UTC, affecting message threads, bulletin details, and packet information
  * Message threads now correctly group messages by local calendar day for improved chronological organization

* **Tests**
  * Added unit tests for date and time formatting utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->